### PR TITLE
ENH: Add single precision computations to ANTS

### DIFF
--- a/Examples/CompositeTransformUtil.cxx
+++ b/Examples/CompositeTransformUtil.cxx
@@ -48,7 +48,7 @@ static void PrintGenericUsageStatement()
  */
 template <unsigned int VImageDimension>
 int
-Disassemble(itk::TransformBase *transform, const std::string & transformName, const std::string & prefix)
+Disassemble(itk::TransformBaseTemplate<double> *transform, const std::string & transformName, const std::string & prefix)
 {
   typedef itk::CompositeTransform<double, VImageDimension>                  CompositeTransformType;
   typedef typename CompositeTransformType::TransformTypePointer             TransformPointer;
@@ -82,7 +82,7 @@ Disassemble(itk::TransformBase *transform, const std::string & transformName, co
       {
       fname << ".mat";  //  .txt does not have enough precision!
       }
-    itk::ants::WriteTransform<VImageDimension>(curXfrm, fname.str() );
+    itk::ants::WriteTransform<double, VImageDimension>(curXfrm, fname.str() );
     }
   return EXIT_SUCCESS;
 }
@@ -90,11 +90,11 @@ Disassemble(itk::TransformBase *transform, const std::string & transformName, co
 static int Disassemble(const std::string & CompositeName,
                        const std::string & Prefix)
 {
-  itk::TransformBase::Pointer transform = itk::ants::ReadTransform<2>(CompositeName).GetPointer();
+  itk::TransformBaseTemplate<double>::Pointer transform = itk::ants::ReadTransform<double, 2>(CompositeName).GetPointer();
 
   if( transform.IsNull() )
     {
-    transform = itk::ants::ReadTransform<3>(CompositeName).GetPointer();
+    transform = itk::ants::ReadTransform<double, 3>(CompositeName).GetPointer();
     if( transform.IsNull() )
       {
       return EXIT_FAILURE; // ReadTransform prints error messages on
@@ -135,7 +135,7 @@ Assemble(const std::string & CompositeName,
   composite->AddTransform(firstTransform);
   for( unsigned int i = 1; i < transformNames.size(); ++i )
     {
-    typename TransformType::Pointer curXfrm = itk::ants::ReadTransform<VImageDimension>(transformNames[i]);
+    typename TransformType::Pointer curXfrm = itk::ants::ReadTransform<double, VImageDimension>(transformNames[i]);
     if( curXfrm.IsNull() )
       {
       return EXIT_FAILURE; // ReadTransform will complain if anything goes wrong.
@@ -143,21 +143,21 @@ Assemble(const std::string & CompositeName,
     composite->AddTransform(curXfrm);
     }
   typename TransformType::Pointer genericXfrmPtr = composite.GetPointer();
-  return itk::ants::WriteTransform<VImageDimension>(genericXfrmPtr, CompositeName);
+  return itk::ants::WriteTransform<double, VImageDimension>(genericXfrmPtr, CompositeName);
 }
 
 static int Assemble(const std::string & CompositeName,
                     const std::vector<std::string> & transformNames)
 {
     {
-    itk::Transform<double, 2, 2>::Pointer FirstTransform = itk::ants::ReadTransform<2>(transformNames[0]);
+    itk::Transform<double, 2, 2>::Pointer FirstTransform = itk::ants::ReadTransform<double, 2>(transformNames[0]);
     if( FirstTransform.IsNotNull() )
       {
       return Assemble<2>(CompositeName, transformNames, FirstTransform);
       }
     }
     {
-    itk::Transform<double, 3, 3>::Pointer FirstTransform = itk::ants::ReadTransform<3>(transformNames[0]);
+    itk::Transform<double, 3, 3>::Pointer FirstTransform = itk::ants::ReadTransform<double, 3>(transformNames[0]);
     if( FirstTransform.IsNotNull() )
       {
       return Assemble<3>(CompositeName, transformNames, FirstTransform);

--- a/Examples/ConvertTransformFile.cxx
+++ b/Examples/ConvertTransformFile.cxx
@@ -330,7 +330,7 @@ int ConvertTransformFile(int argc, char* argv[])
   typename TransformType::Pointer transform;
   typedef itk::MatrixOffsetTransformBase<double, ImageDimension, ImageDimension> baseTransformType;
   itk::TransformFactory<baseTransformType>::RegisterTransform();
-  transform = itk::ants::ReadTransform<ImageDimension>( inputFilename );
+  transform = itk::ants::ReadTransform<double, ImageDimension>( inputFilename );
   if( transform.IsNull() )
     {
     antscout << "Error while reading transform file. Did you specify the correct dimension?" << std::endl;
@@ -418,7 +418,7 @@ int ConvertTransformFile(int argc, char* argv[])
       antscout << "Unexpected error casting from affine transform to transform type." << std::endl;
       return EXIT_FAILURE;
       }
-    int result = itk::ants::WriteTransform<ImageDimension>( transform, outFilename );
+    int result = itk::ants::WriteTransform<double, ImageDimension>( transform, outFilename );
     if( result == EXIT_FAILURE )
       {
       antscout << "Failed writing converted transform to binary format." << std::endl;
@@ -436,7 +436,7 @@ int ConvertTransformFile(int argc, char* argv[])
              << std::endl;
     return EXIT_FAILURE;
     }
-  int result = itk::ants::WriteTransform<ImageDimension>( transform, outFilename );
+  int result = itk::ants::WriteTransform<double, ImageDimension>( transform, outFilename );
   if( result == EXIT_FAILURE )
     {
     antscout << "Failed writing transform to text format." << std::endl;

--- a/Examples/antsApplyTransforms.cxx
+++ b/Examples/antsApplyTransforms.cxx
@@ -279,7 +279,7 @@ int antsApplyTransforms( itk::ants::CommandLineParser::Pointer & parser, unsigne
 
   std::vector<bool> isDerivedTransform;
   typename CompositeTransformType::Pointer compositeTransform =
-    GetCompositeTransformFromParserOption<Dimension>( parser, transformOption, isDerivedTransform, useStaticCastForR );
+    GetCompositeTransformFromParserOption<RealType, Dimension>( parser, transformOption, isDerivedTransform, useStaticCastForR );
   if( compositeTransform.IsNull() )
     {
     return EXIT_FAILURE;

--- a/Examples/antsApplyTransformsToPoints.cxx
+++ b/Examples/antsApplyTransformsToPoints.cxx
@@ -126,7 +126,7 @@ int antsApplyTransformsToPoints( itk::ants::CommandLineParser::Pointer & parser 
 
     std::vector<bool> isDerivedTransform;
     typename CompositeTransformType::Pointer compositeTransform =
-      GetCompositeTransformFromParserOption<Dimension>( parser, transformOption, isDerivedTransform );
+      GetCompositeTransformFromParserOption<RealType, Dimension>( parser, transformOption, isDerivedTransform );
     if( compositeTransform.IsNull() )
       {
       return EXIT_FAILURE;

--- a/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
+++ b/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
@@ -33,7 +33,8 @@ public:
 
   typedef typename TFilter::OutputTransformType                          OutputTransformType;
   typedef typename TFilter::OutputTransformType::ScalarType              RealType;
-  typedef itk::ImageToImageMetricv4<FixedImageType, MovingImageType>     MetricType;
+  typedef itk::ImageToImageMetricv4
+           <FixedImageType, MovingImageType, FixedImageType, RealType>   MetricType;
   typedef typename MetricType::MeasureType                               MeasureType;
   typedef typename MetricType::VirtualImageType                          VirtualImageType;
   typedef itk::CompositeTransform<RealType, VImageDimension>             CompositeTransformType;
@@ -99,7 +100,7 @@ public:
       this->m_lastTotalTime = now;
       m_clock.Start();
 
-      typedef itk::GradientDescentOptimizerv4 GradientDescentOptimizerType;
+      typedef itk::GradientDescentOptimizerTemplatev4<RealType> GradientDescentOptimizerType;
       GradientDescentOptimizerType * optimizer = reinterpret_cast<GradientDescentOptimizerType *>(
           const_cast<typename TFilter::OptimizerType *>( const_cast<TFilter *>( filter )->GetOptimizer() ) );
 
@@ -220,7 +221,7 @@ public:
     // This metric type is used to measure the general similarity metric between the original input fixed and moving
     // images.
     typename MetricType::Pointer metric;
-    typedef itk::ANTSNeighborhoodCorrelationImageToImageMetricv4<FixedImageType, MovingImageType> CorrelationMetricType;
+    typedef itk::ANTSNeighborhoodCorrelationImageToImageMetricv4<FixedImageType, MovingImageType, FixedImageType, MeasureType> CorrelationMetricType;
     typename CorrelationMetricType::Pointer correlationMetric = CorrelationMetricType::New();
       {
       typename CorrelationMetricType::RadiusType radius;
@@ -309,7 +310,7 @@ public:
       */
       if( filter->GetDownsampleImagesForMetricDerivatives() )
         {
-        typedef itk::ResampleImageFilter<FixedImageType, FixedImageType> FixedResamplerType;
+        typedef itk::ResampleImageFilter<FixedImageType, FixedImageType, RealType> FixedResamplerType;
         typename FixedResamplerType::Pointer fixedResampler = FixedResamplerType::New();
         fixedResampler->SetTransform( fixedComposite );
         fixedResampler->SetInput( this->m_origFixedImage );
@@ -317,7 +318,7 @@ public:
         fixedResampler->SetDefaultPixelValue( 0 );
         fixedResampler->Update();
 
-        typedef itk::ResampleImageFilter<MovingImageType, MovingImageType> MovingResamplerType;
+        typedef itk::ResampleImageFilter<MovingImageType, MovingImageType, RealType> MovingResamplerType;
         typename MovingResamplerType::Pointer movingResampler = MovingResamplerType::New();
         movingResampler->SetTransform( movingComposite );
         movingResampler->SetInput( this->m_origMovingImage );
@@ -423,7 +424,7 @@ public:
     typedef itk::LinearInterpolateImageFunction<MovingImageType, RealType> LinearInterpolatorType;
     typename LinearInterpolatorType::Pointer linearInterpolator = LinearInterpolatorType::New();
 
-    typedef itk::ResampleImageFilter<FixedImageType, MovingImageType> ResampleFilterType;
+    typedef itk::ResampleImageFilter<FixedImageType, MovingImageType, RealType> ResampleFilterType;
     typename ResampleFilterType::Pointer resampler = ResampleFilterType::New();
     resampler->SetTransform( outputCompositTransform );
     resampler->SetInput( this->m_origMovingImage );

--- a/Examples/antsRegistration.cxx
+++ b/Examples/antsRegistration.cxx
@@ -386,6 +386,16 @@ void InitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
     option->AddFunction( std::string( "0" ) );
     parser->AddOption( option );
     }
+  
+    {
+    std::string description = std::string( "Use 'float' instead of 'double' for computations." );
+    
+    OptionType::Pointer option = OptionType::New();
+    option->SetLongName( "float" );
+    option->SetDescription( description );
+    option->AddFunction( std::string( "0" ) );
+    parser->AddOption( option );
+    }
 }
 
 static
@@ -468,11 +478,11 @@ RegTypeToFileName(const std::string & type, bool & writeInverse, bool & writeVel
   return "BOGUS.XXXX";
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 int
 DoRegistration(typename ParserType::Pointer & parser)
 {
-  typedef typename ants::RegistrationHelper<VImageDimension>      RegistrationHelperType;
+  typedef typename ants::RegistrationHelper<T, VImageDimension>      RegistrationHelperType;
   typedef typename RegistrationHelperType::ImageType              ImageType;
   typedef typename RegistrationHelperType::CompositeTransformType CompositeTransformType;
 
@@ -560,7 +570,7 @@ DoRegistration(typename ParserType::Pointer & parser)
     {
     std::vector<bool> isDerivedInitialMovingTransform;
     typename CompositeTransformType::Pointer compositeTransform =
-      GetCompositeTransformFromParserOption<VImageDimension>( parser, initialMovingTransformOption,
+      GetCompositeTransformFromParserOption<T, VImageDimension>( parser, initialMovingTransformOption,
                                                               isDerivedInitialMovingTransform );
 
     if( compositeTransform.IsNull() )
@@ -579,7 +589,7 @@ DoRegistration(typename ParserType::Pointer & parser)
 
         typename RegistrationHelperType::CompositeTransformType::TransformTypePointer curTransform =
           compositeTransform->GetNthTransform( n );
-        itk::ants::WriteTransform<VImageDimension>( curTransform, curFileName.str() );
+        itk::ants::WriteTransform<T, VImageDimension>( curTransform, curFileName.str() );
         }
       }
     }
@@ -590,7 +600,7 @@ DoRegistration(typename ParserType::Pointer & parser)
     {
     std::vector<bool> isDerivedInitialFixedTransform;
     typename CompositeTransformType::Pointer compositeTransform =
-      GetCompositeTransformFromParserOption<VImageDimension>( parser, initialFixedTransformOption,
+      GetCompositeTransformFromParserOption<T, VImageDimension>( parser, initialFixedTransformOption,
                                                               isDerivedInitialFixedTransform );
     if( compositeTransform.IsNull() )
       {
@@ -608,7 +618,7 @@ DoRegistration(typename ParserType::Pointer & parser)
 
         typename RegistrationHelperType::CompositeTransformType::TransformTypePointer curTransform =
           compositeTransform->GetNthTransform( n );
-        itk::ants::WriteTransform<VImageDimension>( curTransform, curFileName.str() );
+        itk::ants::WriteTransform<T, VImageDimension>( curTransform, curFileName.str() );
         }
       }
     }
@@ -1211,13 +1221,13 @@ DoRegistration(typename ParserType::Pointer & parser)
 
     typename RegistrationHelperType::CompositeTransformType::TransformTypePointer compositeTransform =
       resultTransform.GetPointer();
-    itk::ants::WriteTransform<VImageDimension>( compositeTransform, compositeTransformFileName.c_str() );
+    itk::ants::WriteTransform<T, VImageDimension>( compositeTransform, compositeTransformFileName.c_str() );
 
     typename RegistrationHelperType::CompositeTransformType::TransformTypePointer inverseCompositeTransform =
       compositeTransform->GetInverseTransform();
     if( inverseCompositeTransform.IsNotNull() )
       {
-      itk::ants::WriteTransform<VImageDimension>( inverseCompositeTransform,
+      itk::ants::WriteTransform<T, VImageDimension>( inverseCompositeTransform,
                                                   inverseCompositeTransformFileName.c_str() );
       }
     }
@@ -1300,7 +1310,7 @@ DoRegistration(typename ParserType::Pointer & parser)
     // WriteTransform will spit all sorts of error messages if it
     // fails, and we want to keep going even if it does so ignore its
     // return value.
-    itk::ants::WriteTransform<VImageDimension>( curTransform, curFileName.str() );
+    itk::ants::WriteTransform<T, VImageDimension>( curTransform, curFileName.str() );
 
     typedef typename RegistrationHelperType::DisplacementFieldTransformType DisplacementFieldTransformType;
     typedef typename DisplacementFieldTransformType::DisplacementFieldType  DisplacementFieldType;
@@ -1336,7 +1346,7 @@ DoRegistration(typename ParserType::Pointer & parser)
       typedef typename RegistrationHelperType::TimeVaryingVelocityFieldTransformType
         VelocityFieldTransformType;
 
-      typedef itk::Image<itk::Vector<double, VImageDimension>, VImageDimension + 1> VelocityFieldType;
+      typedef itk::Image<itk::Vector<T, VImageDimension>, VImageDimension + 1> VelocityFieldType;
       typename VelocityFieldTransformType::Pointer velocityFieldTransform =
         dynamic_cast<VelocityFieldTransformType *>(curTransform.GetPointer() );
       if( !velocityFieldTransform.IsNull() )
@@ -1363,7 +1373,7 @@ DoRegistration(typename ParserType::Pointer & parser)
       }
     }
 
-  typedef double RealType;
+  typedef T RealType;
   std::string whichInterpolator( "linear" );
   typename itk::ants::CommandLineParser::OptionType::Pointer interpolationOption = parser->GetOption( "interpolation" );
   if( interpolationOption && interpolationOption->GetNumberOfFunctions() )
@@ -1501,16 +1511,38 @@ private:
       antscout << "Image dimensionality not specified.  See command line option --dimensionality" << std::endl;
       return EXIT_FAILURE;
       }
+    
+    std::string Type = "double";
+    OptionType::Pointer typeOption = parser->GetOption( "float" );
+    if( typeOption && parser->Convert<bool>( typeOption->GetFunction( 0 )->GetName() ) )
+      {
+      antscout << "Using single precision for computations." << std::endl;
+      Type = "float";
+      }
 
     switch( dimension )
       {
       case 2:
         {
-        return DoRegistration<2>(parser);
+        if( strcmp(Type.c_str(), "float") == 0 )
+          {
+          return DoRegistration<float, 2>(parser);
+          }
+        else
+          {
+          return DoRegistration<double, 2>(parser);
+          }
         }
       case 3:
         {
-        return DoRegistration<3>(parser);
+        if( strcmp(Type.c_str(), "float") == 0 )
+          {
+          return DoRegistration<float, 3>(parser);
+          }
+        else
+          {
+          return DoRegistration<double, 3>(parser);
+          }
         }
       default:
         antscout << "bad image dimension " << dimension << std::endl;

--- a/Examples/antsRegistrationCommandIterationUpdate.h
+++ b/Examples/antsRegistrationCommandIterationUpdate.h
@@ -68,7 +68,7 @@ public:
       this->m_lastTotalTime = now;
       m_clock.Start();
 
-      typedef itk::GradientDescentOptimizerv4 GradientDescentOptimizerType;
+      typedef itk::GradientDescentOptimizerTemplatev4<typename TFilter::RealType> GradientDescentOptimizerType;
       GradientDescentOptimizerType * optimizer = reinterpret_cast<GradientDescentOptimizerType *>(
           const_cast<typename TFilter::OptimizerType *>( const_cast<TFilter *>( filter )->GetOptimizer() ) );
 

--- a/Examples/compareTwoCompositeTransforms.cxx
+++ b/Examples/compareTwoCompositeTransforms.cxx
@@ -168,16 +168,16 @@ int compareTwoCompositeTransforms( std::vector<std::string> args, std::ostream* 
   
   antscout->set_stream( out_stream );
   {
-  itk::Transform<double, 2, 2>::Pointer firstTransform = itk::ants::ReadTransform<2>(args[0]);
-  itk::Transform<double, 2, 2>::Pointer secondTransform = itk::ants::ReadTransform<2>(args[1]);
+  itk::Transform<double, 2, 2>::Pointer firstTransform = itk::ants::ReadTransform<double, 2>(args[0]);
+  itk::Transform<double, 2, 2>::Pointer secondTransform = itk::ants::ReadTransform<double, 2>(args[1]);
   if( firstTransform.IsNotNull() && secondTransform.IsNotNull() )
     {
     return compareComposites<2>(firstTransform, secondTransform);
     }
   }
   {
-  itk::Transform<double, 3, 3>::Pointer firstTransform = itk::ants::ReadTransform<3>(args[0]);
-  itk::Transform<double, 3, 3>::Pointer secondTransform = itk::ants::ReadTransform<3>(args[1]);
+  itk::Transform<double, 3, 3>::Pointer firstTransform = itk::ants::ReadTransform<double, 3>(args[0]);
+  itk::Transform<double, 3, 3>::Pointer secondTransform = itk::ants::ReadTransform<double, 3>(args[1]);
   if( firstTransform.IsNotNull() && secondTransform.IsNotNull() )
     {
     return compareComposites<3>(firstTransform, secondTransform);

--- a/Examples/itkantsRegistrationHelper.h
+++ b/Examples/itkantsRegistrationHelper.h
@@ -95,7 +95,7 @@ namespace ants
 typedef itk::ants::CommandLineParser ParserType;
 typedef ParserType::OptionType       OptionType;
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 class RegistrationHelper : public itk::Object
 {
 public:
@@ -106,13 +106,13 @@ public:
   typedef itk::SmartPointer<const Self> ConstPointer;
   typedef itk::WeakPointer<const Self>  ConstWeakPointer;
 
-  typedef double                                 RealType;
-  typedef double                                 PixelType;
+  typedef T                                      RealType;
+  typedef T                                      PixelType;
   typedef itk::Image<PixelType, VImageDimension> ImageType;
   typedef typename ImageType::Pointer            ImagePointer;
   typedef itk::ImageBase<VImageDimension>        ImageBaseType;
 
-  typedef itk::Transform<double, VImageDimension, VImageDimension>                   TransformType;
+  typedef itk::Transform<T, VImageDimension, VImageDimension>                        TransformType;
   typedef itk::AffineTransform<RealType, VImageDimension>                            AffineTransformType;
   typedef itk::ImageRegistrationMethodv4<ImageType, ImageType, AffineTransformType>  AffineRegistrationType;
   typedef typename AffineRegistrationType::ShrinkFactorsPerDimensionContainerType    ShrinkFactorsPerDimensionContainerType;
@@ -124,8 +124,9 @@ public:
   typedef typename DisplacementFieldTransformType::Pointer                           DisplacementFieldTransformPointer;
   typedef typename DisplacementFieldTransformType::DisplacementFieldType             DisplacementFieldType;
   typedef itk::TimeVaryingVelocityFieldTransform<RealType, VImageDimension>          TimeVaryingVelocityFieldTransformType;
-  typedef itk::ImageToImageMetricv4<ImageType, ImageType>                            MetricType;
-  typedef itk::ObjectToObjectMultiMetricv4<VImageDimension, VImageDimension>         MultiMetricType;
+  typedef itk::ImageToImageMetricv4<ImageType, ImageType, ImageType, RealType>       MetricType;
+  typedef itk::ObjectToObjectMultiMetricv4
+                     <VImageDimension, VImageDimension, ImageType, RealType>         MultiMetricType;
   typedef itk::ImageMaskSpatialObject<VImageDimension>                               ImageMaskSpatialObjectType;
   typedef typename ImageMaskSpatialObjectType::ImageType                             MaskImageType;
   typedef itk::InterpolateImageFunction<ImageType, RealType>                         InterpolatorType;
@@ -665,13 +666,13 @@ private:
 // ##########################################################################
 
 // Provide common way of reading transforms.
-template <unsigned VImageDimension>
-typename ants::RegistrationHelper<VImageDimension>::CompositeTransformType::Pointer
+template <class T, unsigned VImageDimension>
+typename ants::RegistrationHelper<T, VImageDimension>::CompositeTransformType::Pointer
 GetCompositeTransformFromParserOption( typename ParserType::Pointer & parser,
                                        typename ParserType::OptionType::Pointer initialTransformOption,
                                        std::vector<bool> & derivedTransforms, bool useStaticCastForR = false )
 {
-  typedef typename ants::RegistrationHelper<VImageDimension>      RegistrationHelperType;
+  typedef typename ants::RegistrationHelper<T, VImageDimension>      RegistrationHelperType;
   typedef typename RegistrationHelperType::CompositeTransformType CompositeTransformType;
   typename CompositeTransformType::Pointer compositeTransform = CompositeTransformType::New();
 
@@ -712,7 +713,8 @@ GetCompositeTransformFromParserOption( typename ParserType::Pointer & parser,
       unsigned short initializationFeature = parser->Convert<unsigned short>(
         initialTransformOption->GetFunction( n )->GetParameter( 2 ) );
 
-      typedef itk::AffineTransform<double, VImageDimension> TransformType;
+      typedef itk::AffineTransform<T, VImageDimension> TransformType;
+
       typename TransformType::Pointer transform = TransformType::New();
 
       if( initializationFeature == 0 || initializationFeature == 1 )
@@ -759,7 +761,7 @@ GetCompositeTransformFromParserOption( typename ParserType::Pointer & parser,
       initialTransformName += std::string( "fixed image: " ) + initialTransformOption->GetFunction( n )->GetParameter( 0 )
         + std::string( " and moving image: " ) + initialTransformOption->GetFunction( n )->GetParameter( 1 );
 
-      typedef itk::TranslationTransform<double, VImageDimension> TranslationTransformType;
+      typedef itk::TranslationTransform<T, VImageDimension> TranslationTransformType;
       typename TranslationTransformType::Pointer translationTransform = TranslationTransformType::New();
       translationTransform->SetOffset( transform->GetTranslation() );
 
@@ -795,17 +797,17 @@ GetCompositeTransformFromParserOption( typename ParserType::Pointer & parser,
       MatOffRegistered = true;
       // Register the matrix offset transform base class to the
       // transform factory for compatibility with the current ANTs.
-      typedef itk::MatrixOffsetTransformBase<double, VImageDimension, VImageDimension> MatrixOffsetTransformType;
+      typedef itk::MatrixOffsetTransformBase<T, VImageDimension, VImageDimension> MatrixOffsetTransformType;
       itk::TransformFactory<MatrixOffsetTransformType>::RegisterTransform();
       }
 
     if( !calculatedTransformFromImages )
       {
-      typedef ants::RegistrationHelper<VImageDimension>                       RegistrationHelperType;
+      typedef ants::RegistrationHelper<T, VImageDimension>                       RegistrationHelperType;
       typedef typename RegistrationHelperType::DisplacementFieldTransformType DisplacementFieldTransformType;
 
       typedef typename RegistrationHelperType::TransformType TransformType;
-      typename TransformType::Pointer initialTransform = itk::ants::ReadTransform<VImageDimension>(
+      typename TransformType::Pointer initialTransform = itk::ants::ReadTransform<T, VImageDimension>(
 												   initialTransformName , useStaticCastForR );
       if( initialTransform.IsNull() )
         {
@@ -825,8 +827,8 @@ GetCompositeTransformFromParserOption( typename ParserType::Pointer & parser,
       static const std::string CompositeTransformID("CompositeTransform");
       if( initialTransform->GetNameOfClass() == CompositeTransformID )
         {
-        const typename itk::CompositeTransform<double, VImageDimension>::ConstPointer tempComp =
-          dynamic_cast<const itk::CompositeTransform<double, VImageDimension> *>( initialTransform.GetPointer() );
+        const typename itk::CompositeTransform<T, VImageDimension>::ConstPointer tempComp =
+          dynamic_cast<const itk::CompositeTransform<T, VImageDimension> *>( initialTransform.GetPointer() );
         for( unsigned int i = 0; i < tempComp->GetNumberOfTransforms(); ++i )
           {
           std::stringstream tempstream;

--- a/Examples/itkantsRegistrationHelper.hxx
+++ b/Examples/itkantsRegistrationHelper.hxx
@@ -8,29 +8,39 @@
 #include "antsRegistrationOptimizerCommandIterationUpdate.h"
 #include "antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h"
 
+#include <vnl/vnl_matrix.h>
+#include <vnl/vnl_copy.h>
+
 namespace ants
 {
 /**
  * Transform traits to generalize the rigid transform
  */
-template <unsigned int ImageDimension>
+template <class T, unsigned int ImageDimension>
 class RigidTransformTraits
 {
 // Don't worry about the fact that the default option is the
 // affine Transform, that one will not actually be instantiated.
 public:
-  typedef itk::AffineTransform<double, ImageDimension> TransformType;
+  typedef itk::AffineTransform<T, ImageDimension> TransformType;
 };
 
 template <>
-class RigidTransformTraits<2>
+class RigidTransformTraits<double, 2>
 {
 public:
   typedef itk::Euler2DTransform<double> TransformType;
 };
 
 template <>
-class RigidTransformTraits<3>
+class RigidTransformTraits<float, 2>
+{
+public:
+typedef itk::Euler2DTransform<float> TransformType;
+};
+
+template <>
+class RigidTransformTraits<double, 3>
 {
 public:
   // typedef itk::VersorRigid3DTransform<double>    TransformType;
@@ -38,52 +48,91 @@ public:
   typedef itk::Euler3DTransform<double> TransformType;
 };
 
-template <unsigned int ImageDimension>
+template <>
+class RigidTransformTraits<float, 3>
+{
+public:
+  // typedef itk::VersorRigid3DTransform<float>    TransformType;
+  // typedef itk::QuaternionRigidTransform<float>  TransformType;
+typedef itk::Euler3DTransform<float> TransformType;
+};
+
+template <class T, unsigned int ImageDimension>
 class SimilarityTransformTraits
 {
 // Don't worry about the fact that the default option is the
 // affine Transform, that one will not actually be instantiated.
 public:
-  typedef itk::AffineTransform<double, ImageDimension> TransformType;
+  typedef itk::AffineTransform<T, ImageDimension> TransformType;
 };
 
 template <>
-class SimilarityTransformTraits<2>
+class SimilarityTransformTraits<double, 2>
 {
 public:
   typedef itk::Similarity2DTransform<double> TransformType;
 };
 
 template <>
-class SimilarityTransformTraits<3>
+class SimilarityTransformTraits<float, 2>
+{
+public:
+typedef itk::Similarity2DTransform<float> TransformType;
+};
+
+template <>
+class SimilarityTransformTraits<double, 3>
 {
 public:
   typedef itk::Similarity3DTransform<double> TransformType;
 };
 
-template <unsigned int ImageDimension>
+template <>
+class SimilarityTransformTraits<float, 3>
+{
+public:
+typedef itk::Similarity3DTransform<float> TransformType;
+};
+
+template <class T, unsigned int ImageDimension>
 class CompositeAffineTransformTraits
 {
 // Don't worry about the fact that the default option is the
 // affine Transform, that one will not actually be instantiated.
 public:
-  typedef itk::AffineTransform<double, ImageDimension> TransformType;
+  typedef itk::AffineTransform<T, ImageDimension> TransformType;
 };
+
 template <>
-class CompositeAffineTransformTraits<2>
+class CompositeAffineTransformTraits<double, 2>
 {
 public:
   typedef itk::ANTSCenteredAffine2DTransform<double> TransformType;
 };
+
 template <>
-class CompositeAffineTransformTraits<3>
+class CompositeAffineTransformTraits<float, 2>
+{
+public:
+typedef itk::ANTSCenteredAffine2DTransform<float> TransformType;
+};
+
+template <>
+class CompositeAffineTransformTraits<double, 3>
 {
 public:
   typedef itk::ANTSAffine3DTransform<double> TransformType;
 };
 
-template <unsigned VImageDimension>
-RegistrationHelper<VImageDimension>
+template <>
+class CompositeAffineTransformTraits<float, 3>
+{
+public:
+typedef itk::ANTSAffine3DTransform<float> TransformType;
+};
+
+template <class T, unsigned VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::RegistrationHelper() :
   m_CompositeTransform( NULL ),
   m_FixedInitialTransform( NULL ),
@@ -110,8 +159,8 @@ RegistrationHelper<VImageDimension>
   this->m_Interpolator = linearInterpolator;
 }
 
-template <unsigned VImageDimension>
-RegistrationHelper<VImageDimension>
+template <class T, unsigned VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::~RegistrationHelper()
 {
 }
@@ -179,9 +228,9 @@ typename ImageType::Pointer PreprocessImage( typename ImageType::ConstPointer  i
   return outputImage;
 }
 
-template <unsigned VImageDimension>
-typename RegistrationHelper<VImageDimension>::MetricEnumeration
-RegistrationHelper<VImageDimension>
+template <class T, unsigned VImageDimension>
+typename RegistrationHelper<T, VImageDimension>::MetricEnumeration
+RegistrationHelper<T, VImageDimension>
 ::StringToMetricType(const std::string & str) const
 {
   if( str == "cc" )
@@ -211,9 +260,9 @@ RegistrationHelper<VImageDimension>
   return IllegalMetric;
 }
 
-template <unsigned VImageDimension>
-typename RegistrationHelper<VImageDimension>::XfrmMethod
-RegistrationHelper<VImageDimension>
+template <class T, unsigned VImageDimension>
+typename RegistrationHelper<T, VImageDimension>::XfrmMethod
+RegistrationHelper<T, VImageDimension>
 ::StringToXfrmMethod(const std::string & str) const
 {
   if( str == "rigid" )
@@ -282,9 +331,9 @@ RegistrationHelper<VImageDimension>
   return UnknownXfrm;
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::AddMetric( MetricEnumeration metricType,
              typename ImageType::Pointer & fixedImage,
              typename ImageType::Pointer & movingImage,
@@ -303,9 +352,9 @@ RegistrationHelper<VImageDimension>
   this->m_Metrics.push_back( init );
 }
 
-template <unsigned VImageDimension>
-typename RegistrationHelper<VImageDimension>::MetricListType
-RegistrationHelper<VImageDimension>
+template <class T, unsigned VImageDimension>
+typename RegistrationHelper<T, VImageDimension>::MetricListType
+RegistrationHelper<T, VImageDimension>
 ::GetMetricListPerStage( unsigned int stageID )
 {
   MetricListType stageMetricList;
@@ -322,9 +371,9 @@ RegistrationHelper<VImageDimension>
   return stageMetricList;
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::AddRigidTransform(double GradientStep)
 {
   TransformMethod init;
@@ -334,9 +383,9 @@ RegistrationHelper<VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::AddAffineTransform(double GradientStep)
 {
   TransformMethod init;
@@ -346,9 +395,9 @@ RegistrationHelper<VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::AddCompositeAffineTransform(double GradientStep)
 {
   TransformMethod init;
@@ -358,9 +407,9 @@ RegistrationHelper<VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::AddSimilarityTransform(double GradientStep)
 {
   TransformMethod init;
@@ -370,9 +419,9 @@ RegistrationHelper<VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::AddTranslationTransform(double GradientStep)
 {
   TransformMethod init;
@@ -382,9 +431,9 @@ RegistrationHelper<VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::AddBSplineTransform(double GradientStep, std::vector<unsigned int> & MeshSizeAtBaseLevel)
 {
   TransformMethod init;
@@ -395,9 +444,9 @@ RegistrationHelper<VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::AddGaussianDisplacementFieldTransform(double GradientStep, double UpdateFieldVarianceInVarianceSpace,
                                         double TotalFieldVarianceInVarianceSpace)
 {
@@ -410,9 +459,9 @@ RegistrationHelper<VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::AddBSplineDisplacementFieldTransform(double GradientStep,
                                        std::vector<unsigned int> & UpdateFieldMeshSizeAtBaseLevel,
                                        std::vector<unsigned int> & TotalFieldMeshSizeAtBaseLevel,
@@ -428,9 +477,9 @@ RegistrationHelper<VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::AddTimeVaryingVelocityFieldTransform( double GradientStep,
                                         unsigned int NumberOfTimeIndices,
                                         double UpdateFieldVarianceInVarianceSpace,
@@ -450,9 +499,9 @@ RegistrationHelper<VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::AddTimeVaryingBSplineVelocityFieldTransform( double GradientStep, std::vector<unsigned int> VelocityFieldMeshSize,
                                                unsigned int NumberOfTimePointSamples, unsigned int SplineOrder )
 {
@@ -466,9 +515,9 @@ RegistrationHelper<VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::AddSyNTransform( double GradientStep, double UpdateFieldVarianceInVarianceSpace,
                    double TotalFieldVarianceInVarianceSpace )
 {
@@ -481,9 +530,9 @@ RegistrationHelper<VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::AddBSplineSyNTransform( double GradientStep, std::vector<unsigned int> &  UpdateFieldMeshSizeAtBaseLevel,
                           std::vector<unsigned int> &  TotalFieldMeshSizeAtBaseLevel,
                           unsigned int SplineOrder )
@@ -498,9 +547,9 @@ RegistrationHelper<VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::AddExponentialTransform( double GradientStep, double UpdateFieldVarianceInVarianceSpace,
                            double VelocityFieldVarianceInVarianceSpace, unsigned int NumberOfIntegrationSteps )
 {
@@ -515,9 +564,9 @@ RegistrationHelper<VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::AddBSplineExponentialTransform( double GradientStep, std::vector<unsigned int> &  UpdateFieldMeshSizeAtBaseLevel,
                                   std::vector<unsigned int> & VelocityFieldMeshSizeAtBaseLevel,
                                   unsigned int NumberOfIntegrationSteps,
@@ -535,57 +584,57 @@ RegistrationHelper<VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::SetIterations( const std::vector<std::vector<unsigned int> > & Iterations )
 {
   this->m_Iterations = Iterations;
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::SetConvergenceThresholds( const std::vector<double> & thresholds )
 {
   this->m_ConvergenceThresholds = thresholds;
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::SetConvergenceWindowSizes( const std::vector<unsigned int> & windowSizes )
 {
   this->m_ConvergenceWindowSizes = windowSizes;
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::SetSmoothingSigmas( const std::vector<std::vector<float> > & SmoothingSigmas )
 {
   this->m_SmoothingSigmas = SmoothingSigmas;
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::SetSmoothingSigmasAreInPhysicalUnits( const std::vector<bool> & SmoothingSigmasAreInPhysicalUnits )
 {
   this->m_SmoothingSigmasAreInPhysicalUnits = SmoothingSigmasAreInPhysicalUnits;
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::SetShrinkFactors( const std::vector<std::vector<unsigned int> > & ShrinkFactors )
 {
   this->m_ShrinkFactors = ShrinkFactors;
 }
 
-template <unsigned VImageDimension>
-typename RegistrationHelper<VImageDimension>::ShrinkFactorsPerDimensionContainerType
-RegistrationHelper<VImageDimension>
+template <class T, unsigned VImageDimension>
+typename RegistrationHelper<T, VImageDimension>::ShrinkFactorsPerDimensionContainerType
+RegistrationHelper<T, VImageDimension>
 ::CalculateShrinkFactorsPerDimension( unsigned int factor, ImagePointer image )
 {
   typedef typename ImageType::SpacingType SpacingType;
@@ -635,9 +684,9 @@ RegistrationHelper<VImageDimension>
   return shrinkFactorsPerDimension;
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::SetWinsorizeImageIntensities( bool Winsorize, float LowerQuantile, float UpperQuantile )
 {
   this->m_WinsorizeImageIntensities = Winsorize;
@@ -645,9 +694,9 @@ RegistrationHelper<VImageDimension>
   this->m_UpperQuantile = UpperQuantile;
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 int
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::ValidateParameters()
 {
   if( this->m_NumberOfStages == 0 )
@@ -690,15 +739,15 @@ RegistrationHelper<VImageDimension>
   return EXIT_SUCCESS;
 }
 
-template <unsigned VImageDimension>
-typename RegistrationHelper<VImageDimension>::ImageType::Pointer
-RegistrationHelper<VImageDimension>
+template <class T, unsigned VImageDimension>
+typename RegistrationHelper<T, VImageDimension>::ImageType::Pointer
+RegistrationHelper<T, VImageDimension>
 ::GetWarpedImage() const
 {
   typename ImageType::Pointer fixedImage = this->m_Metrics[0].m_FixedImage;
   typename ImageType::Pointer movingImage = this->m_Metrics[0].m_MovingImage;
 
-  typedef itk::ResampleImageFilter<ImageType, ImageType> ResampleFilterType;
+  typedef itk::ResampleImageFilter<ImageType, ImageType, RealType> ResampleFilterType;
   typename ResampleFilterType::Pointer resampler = ResampleFilterType::New();
   resampler->SetTransform( this->m_CompositeTransform );
   resampler->SetInput( movingImage );
@@ -712,9 +761,9 @@ RegistrationHelper<VImageDimension>
   return WarpedImage.GetPointer();
 }
 
-template <unsigned VImageDimension>
-typename RegistrationHelper<VImageDimension>::ImageType::Pointer
-RegistrationHelper<VImageDimension>
+template <class T, unsigned VImageDimension>
+typename RegistrationHelper<T, VImageDimension>::ImageType::Pointer
+RegistrationHelper<T, VImageDimension>
 ::GetInverseWarpedImage() const
 {
   typename ImageType::Pointer fixedImage = this->m_Metrics[0].m_FixedImage;
@@ -724,7 +773,7 @@ RegistrationHelper<VImageDimension>
     {
     return 0;
     }
-  typedef itk::ResampleImageFilter<ImageType, ImageType> ResampleFilterType;
+  typedef itk::ResampleImageFilter<ImageType, ImageType, RealType> ResampleFilterType;
   typename ResampleFilterType::Pointer inverseResampler = ResampleFilterType::New();
   inverseResampler->SetTransform( this->m_CompositeTransform->GetInverseTransform() );
   inverseResampler->SetInput( fixedImage );
@@ -738,9 +787,9 @@ RegistrationHelper<VImageDimension>
   return InverseWarpedImage.GetPointer();
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::SetFixedImageMask(typename MaskImageType::Pointer & fixedImageMask)
 {
   typename ImageMaskSpatialObjectType::Pointer so =
@@ -749,9 +798,9 @@ RegistrationHelper<VImageDimension>
   this->SetFixedImageMask(so);
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::SetMovingImageMask(typename MaskImageType::Pointer & movingImageMask)
 {
   typename ImageMaskSpatialObjectType::Pointer so =
@@ -760,9 +809,9 @@ RegistrationHelper<VImageDimension>
   this->SetMovingImageMask(so);
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 int
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::DoRegistration()
 {
   /** Can really impact performance */
@@ -963,7 +1012,7 @@ RegistrationHelper<VImageDimension>
           this->Logger() << "  using the CC metric (radius = "
                          << radiusOption << ", weight = "
                          << stageMetricList[currentMetricNumber].m_Weighting << ")" << std::endl;
-          typedef itk::ANTSNeighborhoodCorrelationImageToImageMetricv4<ImageType, ImageType> CorrelationMetricType;
+          typedef itk::ANTSNeighborhoodCorrelationImageToImageMetricv4<ImageType, ImageType, ImageType, T> CorrelationMetricType;
           typename CorrelationMetricType::Pointer correlationMetric = CorrelationMetricType::New();
             {
             typename CorrelationMetricType::RadiusType radius;
@@ -982,7 +1031,7 @@ RegistrationHelper<VImageDimension>
           this->Logger() << "  using the Mattes MI metric (number of bins = "
                          << binOption << ", weight = "
                          << stageMetricList[currentMetricNumber].m_Weighting << ")" << std::endl;
-          typedef itk::MattesMutualInformationImageToImageMetricv4<ImageType, ImageType> MutualInformationMetricType;
+          typedef itk::MattesMutualInformationImageToImageMetricv4<ImageType, ImageType, ImageType, T> MutualInformationMetricType;
           typename MutualInformationMetricType::Pointer mutualInformationMetric = MutualInformationMetricType::New();
           mutualInformationMetric = mutualInformationMetric;
           mutualInformationMetric->SetNumberOfHistogramBins( binOption );
@@ -998,8 +1047,8 @@ RegistrationHelper<VImageDimension>
           this->Logger() << "  using the joint histogram MI metric (number of bins = "
                          << binOption << ", weight = "
                          << stageMetricList[currentMetricNumber].m_Weighting << ")" << std::endl;
-          typedef itk::JointHistogramMutualInformationImageToImageMetricv4<ImageType,
-                                                                           ImageType> MutualInformationMetricType;
+          typedef itk::JointHistogramMutualInformationImageToImageMetricv4<ImageType, ImageType, ImageType,
+                                                                           T> MutualInformationMetricType;
           typename MutualInformationMetricType::Pointer mutualInformationMetric = MutualInformationMetricType::New();
           mutualInformationMetric = mutualInformationMetric;
           mutualInformationMetric->SetNumberOfHistogramBins( binOption );
@@ -1015,7 +1064,7 @@ RegistrationHelper<VImageDimension>
           this->Logger() << "  using the MeanSquares metric (weight = "
                          << stageMetricList[currentMetricNumber].m_Weighting << ")" << std::endl;
 
-          typedef itk::MeanSquaresImageToImageMetricv4<ImageType, ImageType> MeanSquaresMetricType;
+          typedef itk::MeanSquaresImageToImageMetricv4<ImageType, ImageType, ImageType, T> MeanSquaresMetricType;
           typename MeanSquaresMetricType::Pointer meanSquaresMetric = MeanSquaresMetricType::New();
           meanSquaresMetric = meanSquaresMetric;
           metric = meanSquaresMetric;
@@ -1026,7 +1075,7 @@ RegistrationHelper<VImageDimension>
           this->Logger() << "  using the Demons metric (weight = "
                          << stageMetricList[currentMetricNumber].m_Weighting << ")" << std::endl;
 
-          typedef itk::DemonsImageToImageMetricv4<ImageType, ImageType> DemonsMetricType;
+          typedef itk::DemonsImageToImageMetricv4<ImageType, ImageType, ImageType, T> DemonsMetricType;
           typename DemonsMetricType::Pointer demonsMetric = DemonsMetricType::New();
           demonsMetric = demonsMetric;
           metric = demonsMetric;
@@ -1036,7 +1085,7 @@ RegistrationHelper<VImageDimension>
           {
           this->Logger() << "  using the global correlation metric (weight = "
                          << stageMetricList[currentMetricNumber].m_Weighting << ")" << std::endl;
-          typedef itk::CorrelationImageToImageMetricv4<ImageType, ImageType> corrMetricType;
+          typedef itk::CorrelationImageToImageMetricv4<ImageType, ImageType, ImageType, T> corrMetricType;
           typename corrMetricType::Pointer corrMetric = corrMetricType::New();
           metric = corrMetric;
           }
@@ -1105,13 +1154,13 @@ RegistrationHelper<VImageDimension>
 
     // There's a scale issue here.  Currently we are using the first metric to estimate the
     // scales but we might need to change this.
-
     typedef itk::RegistrationParameterScalesFromPhysicalShift<MetricType> ScalesEstimatorType;
+
     typename ScalesEstimatorType::Pointer scalesEstimator = ScalesEstimatorType::New();
     scalesEstimator->SetMetric( singleMetric );
     scalesEstimator->SetTransformForward( true );
 
-    typedef itk::ConjugateGradientLineSearchOptimizerv4 ConjugateGradientDescentOptimizerType;
+    typedef itk::ConjugateGradientLineSearchOptimizerTemplatev4<T> ConjugateGradientDescentOptimizerType;
     typename ConjugateGradientDescentOptimizerType::Pointer optimizer = ConjugateGradientDescentOptimizerType::New();
     optimizer->SetLowerLimit( 0 );
     optimizer->SetUpperLimit( 2 );
@@ -1126,8 +1175,7 @@ RegistrationHelper<VImageDimension>
     optimizer->SetDoEstimateLearningRateAtEachIteration( this->m_DoEstimateLearningRateAtEachIteration );
     optimizer->SetDoEstimateLearningRateOnce( !this->m_DoEstimateLearningRateAtEachIteration );
 
-
-    typedef antsRegistrationOptimizerCommandIterationUpdate<VImageDimension,
+    typedef antsRegistrationOptimizerCommandIterationUpdate<T, VImageDimension,
                                                             ConjugateGradientDescentOptimizerType> OptimizerCommandType;
     typename OptimizerCommandType::Pointer optimizerObserver = OptimizerCommandType::New();
     optimizerObserver->SetLogStream( *this->m_LogStream );
@@ -1145,8 +1193,8 @@ RegistrationHelper<VImageDimension>
       optimizerObserver->SetCurrentStageNumber( currentStageNumber );
       }
 
-    typedef itk::GradientDescentLineSearchOptimizerv4 GradientDescentLSOptimizerType;
-    typedef itk::GradientDescentOptimizerv4           GradientDescentOptimizerType;
+    typedef itk::GradientDescentLineSearchOptimizerTemplatev4<T> GradientDescentLSOptimizerType;
+    typedef itk::GradientDescentOptimizerTemplatev4<T>           GradientDescentOptimizerType;
     typename GradientDescentOptimizerType::Pointer optimizer2 = GradientDescentOptimizerType::New();
     //    optimizer2->SetLowerLimit( 0 );
     //    optimizer2->SetUpperLimit( 2 );
@@ -1161,7 +1209,7 @@ RegistrationHelper<VImageDimension>
     optimizer2->SetDoEstimateLearningRateAtEachIteration( this->m_DoEstimateLearningRateAtEachIteration );
     optimizer2->SetDoEstimateLearningRateOnce( !this->m_DoEstimateLearningRateAtEachIteration );
 
-    typedef antsRegistrationOptimizerCommandIterationUpdate<VImageDimension,
+    typedef antsRegistrationOptimizerCommandIterationUpdate<T, VImageDimension,
                                                             GradientDescentOptimizerType> OptimizerCommandType2;
     typename OptimizerCommandType2::Pointer optimizerObserver2 = OptimizerCommandType2::New();
     optimizerObserver2->SetLogStream( *this->m_LogStream );
@@ -1255,7 +1303,7 @@ RegistrationHelper<VImageDimension>
         break;
       case Rigid:
         {
-        typedef typename RigidTransformTraits<VImageDimension>::TransformType RigidTransformType;
+        typedef typename RigidTransformTraits<T, VImageDimension>::TransformType RigidTransformType;
 
         typedef itk::ImageRegistrationMethodv4<ImageType, ImageType, RigidTransformType> RigidRegistrationType;
         typename RigidRegistrationType::Pointer rigidRegistration = RigidRegistrationType::New();
@@ -1330,7 +1378,7 @@ RegistrationHelper<VImageDimension>
         break;
       case CompositeAffine:
         {
-        typedef typename CompositeAffineTransformTraits<VImageDimension>::TransformType CompositeAffineTransformType;
+        typedef typename CompositeAffineTransformTraits<T, VImageDimension>::TransformType CompositeAffineTransformType;
 
         typedef itk::ImageRegistrationMethodv4<ImageType, ImageType,
                                                CompositeAffineTransformType> CompositeAffineRegistrationType;
@@ -1406,7 +1454,7 @@ RegistrationHelper<VImageDimension>
         break;
       case Similarity:
         {
-        typedef typename SimilarityTransformTraits<VImageDimension>::TransformType SimilarityTransformType;
+        typedef typename SimilarityTransformTraits<T, VImageDimension>::TransformType SimilarityTransformType;
 
         typedef itk::ImageRegistrationMethodv4<ImageType, ImageType,
                                                SimilarityTransformType> SimilarityRegistrationType;
@@ -2026,8 +2074,12 @@ RegistrationHelper<VImageDimension>
           this->m_TransformMethods[currentStageNumber].m_TotalFieldVarianceInVarianceSpace;
         RealType varianceForTotalFieldTime = this->m_TransformMethods[currentStageNumber].m_TotalFieldTimeSigma;
 
-        typedef itk::TimeVaryingVelocityFieldImageRegistrationMethodv4<ImageType, ImageType>
-          VelocityFieldRegistrationType;
+        typedef itk::GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform <T, ImageType::ImageDimension>
+           TimeVaryingVelocityFieldOutputTransformType;
+
+        typedef itk::TimeVaryingVelocityFieldImageRegistrationMethodv4<ImageType, ImageType,
+                                                                       TimeVaryingVelocityFieldOutputTransformType>
+                                                                                            VelocityFieldRegistrationType;
         typename VelocityFieldRegistrationType::Pointer velocityFieldRegistration =
           VelocityFieldRegistrationType::New();
 
@@ -2220,7 +2272,11 @@ RegistrationHelper<VImageDimension>
         typename TimeVaryingVelocityFieldControlPointLatticeType::SizeType initialTransformDomainMeshSize =
           transformDomainMeshSize;
 
-        typedef itk::TimeVaryingBSplineVelocityFieldImageRegistrationMethod<ImageType, ImageType>
+        typedef itk::TimeVaryingBSplineVelocityFieldTransform <T, ImageType::ImageDimension>
+          TimeVaryingBSplineVelocityFieldOutputTransformType;
+
+        typedef itk::TimeVaryingBSplineVelocityFieldImageRegistrationMethod<ImageType, ImageType,
+                                                                            TimeVaryingBSplineVelocityFieldOutputTransformType>
           VelocityFieldRegistrationType;
         typename VelocityFieldRegistrationType::Pointer velocityFieldRegistration =
           VelocityFieldRegistrationType::New();
@@ -3009,9 +3065,9 @@ RegistrationHelper<VImageDimension>
   return EXIT_SUCCESS;
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::SetMovingInitialTransform( const TransformType *initialTransform )
 {
   // Since the initial transform might be linear (or a composition of
@@ -3036,9 +3092,9 @@ RegistrationHelper<VImageDimension>
     }
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::SetFixedInitialTransform( const TransformType *initialTransform  )
 {
   typename CompositeTransformType::Pointer compToAdd;
@@ -3076,9 +3132,9 @@ RegistrationHelper<VImageDimension>
     }
 }
 
-template <unsigned VImageDimension>
-typename RegistrationHelper<VImageDimension>::AffineTransformType::Pointer
-RegistrationHelper<VImageDimension>
+template <class T, unsigned VImageDimension>
+typename RegistrationHelper<T, VImageDimension>::AffineTransformType::Pointer
+RegistrationHelper<T, VImageDimension>
 ::CollapseLinearTransforms( const CompositeTransformType * compositeTransform )
 {
   if( !compositeTransform->IsLinear() )
@@ -3113,9 +3169,9 @@ RegistrationHelper<VImageDimension>
   return totalTransform;
 }
 
-template <unsigned VImageDimension>
-typename RegistrationHelper<VImageDimension>::DisplacementFieldTransformPointer
-RegistrationHelper<VImageDimension>
+template <class T, unsigned VImageDimension>
+typename RegistrationHelper<T, VImageDimension>::DisplacementFieldTransformPointer
+RegistrationHelper<T, VImageDimension>
 ::CollapseDisplacementFieldTransforms( const CompositeTransformType * compositeTransform )
 {
   if( compositeTransform->GetTransformCategory() != TransformType::DisplacementField  )
@@ -3188,9 +3244,9 @@ RegistrationHelper<VImageDimension>
   return totalTransform;
 }
 
-template <unsigned VImageDimension>
-typename RegistrationHelper<VImageDimension>::CompositeTransformPointer
-RegistrationHelper<VImageDimension>
+template <class T, unsigned VImageDimension>
+typename RegistrationHelper<T, VImageDimension>::CompositeTransformPointer
+RegistrationHelper<T, VImageDimension>
 ::CollapseCompositeTransform( const CompositeTransformType * compositeTransform )
 {
   CompositeTransformPointer collapsedCompositeTransform = CompositeTransformType::New();
@@ -3284,9 +3340,9 @@ RegistrationHelper<VImageDimension>
   return collapsedCompositeTransform;
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::ApplyCompositeLinearTransformToImageHeader( const CompositeTransformType * compositeTransform,
                                               ImageBaseType * const image,
                                               const bool applyInverse )
@@ -3301,9 +3357,21 @@ RegistrationHelper<VImageDimension>
   typename ImageType::PointType origin = image->GetOrigin();
   typename ImageType::DirectionType direction = image->GetDirection();
 
+  // Image direction matrix is type of double.
+  // It should be converted to the current InternalComputationType before it is used to set transfrom parameters.
+  vnl_matrix<double> DoubleLocalDirection( VImageDimension, VImageDimension );
+  vnl_matrix<T> localDirection( VImageDimension, VImageDimension );
+  DoubleLocalDirection = direction.GetVnlMatrix();
+  vnl_copy( DoubleLocalDirection, localDirection );
+
+  // Image origin is an itk point of type double.
+  // It should be converted to the current InternalComputationType before it is used to set the offset parameters of transform.
+  typename itk::Point<T, VImageDimension> localOrigin;
+  localOrigin.CastFrom(origin);
+
   typename AffineTransformType::Pointer imageTransform = AffineTransformType::New();
-  imageTransform->SetMatrix( direction );
-  imageTransform->SetOffset( origin.GetVectorFromOrigin() );
+  imageTransform->SetMatrix( localDirection );
+  imageTransform->SetOffset( localOrigin.GetVectorFromOrigin() );
 
   if( applyInverse )
     {
@@ -3322,7 +3390,11 @@ RegistrationHelper<VImageDimension>
       {
       origin[d] = inverseOffset[d];
       }
-    direction = inverseMatrix;
+    //direction = inverseMatrix; // Does not work because they probably have different types!
+    vnl_matrix<T> localInverseMatrix( VImageDimension, VImageDimension );
+    localInverseMatrix = inverseMatrix.GetVnlMatrix();
+    vnl_copy(localInverseMatrix, DoubleLocalDirection);
+    direction = DoubleLocalDirection;
     }
   else
     {
@@ -3334,16 +3406,20 @@ RegistrationHelper<VImageDimension>
       {
       origin[d] = offset[d];
       }
-    direction = matrix;
+    //direction = matrix; // Does not work because they probably have different types!
+    vnl_matrix<T> localMatrix( VImageDimension, VImageDimension );
+    localMatrix = matrix.GetVnlMatrix();
+    vnl_copy(localMatrix, DoubleLocalDirection);
+    direction = DoubleLocalDirection;
     }
 
   image->SetDirection( direction );
   image->SetOrigin( origin );
 }
 
-template <unsigned VImageDimension>
+template <class T, unsigned VImageDimension>
 void
-RegistrationHelper<VImageDimension>
+RegistrationHelper<T, VImageDimension>
 ::PrintState() const
 {
   this->Logger() << "Dimension = " << Self::ImageDimension << std::endl

--- a/Examples/make_interpolator_snip.tmpl
+++ b/Examples/make_interpolator_snip.tmpl
@@ -74,37 +74,38 @@ typename InterpolatorType::Pointer interpolator = NULL;
     gaussianInterpolator->SetParameters( sigma, alpha );
     interpolator = gaussianInterpolator;
     }
-  else if( !std::strcmp( whichInterpolator.c_str(), "cosinewindowedsinc" ) )
+  else if( !std::strcmp( whichInterpolator.c_str(), "CosineWindowedSinc" ) )
     {
-    typedef itk::WindowedSincInterpolateImageFunction<ImageType, 3,
-	    itk::Function::CosineWindowFunction<3> > CosineInterpolatorType;
+    typedef itk::WindowedSincInterpolateImageFunction
+                 <ImageType, 3, itk::Function::CosineWindowFunction<3, RealType, RealType>, itk::ConstantBoundaryCondition< ImageType >, RealType> CosineInterpolatorType;
     typename CosineInterpolatorType::Pointer cosineInterpolator = CosineInterpolatorType::New();
     interpolator = cosineInterpolator;
     }
   else if( !std::strcmp( whichInterpolator.c_str(), "hammingwindowedsinc" ) )
     {
-    typedef itk::WindowedSincInterpolateImageFunction<ImageType, 3> HammingInterpolatorType;
+    typedef itk::WindowedSincInterpolateImageFunction
+                 <ImageType, 3, itk::Function::HammingWindowFunction<3, RealType, RealType >, itk::ConstantBoundaryCondition< ImageType >, RealType> HammingInterpolatorType;
     typename HammingInterpolatorType::Pointer hammingInterpolator = HammingInterpolatorType::New();
     interpolator = hammingInterpolator;
     }
   else if( !std::strcmp( whichInterpolator.c_str(), "lanczoswindowedsinc" ) )
     {
-    typedef itk::WindowedSincInterpolateImageFunction<ImageType, 3,
-	    itk::Function::LanczosWindowFunction<3> > LanczosInterpolatorType;
+    typedef itk::WindowedSincInterpolateImageFunction
+                 <ImageType, 3, itk::Function::LanczosWindowFunction<3, RealType, RealType>, itk::ConstantBoundaryCondition< ImageType >, RealType > LanczosInterpolatorType;
     typename LanczosInterpolatorType::Pointer lanczosInterpolator = LanczosInterpolatorType::New();
     interpolator = lanczosInterpolator;
     }
   else if( !std::strcmp( whichInterpolator.c_str(), "blackmanwindowedsinc" ) )
     {
-    typedef itk::WindowedSincInterpolateImageFunction<ImageType, 3,
-	    itk::Function::BlackmanWindowFunction<3> > BlackmanInterpolatorType;
+    typedef itk::WindowedSincInterpolateImageFunction
+                 <ImageType, 3, itk::Function::BlackmanWindowFunction<3, RealType, RealType>, itk::ConstantBoundaryCondition< ImageType >, RealType > BlackmanInterpolatorType;
     typename BlackmanInterpolatorType::Pointer blackmanInterpolator = BlackmanInterpolatorType::New();
     interpolator = blackmanInterpolator;
     }
   else if( !std::strcmp( whichInterpolator.c_str(), "welchwindowedsinc" ) )
     {
-    typedef itk::WindowedSincInterpolateImageFunction<ImageType, 3,
-	    itk::Function::WelchWindowFunction<3> > WelchInterpolatorType;
+    typedef itk::WindowedSincInterpolateImageFunction
+                 <ImageType, 3, itk::Function::WelchWindowFunction<3, RealType, RealType>, itk::ConstantBoundaryCondition< ImageType >, RealType > WelchInterpolatorType;
     typename WelchInterpolatorType::Pointer welchInterpolator = WelchInterpolatorType::New();
     interpolator = welchInterpolator;
     }

--- a/Examples/simpleSynRegistration.cxx
+++ b/Examples/simpleSynRegistration.cxx
@@ -16,7 +16,7 @@ output prefix file name
 
 namespace ants
 {
-typedef  ants::RegistrationHelper<3>                    RegistrationHelperType;
+typedef  ants::RegistrationHelper<double, 3>                    RegistrationHelperType;
 typedef  RegistrationHelperType::ImageType              ImageType;
 typedef  RegistrationHelperType::CompositeTransformType CompositeTransformType;
 
@@ -150,7 +150,7 @@ int simpleSynRegistration( std::vector<std::string> args, std::ostream* out_stre
 
   // ===========Read the initial transform and write that in a composite transform
   typedef RegistrationHelperType::TransformType TransformType;
-  TransformType::Pointer initialTransform = itk::ants::ReadTransform<3>( args[2] );
+  TransformType::Pointer initialTransform = itk::ants::ReadTransform<double, 3>( args[2] );
   if( initialTransform.IsNull() )
     {
     antscout << "Can't read initial transform " << std::endl;
@@ -171,7 +171,7 @@ int simpleSynRegistration( std::vector<std::string> args, std::ostream* out_stre
   antscout << "***** Ready to write the results ...\n" << std::endl;
   std::stringstream outputFileName;
   outputFileName << args[3] << "Warp.nii.gz";
-  itk::ants::WriteTransform<3>( outputTransform, outputFileName.str() );
+  itk::ants::WriteTransform<double, 3>( outputTransform, outputFileName.str() );
 
   // compute and write the inverse of the output transform
   const bool writeInverse(true);

--- a/SuperBuild/External_ITKv4.cmake
+++ b/SuperBuild/External_ITKv4.cmake
@@ -81,7 +81,7 @@ if(NOT DEFINED ${extProjName}_DIR AND NOT ${USE_SYSTEM_${extProjName}})
     )
   ### --- End Project specific additions
   set(${proj}_REPOSITORY ${git_protocol}://itk.org/ITK.git)
-  set(${proj}_GIT_TAG 57d6ee8b0fbca5bcc6a00d6c02d00efa44e15a4f) #2013-06-20 SinglePrecision
+  set(${proj}_GIT_TAG ec61e6e2b09aed85c758c173ba0de0a18587c82c) #2013-06-21 SinglePrecision
   ExternalProject_Add(${proj}
     GIT_REPOSITORY ${${proj}_REPOSITORY}
     GIT_TAG ${${proj}_GIT_TAG}

--- a/Utilities/itkantsReadWriteTransform.h
+++ b/Utilities/itkantsReadWriteTransform.h
@@ -13,8 +13,8 @@ namespace itk
 {
 namespace ants
 {
-template <unsigned VImageDimension>
-typename itk::Transform<double, VImageDimension, VImageDimension>::Pointer
+template <class T, unsigned VImageDimension>
+typename itk::Transform<T, VImageDimension, VImageDimension>::Pointer
 ReadTransform(const std::string & filename,
               const bool useStaticCastForR = false) // This parameter changes to true by the programs that use R, so this code
                                                      // returns a different output for them.
@@ -29,7 +29,7 @@ ReadTransform(const std::string & filename,
 
   bool hasTransformBeenRead = false;
 
-  typedef typename itk::DisplacementFieldTransform<double, VImageDimension> DisplacementFieldTransformType;
+  typedef typename itk::DisplacementFieldTransform<T, VImageDimension> DisplacementFieldTransformType;
   typedef typename DisplacementFieldTransformType::DisplacementFieldType    DisplacementFieldType;
   typedef itk::ImageFileReader<DisplacementFieldType>                       DisplacementFieldReaderType;
   typename DisplacementFieldReaderType::Pointer fieldReader = DisplacementFieldReaderType::New();
@@ -56,7 +56,7 @@ ReadTransform(const std::string & filename,
       }
     }
 
-  typedef typename itk::Transform<double, VImageDimension, VImageDimension> TransformType;
+  typedef typename itk::Transform<T, VImageDimension, VImageDimension> TransformType;
   typename TransformType::Pointer transform;
   if( hasTransformBeenRead )
     {
@@ -67,8 +67,8 @@ ReadTransform(const std::string & filename,
     }
   else
     {
-    typename itk::TransformFileReader::Pointer transformReader
-      = itk::TransformFileReader::New();
+    typename itk::TransformFileReaderTemplate<T>::Pointer transformReader
+      = itk::TransformFileReaderTemplate<T>::New();
 
     transformReader->SetFileName( filename.c_str() );
     try
@@ -96,10 +96,10 @@ ReadTransform(const std::string & filename,
       return transform;
       }
 
-    const typename itk::TransformFileReader::TransformListType * const listOfTransforms =
+    const typename itk::TransformFileReaderTemplate<T>::TransformListType * const listOfTransforms =
       transformReader->GetTransformList();
     transform = dynamic_cast<TransformType *>( listOfTransforms->front().GetPointer() );
-    
+
     /** below is a bad thing but it's the only temporary fix i could find for ANTsR on unix --- B.A. */
     if ( transform.IsNull() && ( useStaticCastForR == true ) )
        {
@@ -109,15 +109,15 @@ ReadTransform(const std::string & filename,
   return transform;
 }
 
-template <unsigned int VImageDimension>
+template <class T, unsigned int VImageDimension>
 int
-WriteTransform(typename itk::Transform<double, VImageDimension, VImageDimension>::Pointer & xfrm,
+WriteTransform(typename itk::Transform<T, VImageDimension, VImageDimension>::Pointer & xfrm,
                const std::string & filename)
 {
-  typedef typename itk::DisplacementFieldTransform<double, VImageDimension> DisplacementFieldTransformType;
+  typedef typename itk::DisplacementFieldTransform<T, VImageDimension>      DisplacementFieldTransformType;
   typedef typename DisplacementFieldTransformType::DisplacementFieldType    DisplacementFieldType;
   typedef typename itk::ImageFileWriter<DisplacementFieldType>              DisplacementFieldWriter;
-  typedef itk::TransformFileWriter                                          TransformWriterType;
+  typedef itk::TransformFileWriterTemplate<T>                               TransformWriterType;
 
   DisplacementFieldTransformType *dispXfrm =
     dynamic_cast<DisplacementFieldTransformType *>(xfrm.GetPointer() );


### PR DESCRIPTION
There is a new command line "--float" for antsRegistration, and
eventually for other programs as well.

The final goal is to make "antsRegistration" program capable to
do its computations using single precision (float type) instead of
'double' precision.
It helps CPU to do more processings per time unit when the single precision is enough
for our computations.

By this patch antsRegistration is made as a template over computations type that can
accept 'float' or 'double'. The float precision can be enabled using the
"--float" flag. e.g. --float 1

Based on the new changes on ITK, its registration framework allows us to
do our computations in single precision, and the "float" option will
work when ANTs is built based on this new version of ITK.

After the changes of this pacth, ANTs is built successfully based on
the new version of itk.
