### PR TITLE
STYLE: ITK_EXPORT had no use

### DIFF
--- a/ImageRegistration/itkANTSAffine3DTransform.h
+++ b/ImageRegistration/itkANTSAffine3DTransform.h
@@ -15,7 +15,7 @@ namespace itk
  */
 template <class TScalarType = double>
 // Data type for scalars (float or double)
-class ITK_EXPORT ANTSAffine3DTransform :
+class ANTSAffine3DTransform :
   public         MatrixOffsetTransformBase<TScalarType, 3, 3>
   //        public Rigid3DTransform< TScalarType >
 {

--- a/ImageRegistration/itkANTSCenteredAffine2DTransform.h
+++ b/ImageRegistration/itkANTSCenteredAffine2DTransform.h
@@ -9,8 +9,8 @@ namespace itk
 {
 template <class TScalarType = double>
 // Data type for scalars (float or double)
-// class ITK_EXPORT Rigid2DTransform :
-class ITK_EXPORT ANTSCenteredAffine2DTransform :
+// class Rigid2DTransform :
+class ANTSCenteredAffine2DTransform :
   public         MatrixOffsetTransformBase<TScalarType, 2, 2> // Dimensions of input and output spaces
 {
 public:

--- a/ImageRegistration/itkANTSImageRegistrationOptimizer.h
+++ b/ImageRegistration/itkANTSImageRegistrationOptimizer.h
@@ -57,7 +57,7 @@
 namespace itk
 {
 template <unsigned int TDimension = 3, class TReal = float>
-class ITK_EXPORT ANTSImageRegistrationOptimizer
+class ANTSImageRegistrationOptimizer
   : public       Object
 {
 public:

--- a/ImageRegistration/itkANTSImageTransformation.h
+++ b/ImageRegistration/itkANTSImageTransformation.h
@@ -36,7 +36,7 @@
 namespace itk
 {
 template <unsigned int TDimension = 3, class TReal = float>
-class ITK_EXPORT ANTSImageTransformation
+class ANTSImageTransformation
   : public       Object
 {
 public:

--- a/ImageRegistration/itkANTSLabeledPointSet.h
+++ b/ImageRegistration/itkANTSLabeledPointSet.h
@@ -28,7 +28,7 @@
 namespace itk
 {
 template <unsigned int TDimension = 3>
-class ITK_EXPORT ANTSLabeledPointSet
+class ANTSLabeledPointSet
   : public       Object
 {
 public:

--- a/ImageRegistration/itkANTSSimilarityMetric.h
+++ b/ImageRegistration/itkANTSSimilarityMetric.h
@@ -29,7 +29,7 @@
 namespace itk
 {
 template <unsigned int TDimension = 3, class TReal = float>
-class ITK_EXPORT ANTSSimilarityMetric
+class ANTSSimilarityMetric
   : public       Object
 {
 public:

--- a/ImageRegistration/itkAvantsMutualInformationRegistrationFunction.h
+++ b/ImageRegistration/itkAvantsMutualInformationRegistrationFunction.h
@@ -120,7 +120,7 @@ namespace itk
  * \ingroup ThreadUnSafe
  */
 template <class TFixedImage, class TMovingImage, class TDisplacementField>
-class ITK_EXPORT AvantsMutualInformationRegistrationFunction :
+class AvantsMutualInformationRegistrationFunction :
   public         AvantsPDEDeformableRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>
 {
 public:

--- a/ImageRegistration/itkAvantsPDEDeformableRegistrationFunction.h
+++ b/ImageRegistration/itkAvantsPDEDeformableRegistrationFunction.h
@@ -38,7 +38,7 @@ namespace itk
  * \ingroup PDEDeformableRegistrationFunctions
  */
 template <class TFixedImage, class TMovingImage, class TDisplacementField>
-class ITK_EXPORT AvantsPDEDeformableRegistrationFunction :
+class AvantsPDEDeformableRegistrationFunction :
   public         PDEDeformableRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>
 {
 public:

--- a/ImageRegistration/itkCrossCorrelationRegistrationFunction.h
+++ b/ImageRegistration/itkCrossCorrelationRegistrationFunction.h
@@ -55,7 +55,7 @@ namespace itk
  * \ingroup FiniteDifferenceFunctions
  */
 template <class TFixedImage, class TMovingImage, class TDisplacementField>
-class ITK_EXPORT CrossCorrelationRegistrationFunction :
+class CrossCorrelationRegistrationFunction :
   public         AvantsPDEDeformableRegistrationFunction<TFixedImage,
                                                          TMovingImage, TDisplacementField>
 {

--- a/ImageRegistration/itkExpectationBasedPointSetRegistrationFunction.h
+++ b/ImageRegistration/itkExpectationBasedPointSetRegistrationFunction.h
@@ -61,7 +61,7 @@ namespace itk
 * \ingroup FiniteDifferenceFunctions
 */
 template <class TFixedImage, class TMovingImage, class TDisplacementField, class TPointSet>
-class ITK_EXPORT ExpectationBasedPointSetRegistrationFunction :
+class ExpectationBasedPointSetRegistrationFunction :
   public         AvantsPDEDeformableRegistrationFunction<TFixedImage,
                                                          TMovingImage,
                                                          TDisplacementField>

--- a/ImageRegistration/itkJensenHavrdaCharvatTsallisLabeledPointSetMetric.h
+++ b/ImageRegistration/itkJensenHavrdaCharvatTsallisLabeledPointSetMetric.h
@@ -32,7 +32,7 @@ namespace itk
  *
  */
 template <class TPointSet>
-class ITK_EXPORT JensenHavrdaCharvatTsallisLabeledPointSetMetric :
+class JensenHavrdaCharvatTsallisLabeledPointSetMetric :
   public         PointSetToPointSetMetric<TPointSet, TPointSet>
 {
 public:

--- a/ImageRegistration/itkJensenHavrdaCharvatTsallisPointSetMetric.h
+++ b/ImageRegistration/itkJensenHavrdaCharvatTsallisPointSetMetric.h
@@ -31,7 +31,7 @@ namespace itk
  *
  */
 template <class TPointSet>
-class ITK_EXPORT JensenHavrdaCharvatTsallisPointSetMetric :
+class JensenHavrdaCharvatTsallisPointSetMetric :
   public         PointSetToPointSetMetric<TPointSet, TPointSet>
 {
 public:

--- a/ImageRegistration/itkJensenTsallisBSplineRegistrationFunction.h
+++ b/ImageRegistration/itkJensenTsallisBSplineRegistrationFunction.h
@@ -33,7 +33,7 @@ namespace itk
 template <class TFixedImage, class TFixedPointSet,
           class TMovingImage, class TMovingPointSet,
           class TDisplacementField>
-class ITK_EXPORT JensenTsallisBSplineRegistrationFunction :
+class JensenTsallisBSplineRegistrationFunction :
   public         AvantsPDEDeformableRegistrationFunction<TFixedImage,
                                                          TMovingImage, TDisplacementField>
 {

--- a/ImageRegistration/itkPICSLAdvancedNormalizationToolKit.h
+++ b/ImageRegistration/itkPICSLAdvancedNormalizationToolKit.h
@@ -32,7 +32,7 @@
 namespace itk
 {
 template <unsigned int TDimension = 3, class TReal = float>
-class ITK_EXPORT PICSLAdvancedNormalizationToolKit
+class PICSLAdvancedNormalizationToolKit
   : public       Object
 {
 public:

--- a/ImageRegistration/itkProbabilisticRegistrationFunction.h
+++ b/ImageRegistration/itkProbabilisticRegistrationFunction.h
@@ -55,7 +55,7 @@ namespace itk
  * \ingroup FiniteDifferenceFunctions
  */
 template <class TFixedImage, class TMovingImage, class TDisplacementField>
-class ITK_EXPORT ProbabilisticRegistrationFunction :
+class ProbabilisticRegistrationFunction :
   public         AvantsPDEDeformableRegistrationFunction<TFixedImage,
                                                          TMovingImage, TDisplacementField>
 {

--- a/ImageRegistration/itkSpatialMutualInformationRegistrationFunction.h
+++ b/ImageRegistration/itkSpatialMutualInformationRegistrationFunction.h
@@ -119,7 +119,7 @@ namespace itk
  * \ingroup ThreadUnSafe
  */
 template <class TFixedImage, class TMovingImage, class TDisplacementField>
-class ITK_EXPORT SpatialMutualInformationRegistrationFunction :
+class SpatialMutualInformationRegistrationFunction :
   public         AvantsPDEDeformableRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>
 {
 public:

--- a/ImageRegistration/itkSyNDemonsRegistrationFunction.h
+++ b/ImageRegistration/itkSyNDemonsRegistrationFunction.h
@@ -51,7 +51,7 @@ namespace itk
 * \ingroup FiniteDifferenceFunctions
 */
 template <class TFixedImage, class TMovingImage, class TDisplacementField>
-class ITK_EXPORT SyNDemonsRegistrationFunction :
+class SyNDemonsRegistrationFunction :
   public         AvantsPDEDeformableRegistrationFunction<TFixedImage,
                                                          TMovingImage,
                                                          TDisplacementField>

--- a/ImageRegistration/itkVectorParameterizedNeighborhoodOperatorImageFilter.h
+++ b/ImageRegistration/itkVectorParameterizedNeighborhoodOperatorImageFilter.h
@@ -56,7 +56,7 @@ namespace itk
  */
 
 template <class TInputImage, class TOutputImage, class TParamImage>
-class ITK_EXPORT VectorParameterizedNeighborhoodOperatorImageFilter :
+class VectorParameterizedNeighborhoodOperatorImageFilter :
   public         ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:

--- a/ImageSegmentation/antsAtroposSegmentationImageFilter.h
+++ b/ImageSegmentation/antsAtroposSegmentationImageFilter.h
@@ -66,7 +66,7 @@ namespace ants
 template <class TInputImage, class TMaskImage
             = Image<unsigned char, TInputImage::ImageDimension>,
           class TClassifiedImage = TMaskImage>
-class ITK_EXPORT AtroposSegmentationImageFilter :
+class AtroposSegmentationImageFilter :
   public         ImageToImageFilter<TInputImage, TClassifiedImage>
 {
 public:

--- a/ImageSegmentation/antsBoxPlotQuantileListSampleFilter.h
+++ b/ImageSegmentation/antsBoxPlotQuantileListSampleFilter.h
@@ -36,7 +36,7 @@ namespace Statistics
  */
 
 template <class TScalarListSample>
-class ITK_EXPORT BoxPlotQuantileListSampleFilter
+class BoxPlotQuantileListSampleFilter
   : public       ListSampleToListSampleFilter<TScalarListSample, TScalarListSample>
 {
 public:

--- a/ImageSegmentation/antsGaussianListSampleFunction.h
+++ b/ImageSegmentation/antsGaussianListSampleFunction.h
@@ -34,7 +34,7 @@ namespace Statistics
  */
 
 template <class TListSample, class TOutput = double, class TCoordRep = double>
-class ITK_EXPORT GaussianListSampleFunction
+class GaussianListSampleFunction
   : public       ListSampleFunction<TListSample, TOutput, TCoordRep>
 {
 public:

--- a/ImageSegmentation/antsGrubbsRosnerListSampleFilter.h
+++ b/ImageSegmentation/antsGrubbsRosnerListSampleFilter.h
@@ -36,7 +36,7 @@ namespace Statistics
  */
 
 template <class TScalarListSample>
-class ITK_EXPORT GrubbsRosnerListSampleFilter
+class GrubbsRosnerListSampleFilter
   : public       ListSampleToListSampleFilter<TScalarListSample, TScalarListSample>
 {
 public:

--- a/ImageSegmentation/antsHistogramParzenWindowsListSampleFunction.h
+++ b/ImageSegmentation/antsHistogramParzenWindowsListSampleFunction.h
@@ -36,7 +36,7 @@ namespace Statistics
  */
 
 template <class TListSample, class TOutput = double, class TCoordRep = double>
-class ITK_EXPORT HistogramParzenWindowsListSampleFunction
+class HistogramParzenWindowsListSampleFunction
   : public       ListSampleFunction<TListSample, TOutput, TCoordRep>
 {
 public:

--- a/ImageSegmentation/antsJointHistogramParzenShapeAndOrientationListSampleFunction.h
+++ b/ImageSegmentation/antsJointHistogramParzenShapeAndOrientationListSampleFunction.h
@@ -35,7 +35,7 @@ namespace Statistics
  */
 
 template <class TListSample, class TOutput = double, class TCoordRep = double>
-class ITK_EXPORT JointHistogramParzenShapeAndOrientationListSampleFunction
+class JointHistogramParzenShapeAndOrientationListSampleFunction
   : public       ListSampleFunction<TListSample, TOutput, TCoordRep>
 {
 public:

--- a/ImageSegmentation/antsJointHistogramParzenWindowsListSampleFunction.h
+++ b/ImageSegmentation/antsJointHistogramParzenWindowsListSampleFunction.h
@@ -34,7 +34,7 @@ namespace Statistics
  */
 
 template <class TListSample, class TOutput = double, class TCoordRep = double>
-class ITK_EXPORT JointHistogramParzenWindowsListSampleFunction
+class JointHistogramParzenWindowsListSampleFunction
   : public       ListSampleFunction<TListSample, TOutput, TCoordRep>
 {
 public:

--- a/ImageSegmentation/antsListSampleFunction.h
+++ b/ImageSegmentation/antsListSampleFunction.h
@@ -44,7 +44,7 @@ namespace Statistics
  * \ingroup ListSampleFunctions
  */
 template <class TInputListSample, class TOutput, class TCoordRep = float>
-class ITK_EXPORT ListSampleFunction :
+class ListSampleFunction :
   public         FunctionBase<typename TInputListSample::MeasurementVectorType, TOutput>
 {
 public:

--- a/ImageSegmentation/antsListSampleToListSampleFilter.h
+++ b/ImageSegmentation/antsListSampleToListSampleFilter.h
@@ -39,7 +39,7 @@ namespace Statistics
  *
  */
 template <class TInputListSample, class TOutputListSample = TInputListSample>
-class ITK_EXPORT ListSampleToListSampleFilter : public ProcessObject
+class ListSampleToListSampleFilter : public ProcessObject
 {
 public:
   /** Standard class typedefs. */

--- a/ImageSegmentation/antsLogEuclideanGaussianListSampleFunction.h
+++ b/ImageSegmentation/antsLogEuclideanGaussianListSampleFunction.h
@@ -34,7 +34,7 @@ namespace Statistics
  */
 
 template <class TListSample, class TOutput = double, class TCoordRep = double>
-class ITK_EXPORT LogEuclideanGaussianListSampleFunction
+class LogEuclideanGaussianListSampleFunction
   : public       ListSampleFunction<TListSample, TOutput, TCoordRep>
 {
 public:

--- a/ImageSegmentation/antsManifoldParzenWindowsListSampleFunction.h
+++ b/ImageSegmentation/antsManifoldParzenWindowsListSampleFunction.h
@@ -37,7 +37,7 @@ namespace Statistics
  */
 
 template <class TListSample, class TOutput = double, class TCoordRep = double>
-class ITK_EXPORT ManifoldParzenWindowsListSampleFunction
+class ManifoldParzenWindowsListSampleFunction
   : public       ListSampleFunction<TListSample, TOutput, TCoordRep>
 {
 public:

--- a/ImageSegmentation/antsPartialVolumeGaussianListSampleFunction.h
+++ b/ImageSegmentation/antsPartialVolumeGaussianListSampleFunction.h
@@ -34,7 +34,7 @@ namespace Statistics
  */
 
 template <class TListSample, class TOutput = double, class TCoordRep = double>
-class ITK_EXPORT PartialVolumeGaussianListSampleFunction
+class PartialVolumeGaussianListSampleFunction
   : public       ListSampleFunction<TListSample, TOutput, TCoordRep>
 {
 public:

--- a/ImageSegmentation/antsPassThroughListSampleFilter.h
+++ b/ImageSegmentation/antsPassThroughListSampleFilter.h
@@ -33,7 +33,7 @@ namespace Statistics
  */
 
 template <class TListSample>
-class ITK_EXPORT PassThroughListSampleFilter
+class PassThroughListSampleFilter
   : public       ListSampleToListSampleFilter<TListSample, TListSample>
 {
 public:

--- a/Temporary/itkAddConstantToImageFilter.h
+++ b/Temporary/itkAddConstantToImageFilter.h
@@ -83,7 +83,7 @@ public:
 }
 
 template <class TInputImage, class TConstant, class TOutputImage>
-class ITK_EXPORT AddConstantToImageFilter :
+class AddConstantToImageFilter :
   public
   UnaryFunctorImageFilter<TInputImage, TOutputImage,
                           Functor::AddConstantTo<

--- a/Temporary/itkDivideByConstantImageFilter.h
+++ b/Temporary/itkDivideByConstantImageFilter.h
@@ -89,7 +89,7 @@ public:
 }
 
 template <class TInputImage, class TConstant, class TOutputImage>
-class ITK_EXPORT DivideByConstantImageFilter :
+class DivideByConstantImageFilter :
   public
   UnaryFunctorImageFilter<TInputImage, TOutputImage,
                           Functor::DivideByConstant<

--- a/Temporary/itkFastMarchingImageFilter.h
+++ b/Temporary/itkFastMarchingImageFilter.h
@@ -104,7 +104,7 @@ namespace itk
 template <
   class TLevelSet,
   class TSpeedImage = Image<float, TLevelSet::ImageDimension> >
-class ITK_EXPORT FastMarchingImageFilter :
+class FastMarchingImageFilter :
   public         ImageToImageFilter<TSpeedImage, TLevelSet>
 {
 public:

--- a/Temporary/itkMultiplyByConstantImageFilter.h
+++ b/Temporary/itkMultiplyByConstantImageFilter.h
@@ -37,7 +37,7 @@ namespace itk
  * \sa MultiplyImageFilter
  */
 template <class TInputImage, class TConstant, class TOutputImage>
-class ITK_EXPORT MultiplyByConstantImageFilter :
+class MultiplyByConstantImageFilter :
   public
   MultiplyImageFilter<TInputImage, Image<TConstant, TInputImage::ImageDimension>, TOutputImage>
 {

--- a/Tensor/itkExpTensorImageFilter.h
+++ b/Tensor/itkExpTensorImageFilter.h
@@ -41,7 +41,7 @@ namespace itk
  * \ingroup IntensityImageFilters
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT ExpTensorImageFilter :
+class ExpTensorImageFilter :
   public         ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:

--- a/Tensor/itkLogTensorImageFilter.h
+++ b/Tensor/itkLogTensorImageFilter.h
@@ -41,7 +41,7 @@ namespace itk
  * \ingroup IntensityImageFilters
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT LogTensorImageFilter :
+class LogTensorImageFilter :
   public         ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:

--- a/Tensor/itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.h
+++ b/Tensor/itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.h
@@ -45,7 +45,7 @@ namespace itk
  * \ingroup IntensityImageFilters
  */
 template <typename TTensorImage, typename TVectorImage>
-class ITK_EXPORT PreservationOfPrincipalDirectionTensorReorientationImageFilter :
+class PreservationOfPrincipalDirectionTensorReorientationImageFilter :
   public         ImageToImageFilter<TTensorImage, TTensorImage>
 {
 public:

--- a/Tensor/itkWarpTensorImageMultiTransformFilter.h
+++ b/Tensor/itkWarpTensorImageMultiTransformFilter.h
@@ -86,7 +86,7 @@ template <
   class TDisplacementField,
   class TTransform
   >
-class ITK_EXPORT WarpTensorImageMultiTransformFilter :
+class WarpTensorImageMultiTransformFilter :
   public         ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:

--- a/Utilities/antsCommandLineOption.h
+++ b/Utilities/antsCommandLineOption.h
@@ -47,7 +47,7 @@ namespace ants
       -m mutualinformation[parameter1] --optimization gradientdescent"
 */
 
-class ITK_EXPORT OptionFunction
+class OptionFunction
   : public       DataObject
 {
 public:
@@ -116,7 +116,7 @@ private:
   ParameterStackType m_Parameters;
 };
 
-class ITK_EXPORT CommandLineOption
+class CommandLineOption
   : public       DataObject
 {
 public:

--- a/Utilities/antsCommandLineParser.h
+++ b/Utilities/antsCommandLineParser.h
@@ -43,7 +43,7 @@ namespace ants
     {10, 20, 30} as "10x20x30".
 */
 
-class ITK_EXPORT CommandLineParser
+class CommandLineParser
   : public       DataObject
 {
 public:

--- a/Utilities/antsMatrixUtilities.h
+++ b/Utilities/antsMatrixUtilities.h
@@ -26,7 +26,7 @@ namespace itk
 namespace ants
 {
 template <class TInputImage, class TRealType = double>
-class ITK_EXPORT antsMatrixUtilities :
+class antsMatrixUtilities :
   public         ImageToImageFilter<TInputImage, TInputImage>
 {
 public:

--- a/Utilities/antsSCCANObject.h
+++ b/Utilities/antsSCCANObject.h
@@ -33,7 +33,7 @@ namespace itk
 namespace ants
 {
 template <class TInputImage, class TRealType = double>
-class ITK_EXPORT antsSCCANObject :
+class antsSCCANObject :
   public         ImageToImageFilter<TInputImage, TInputImage>
 {
 public:

--- a/Utilities/itkAlternatingValueDifferenceImageFilter.h
+++ b/Utilities/itkAlternatingValueDifferenceImageFilter.h
@@ -41,7 +41,7 @@ namespace itk
  *
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT AlternatingValueDifferenceImageFilter :
+class AlternatingValueDifferenceImageFilter :
   public         ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:

--- a/Utilities/itkAlternatingValueSimpleSubtractionImageFilter.h
+++ b/Utilities/itkAlternatingValueSimpleSubtractionImageFilter.h
@@ -37,7 +37,7 @@ namespace itk
  *
  */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT AlternatingValueSimpleSubtractionImageFilter :
+class AlternatingValueSimpleSubtractionImageFilter :
   public         ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:

--- a/Utilities/itkAverageAffineTransformFunction.h
+++ b/Utilities/itkAverageAffineTransformFunction.h
@@ -121,7 +121,7 @@ public:
 }
 
 template <class TTransform>
-class ITK_EXPORT AverageAffineTransformFunction
+class AverageAffineTransformFunction
 {
 public:
 

--- a/Utilities/itkAverageAffineTransformNoRigidFunction.h
+++ b/Utilities/itkAverageAffineTransformNoRigidFunction.h
@@ -121,7 +121,7 @@ public:
 }
 
 template <class TTransform>
-class ITK_EXPORT AverageAffineTransformNoRigidFunction
+class AverageAffineTransformNoRigidFunction
 {
 public:
 

--- a/Utilities/itkAverageOverDimensionImageFilter.h
+++ b/Utilities/itkAverageOverDimensionImageFilter.h
@@ -87,7 +87,7 @@ namespace itk
  */
 
 template< class TInputImage, class TOutputImage >
-class ITK_EXPORT AverageOverDimensionImageFilter:
+class AverageOverDimensionImageFilter:
   public InPlaceImageFilter< TInputImage, TOutputImage >
 {
 public:

--- a/Utilities/itkDecomposeTensorFunction.h
+++ b/Utilities/itkDecomposeTensorFunction.h
@@ -34,7 +34,7 @@ template <typename TInput,
           typename TRealType = float,
           typename TOutput = itk::VariableSizeMatrix<TRealType>
           >
-class ITK_EXPORT DecomposeTensorFunction : public ProcessObject
+class DecomposeTensorFunction : public ProcessObject
 {
 public:
   /** Standard class typedefs. */

--- a/Utilities/itkDisplacementFieldFromMultiTransformFilter.h
+++ b/Utilities/itkDisplacementFieldFromMultiTransformFilter.h
@@ -10,7 +10,7 @@ template <
   class TDisplacementField,
   class TTransform
   >
-class ITK_EXPORT DisplacementFieldFromMultiTransformFilter :
+class DisplacementFieldFromMultiTransformFilter :
   public         WarpImageMultiTransformFilter<TOutputImage, TOutputImage, TDisplacementField, TTransform>
 {
 public:

--- a/Utilities/itkLabelOverlapMeasuresImageFilter.h
+++ b/Utilities/itkLabelOverlapMeasuresImageFilter.h
@@ -35,7 +35,7 @@ namespace itk
  * \ingroup MultiThreaded
  */
 template <class TLabelImage>
-class ITK_EXPORT LabelOverlapMeasuresImageFilter :
+class LabelOverlapMeasuresImageFilter :
   public         ImageToImageFilter<TLabelImage, TLabelImage>
 {
 public:

--- a/Utilities/itkManifoldParzenWindowsPointSetFunction.h
+++ b/Utilities/itkManifoldParzenWindowsPointSetFunction.h
@@ -39,7 +39,7 @@ namespace itk
  */
 
 template <class TPointSet, class TOutput = double, class TCoordRep = double>
-class ITK_EXPORT ManifoldParzenWindowsPointSetFunction
+class ManifoldParzenWindowsPointSetFunction
   : public       PointSetFunction<TPointSet, TOutput, TCoordRep>
 {
 public:

--- a/Utilities/itkMultiScaleLaplacianBlobDetectorImageFilter.h
+++ b/Utilities/itkMultiScaleLaplacianBlobDetectorImageFilter.h
@@ -103,7 +103,7 @@ private:
  * \author Bradley Lowekamp
 */
 template <class TInputImage>
-class ITK_EXPORT MultiScaleLaplacianBlobDetectorImageFilter
+class MultiScaleLaplacianBlobDetectorImageFilter
   : public       ImageToImageFilter<TInputImage, TInputImage>
 {
 public:

--- a/Utilities/itkMultiplyByConstantVectorImageFilter.h
+++ b/Utilities/itkMultiplyByConstantVectorImageFilter.h
@@ -85,7 +85,7 @@ public:
 }
 
 template <class TInputImage, class TConstantVector, class TOutputImage>
-class ITK_EXPORT MultiplyByConstantVectorImageFilter :
+class MultiplyByConstantVectorImageFilter :
   public
   UnaryFunctorImageFilter<TInputImage, TOutputImage,
                           Functor::MultiplyByConstantVector<

--- a/Utilities/itkN3MRIBiasFieldCorrectionImageFilter.h
+++ b/Utilities/itkN3MRIBiasFieldCorrectionImageFilter.h
@@ -89,7 +89,7 @@ namespace itk
 
 template <class TInputImage, class TBiasFieldImage, class TMaskImage,
           class TConfidenceImage>
-class ITK_EXPORT N3BiasFieldScaleCostFunction
+class N3BiasFieldScaleCostFunction
   : public       SingleValuedCostFunction
 {
 public:
@@ -143,7 +143,7 @@ private:
 template <class TInputImage, class TMaskImage = Image<unsigned char,
                                                       TInputImage::ImageDimension>,
           class TOutputImage = TInputImage>
-class ITK_EXPORT N3MRIBiasFieldCorrectionImageFilter :
+class N3MRIBiasFieldCorrectionImageFilter :
   public         ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:

--- a/Utilities/itkOptimalSharpeningImageFilter.h
+++ b/Utilities/itkOptimalSharpeningImageFilter.h
@@ -46,7 +46,7 @@ namespace itk
  *
  * \ingroup ImageFeatureExtraction */
 template <class TInputImage, class TOutputImage>
-class ITK_EXPORT OptimalSharpeningImageFilter :
+class OptimalSharpeningImageFilter :
   public         ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:

--- a/Utilities/itkPointSetFunction.h
+++ b/Utilities/itkPointSetFunction.h
@@ -56,7 +56,7 @@ template <
   class TOutput,
   class TCoordRep = float
   >
-class ITK_EXPORT PointSetFunction :
+class PointSetFunction :
   public         FunctionBase<typename TInputPointSet::PointType, TOutput>
 {
 public:

--- a/Utilities/itkPseudoContinuousArterialSpinLabeledCerebralBloodFlowImageFilter.h
+++ b/Utilities/itkPseudoContinuousArterialSpinLabeledCerebralBloodFlowImageFilter.h
@@ -47,7 +47,7 @@ namespace itk
  * \ingroup ITKImageCompose
  */
 template <class TInputImage, class TReferenceImage, class TOutputImage>
-class ITK_EXPORT PseudoContinuousArterialSpinLabeledCerebralBloodFlowImageFilter :
+class PseudoContinuousArterialSpinLabeledCerebralBloodFlowImageFilter :
   public         ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:

--- a/Utilities/itkPulsedArterialSpinLabeledCerebralBloodFlowImageFilter.h
+++ b/Utilities/itkPulsedArterialSpinLabeledCerebralBloodFlowImageFilter.h
@@ -47,7 +47,7 @@ namespace itk
  * \ingroup ITKImageCompose
  */
 template <class TInputImage, class TReferenceImage, class TOutputImage>
-class ITK_EXPORT PulsedArterialSpinLabeledCerebralBloodFlowImageFilter :
+class PulsedArterialSpinLabeledCerebralBloodFlowImageFilter :
   public         ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:

--- a/Utilities/itkSplitAlternatingTimeSeriesImageFilter.h
+++ b/Utilities/itkSplitAlternatingTimeSeriesImageFilter.h
@@ -47,7 +47,7 @@ namespace itk
  * \ingroup ITKImageCompose
  */
 template< class TInputImage, class TOutputImage >
-class ITK_EXPORT SplitAlternatingTimeSeriesImageFilter:
+class SplitAlternatingTimeSeriesImageFilter:
   public ImageToImageFilter< TInputImage, TOutputImage >
 {
 public:

--- a/Utilities/itkVectorFieldGradientImageFunction.h
+++ b/Utilities/itkVectorFieldGradientImageFunction.h
@@ -31,7 +31,7 @@ template <typename TInputImage,
           typename TOutput =
             itk::VariableSizeMatrix<TRealType>
           >
-class ITK_EXPORT VectorFieldGradientImageFunction :
+class VectorFieldGradientImageFunction :
   public         ImageFunction<TInputImage, TOutput>
 {
 public:

--- a/Utilities/itkVectorGaussianInterpolateImageFunction.h
+++ b/Utilities/itkVectorGaussianInterpolateImageFunction.h
@@ -36,7 +36,7 @@ namespace itk
  * \ingroup ImageFunctions ImageInterpolators
  */
 template <class TInputImage, class TCoordRep = double>
-class ITK_EXPORT VectorGaussianInterpolateImageFunction :
+class VectorGaussianInterpolateImageFunction :
   public         InterpolateImageFunction<TInputImage, TCoordRep>
 {
 public:

--- a/Utilities/itkVectorImageFileReader.h
+++ b/Utilities/itkVectorImageFileReader.h
@@ -82,7 +82,7 @@ public:
 template <class TImage, class TVectorImage,
           class ConvertPixelTraits = DefaultConvertPixelTraits<
               ITK_TYPENAME TImage::IOPixelType> >
-class ITK_EXPORT VectorImageFileReader : public ImageSource<TVectorImage>
+class VectorImageFileReader : public ImageSource<TVectorImage>
 {
 public:
   /** Standard class typedefs. */

--- a/Utilities/itkVectorImageFileWriter.h
+++ b/Utilities/itkVectorImageFileWriter.h
@@ -58,7 +58,7 @@ public:
  * \ingroup IOFilters
  */
 template <class TVectorImage, class TImage>
-class ITK_EXPORT VectorImageFileWriter :
+class VectorImageFileWriter :
   public         ProcessObject
 {
 public:

--- a/Utilities/itkWarpImageMultiTransformFilter.h
+++ b/Utilities/itkWarpImageMultiTransformFilter.h
@@ -86,7 +86,7 @@ template <
   class TDisplacementField,
   class TTransform
   >
-class ITK_EXPORT WarpImageMultiTransformFilter :
+class WarpImageMultiTransformFilter :
   public         ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:

--- a/Utilities/itkWarpImageWAffineFilter.h
+++ b/Utilities/itkWarpImageWAffineFilter.h
@@ -83,7 +83,7 @@ template <
   class TDisplacementField,
   class TTransform
   >
-class ITK_EXPORT WarpImageWAffineFilter :
+class WarpImageWAffineFilter :
   public         ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:

--- a/Utilities/itkWarpTensorImageMultiTransformFilter.h
+++ b/Utilities/itkWarpTensorImageMultiTransformFilter.h
@@ -85,7 +85,7 @@ template <
   class TDisplacementField,
   class TTransform
   >
-class ITK_EXPORT WarpTensorImageMultiTransformFilter :
+class WarpTensorImageMultiTransformFilter :
   public         ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:


### PR DESCRIPTION
The defintion of ITK_EXPORT was empty in all cases

This has been identified since 2003 as not being necessary
for builds. see https://issues.itk.org/jira/browse/ITK-3110

On Windows builds that need exports, they must
be unique per library, and that is not controlled by CMake now.

The PrintSelfCheck.tcl was the only remenant need for
This patch, and that is no longer being used, so that
file as been removed.

The ITK_EXPORT define was set to nothing and had no
known remaining purpose.  It was removed to make the
over all code easier to understand.  There was,
understandably, a bit of confusion about the
need for this being pervasive in the code.

It is currently backwards compatible to have
this in code, but at some future point it will
be removed.
