### PR TITLE
ENH: list all parameters that are mandatory for antsRegistration

### DIFF
--- a/Examples/antsRegistration.cxx
+++ b/Examples/antsRegistration.cxx
@@ -452,7 +452,9 @@ private:
     std::string commandDescription = std::string( "This program is a user-level " )
       + std::string( "registration application meant to utilize ITKv4-only classes. The user can specify " )
       + std::string( "any number of \"stages\" where a stage consists of a transform; an image metric; " )
-      + std::string( "and iterations, shrink factors, and smoothing sigmas for each level." );
+      + std::string( "and iterations, shrink factors, and smoothing sigmas for each level." )
+      + std::string( "Note that dimensionality, metric, transform, output, convergence, shrink-factors ")
+      + std::string( " and smoothing-sigmas parameters are mandatory.")
 
     parser->SetCommandDescription( commandDescription );
     InitializeCommandLineOptions( parser );


### PR DESCRIPTION
The current behavior of antsRegistration is segmentation fault when any of these
parameters (except dimensionality) is not listed in the command line.
