### PR TITLE
ENH: Force using consistent type precision when float is selected.

### DIFF
--- a/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
+++ b/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
@@ -157,7 +157,7 @@ public:
         std::cout << " "; // if the output of current iteration is written to disk, and star
         }                 // will appear before line, else a free space will be printed to keep visual alignment.
 
-      this->Logger() << "DIAGNOSTIC, "
+      this->Logger() << "1DIAGNOSTIC, "
                      << std::setw(5) << lCurrentIteration << ", "
                      << std::scientific << std::setprecision(12) << filter->GetCurrentMetricValue() << ", "
                      << std::scientific << std::setprecision(12) << filter->GetCurrentConvergenceValue() << ", "

--- a/Examples/antsRegistrationCommandIterationUpdate.h
+++ b/Examples/antsRegistrationCommandIterationUpdate.h
@@ -88,7 +88,7 @@ public:
 
       m_clock.Stop();
       const itk::RealTimeClock::TimeStampType now = m_clock.GetTotal();
-      this->Logger() << "DIAGNOSTIC, "
+      this->Logger() << "WDIAGNOSTIC, "
                      << std::setw(5) << lCurrentIteration << ", "
                      << std::scientific << std::setprecision(12) << filter->GetCurrentMetricValue() << ", "
                      << std::scientific << std::setprecision(12) << filter->GetCurrentConvergenceValue() << ", "

--- a/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
+++ b/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
@@ -139,7 +139,7 @@ public:
         std::cout << " "; // if the output of current iteration is written to disk, and star
         }                 // will appear before line, else a free space will be printed to keep visual alignment.
 
-      this->Logger() << "DIAGNOSTIC, "
+      this->Logger() << "2DIAGNOSTIC, "
                      << std::setw(5) << lCurrentIteration << ", "
                      << std::scientific << std::setprecision(12) << this->m_Optimizer->GetValue() << ", "
                      << std::scientific << std::setprecision(12) << this->m_Optimizer->GetConvergenceValue() << ", "

--- a/Examples/antsRegistrationTemplateHeader.h
+++ b/Examples/antsRegistrationTemplateHeader.h
@@ -24,11 +24,12 @@ namespace ants {
 
 extern const char * RegTypeToFileName(const std::string & type, bool & writeInverse, bool & writeVelocityField);
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 int
 DoRegistration(typename ParserType::Pointer & parser)
 {
-  typedef typename ants::RegistrationHelper<T, VImageDimension>      RegistrationHelperType;
+  typedef TComputeType RealType;
+  typedef typename ants::RegistrationHelper<TComputeType, VImageDimension>      RegistrationHelperType;
   typedef typename RegistrationHelperType::ImageType              ImageType;
   typedef typename RegistrationHelperType::CompositeTransformType CompositeTransformType;
 
@@ -116,7 +117,7 @@ DoRegistration(typename ParserType::Pointer & parser)
     {
     std::vector<bool> isDerivedInitialMovingTransform;
     typename CompositeTransformType::Pointer compositeTransform =
-      GetCompositeTransformFromParserOption<T, VImageDimension>( parser, initialMovingTransformOption,
+      GetCompositeTransformFromParserOption<TComputeType, VImageDimension>( parser, initialMovingTransformOption,
                                                               isDerivedInitialMovingTransform );
 
     if( compositeTransform.IsNull() )
@@ -135,7 +136,7 @@ DoRegistration(typename ParserType::Pointer & parser)
 
         typename RegistrationHelperType::CompositeTransformType::TransformTypePointer curTransform =
           compositeTransform->GetNthTransform( n );
-        itk::ants::WriteTransform<T, VImageDimension>( curTransform, curFileName.str() );
+        itk::ants::WriteTransform<TComputeType, VImageDimension>( curTransform, curFileName.str() );
         }
       }
     }
@@ -146,7 +147,7 @@ DoRegistration(typename ParserType::Pointer & parser)
     {
     std::vector<bool> isDerivedInitialFixedTransform;
     typename CompositeTransformType::Pointer compositeTransform =
-      GetCompositeTransformFromParserOption<T, VImageDimension>( parser, initialFixedTransformOption,
+      GetCompositeTransformFromParserOption<TComputeType, VImageDimension>( parser, initialFixedTransformOption,
                                                               isDerivedInitialFixedTransform );
     if( compositeTransform.IsNull() )
       {
@@ -164,7 +165,7 @@ DoRegistration(typename ParserType::Pointer & parser)
 
         typename RegistrationHelperType::CompositeTransformType::TransformTypePointer curTransform =
           compositeTransform->GetNthTransform( n );
-        itk::ants::WriteTransform<T, VImageDimension>( curTransform, curFileName.str() );
+        itk::ants::WriteTransform<TComputeType, VImageDimension>( curTransform, curFileName.str() );
         }
       }
     }
@@ -270,7 +271,7 @@ DoRegistration(typename ParserType::Pointer & parser)
     }
 
   std::vector<std::vector<unsigned int> > iterationList;
-  std::vector<double>                     convergenceThresholdList;
+  std::vector<RealType>                     convergenceThresholdList;
   std::vector<unsigned int>               convergenceWindowSizeList;
   std::vector<std::vector<unsigned int> > shrinkFactorsList;
   std::vector<std::vector<float> >        smoothingSigmasList;
@@ -296,7 +297,7 @@ DoRegistration(typename ParserType::Pointer & parser)
     // Get the number of iterations and use that information to specify the number of levels
 
     std::vector<unsigned int> iterations;
-    double                    convergenceThreshold = 1e-6;
+    RealType                    convergenceThreshold = 1e-6;
     unsigned int              convergenceWindowSize = 10;
     if( convergenceOption.IsNotNull() && convergenceOption->GetNumberOfFunctions() )
       {
@@ -311,7 +312,7 @@ DoRegistration(typename ParserType::Pointer & parser)
         }
       if( convergenceOption->GetFunction( currentStage )->GetNumberOfParameters() > 1 )
         {
-        convergenceThreshold = parser->Convert<double>( convergenceOption->GetFunction( currentStage )->GetParameter(
+        convergenceThreshold = parser->Convert<RealType>( convergenceOption->GetFunction( currentStage )->GetParameter(
                                                           1 ) );
         }
       if( convergenceOption->GetFunction( currentStage )->GetNumberOfParameters() > 2 )
@@ -767,13 +768,13 @@ DoRegistration(typename ParserType::Pointer & parser)
 
     typename RegistrationHelperType::CompositeTransformType::TransformTypePointer compositeTransform =
       resultTransform.GetPointer();
-    itk::ants::WriteTransform<T, VImageDimension>( compositeTransform, compositeTransformFileName.c_str() );
+    itk::ants::WriteTransform<TComputeType, VImageDimension>( compositeTransform, compositeTransformFileName.c_str() );
 
     typename RegistrationHelperType::CompositeTransformType::TransformTypePointer inverseCompositeTransform =
       compositeTransform->GetInverseTransform();
     if( inverseCompositeTransform.IsNotNull() )
       {
-      itk::ants::WriteTransform<T, VImageDimension>( inverseCompositeTransform,
+      itk::ants::WriteTransform<TComputeType, VImageDimension>( inverseCompositeTransform,
                                                   inverseCompositeTransformFileName.c_str() );
       }
     }
@@ -856,7 +857,7 @@ DoRegistration(typename ParserType::Pointer & parser)
     // WriteTransform will spit all sorts of error messages if it
     // fails, and we want to keep going even if it does so ignore its
     // return value.
-    itk::ants::WriteTransform<T, VImageDimension>( curTransform, curFileName.str() );
+    itk::ants::WriteTransform<TComputeType, VImageDimension>( curTransform, curFileName.str() );
 
     typedef typename RegistrationHelperType::DisplacementFieldTransformType DisplacementFieldTransformType;
     typedef typename DisplacementFieldTransformType::DisplacementFieldType  DisplacementFieldType;
@@ -892,7 +893,7 @@ DoRegistration(typename ParserType::Pointer & parser)
       typedef typename RegistrationHelperType::TimeVaryingVelocityFieldTransformType
         VelocityFieldTransformType;
 
-      typedef itk::Image<itk::Vector<T, VImageDimension>, VImageDimension + 1> VelocityFieldType;
+      typedef itk::Image<itk::Vector<TComputeType, VImageDimension>, VImageDimension + 1> VelocityFieldType;
       typename VelocityFieldTransformType::Pointer velocityFieldTransform =
         dynamic_cast<VelocityFieldTransformType *>(curTransform.GetPointer() );
       if( !velocityFieldTransform.IsNull() )
@@ -919,7 +920,6 @@ DoRegistration(typename ParserType::Pointer & parser)
       }
     }
 
-  typedef T RealType;
   std::string whichInterpolator( "linear" );
   typename itk::ants::CommandLineParser::OptionType::Pointer interpolationOption = parser->GetOption( "interpolation" );
   if( interpolationOption && interpolationOption->GetNumberOfFunctions() )

--- a/Examples/itkantsRegistrationHelper.h
+++ b/Examples/itkantsRegistrationHelper.h
@@ -95,7 +95,7 @@ namespace ants
 typedef itk::ants::CommandLineParser ParserType;
 typedef ParserType::OptionType       OptionType;
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 class RegistrationHelper : public itk::Object
 {
 public:
@@ -106,13 +106,13 @@ public:
   typedef itk::SmartPointer<const Self> ConstPointer;
   typedef itk::WeakPointer<const Self>  ConstWeakPointer;
 
-  typedef T                                      RealType;
-  typedef T                                      PixelType;
+  typedef TComputeType                                      RealType;
+  typedef TComputeType                                      PixelType;
   typedef itk::Image<PixelType, VImageDimension> ImageType;
   typedef typename ImageType::Pointer            ImagePointer;
   typedef itk::ImageBase<VImageDimension>        ImageBaseType;
 
-  typedef itk::Transform<T, VImageDimension, VImageDimension>                        TransformType;
+  typedef itk::Transform<TComputeType, VImageDimension, VImageDimension>             TransformType;
   typedef itk::AffineTransform<RealType, VImageDimension>                            AffineTransformType;
   typedef itk::ImageRegistrationMethodv4<ImageType, ImageType, AffineTransformType>  AffineRegistrationType;
   typedef typename AffineRegistrationType::ShrinkFactorsPerDimensionContainerType    ShrinkFactorsPerDimensionContainerType;
@@ -152,9 +152,9 @@ public:
   {
 public:
     Metric( MetricEnumeration metricType, typename ImageType::Pointer & fixedImage,
-            typename ImageType::Pointer & movingImage, unsigned int stageID, double weighting,
+            typename ImageType::Pointer & movingImage, unsigned int stageID, RealType weighting,
             SamplingStrategy samplingStrategy, int numberOfBins, unsigned int radius,
-            double samplingPercentage ) :
+            RealType samplingPercentage ) :
       m_MetricType( metricType ),
       m_FixedImage( fixedImage ),
       m_MovingImage( movingImage ),
@@ -207,11 +207,11 @@ public:
     typename ImageType::Pointer m_FixedImage;
     typename ImageType::Pointer m_MovingImage;
     unsigned int     m_StageID;
-    double           m_Weighting;
+    RealType           m_Weighting;
     SamplingStrategy m_SamplingStrategy;
     int              m_NumberOfBins;
     unsigned int     m_Radius;
-    double           m_SamplingPercentage;
+    RealType           m_SamplingPercentage;
   };
 
   typedef std::deque<Metric> MetricListType;
@@ -318,25 +318,25 @@ public:
 
     XfrmMethod m_XfrmMethod;
     // all transforms
-    double m_GradientStep;
+    RealType m_GradientStep;
     // BSPline
     std::vector<unsigned int> m_MeshSizeAtBaseLevel;
     // GaussianDisplacementField
-    double m_UpdateFieldVarianceInVarianceSpace;
-    double m_TotalFieldVarianceInVarianceSpace;
+    RealType m_UpdateFieldVarianceInVarianceSpace;
+    RealType m_TotalFieldVarianceInVarianceSpace;
     // BSplineDisplacementField
     std::vector<unsigned int> m_TotalFieldMeshSizeAtBaseLevel;
     std::vector<unsigned int> m_UpdateFieldMeshSizeAtBaseLevel;
     unsigned int              m_SplineOrder; // also anything B-spline
     // TimeVaryingVelocityField
-    double       m_UpdateFieldTimeSigma;
-    double       m_TotalFieldTimeSigma;
+    RealType       m_UpdateFieldTimeSigma;
+    RealType       m_TotalFieldTimeSigma;
     unsigned int m_NumberOfTimeIndices;
     // TimeVaryingBSplineVelocityField
     std::vector<unsigned int> m_VelocityFieldMeshSize;
     unsigned int              m_NumberOfTimePointSamples;
     // Exponential
-    double m_VelocityFieldVarianceInVarianceSpace;
+    RealType m_VelocityFieldVarianceInVarianceSpace;
     // BSplineExponential
     std::vector<unsigned int> m_VelocityFieldMeshSizeAtBaseLevel;
   };
@@ -361,11 +361,11 @@ public:
                   typename ImageType::Pointer & fixedImage,
                   typename ImageType::Pointer & movingImage,
                   unsigned int stageID,
-                  double weighting,
+                  RealType weighting,
                   SamplingStrategy samplingStrategy,
                   int numberOfBins,
                   unsigned int radius,
-                  double samplingPercentage );
+                  RealType samplingPercentage );
 
   /**
    * Get set of metrics per stage.  If we have more than one, we have
@@ -396,43 +396,43 @@ public:
   /**
    * add a rigid transform
    */
-  void AddRigidTransform( double GradientStep );
+  void AddRigidTransform( RealType GradientStep );
 
   /**
    * add an affine transform
    */
-  void AddAffineTransform( double GradientStep );
+  void AddAffineTransform( RealType GradientStep );
 
   /**
    * add a composite affine transform
    */
-  void AddCompositeAffineTransform( double GradientStep );
+  void AddCompositeAffineTransform( RealType GradientStep );
 
   /**
    * add a similarity transform
    */
-  void AddSimilarityTransform( double GradientStep );
+  void AddSimilarityTransform( RealType GradientStep );
 
   /**
    * add a translation transform
    */
-  void AddTranslationTransform( double GradientStep );
+  void AddTranslationTransform( RealType GradientStep );
 
   /**
    * add a spline transform
    */
-  void AddBSplineTransform( double GradientStep, std::vector<unsigned int> & MeshSizeAtBaseLevel );
+  void AddBSplineTransform( RealType GradientStep, std::vector<unsigned int> & MeshSizeAtBaseLevel );
 
   /**
    * add gaussian displacement transform
    */
-  void AddGaussianDisplacementFieldTransform( double GradientStep, double UpdateFieldVarianceInVarianceSpace,
-                                              double TotalFieldVarianceInVarianceSpace );
+  void AddGaussianDisplacementFieldTransform( RealType GradientStep, RealType UpdateFieldVarianceInVarianceSpace,
+                                              RealType TotalFieldVarianceInVarianceSpace );
 
   /**
    * add bspline displacement transform
    */
-  void AddBSplineDisplacementFieldTransform( double GradientStep,
+  void AddBSplineDisplacementFieldTransform( RealType GradientStep,
                                              std::vector<unsigned int> & UpdateFieldMeshSizeAtBaseLevel,
                                              std::vector<unsigned int> & TotalFieldMeshSizeAtBaseLevel,
                                              unsigned int SplineOrder );
@@ -440,39 +440,39 @@ public:
   /**
    * add a time varying velocity field transform
    */
-  void AddTimeVaryingVelocityFieldTransform( double GradientStep, unsigned int NumberOfTimeIndices,
-                                             double UpdateFieldVarianceInVarianceSpace, double UpdateFieldTimeSigma,
-                                             double TotalFieldVarianceInVarianceSpace, double TotalFieldTimeSigma );
+  void AddTimeVaryingVelocityFieldTransform( RealType GradientStep, unsigned int NumberOfTimeIndices,
+                                             RealType UpdateFieldVarianceInVarianceSpace, RealType UpdateFieldTimeSigma,
+                                             RealType TotalFieldVarianceInVarianceSpace, RealType TotalFieldTimeSigma );
 
   /**
    * add a time varying b spline velocity field transform
    */
-  void AddTimeVaryingBSplineVelocityFieldTransform( double GradientStep,
+  void AddTimeVaryingBSplineVelocityFieldTransform( RealType GradientStep,
                                                     std::vector<unsigned int> VelocityFieldMeshSize,
                                                     unsigned int NumberOfTimePointSamples, unsigned int SplineOrder );
 
   /**
    * add a SyN transform
    */
-  void AddSyNTransform( double GradientStep, double UpdateFieldVarianceInVarianceSpace,
-                        double TotalFieldVarianceInVarianceSpace );
+  void AddSyNTransform( RealType GradientStep, RealType UpdateFieldVarianceInVarianceSpace,
+                        RealType TotalFieldVarianceInVarianceSpace );
 
   /**
    * add a B-spline SyN transform
    */
-  void AddBSplineSyNTransform( double GradientStep, std::vector<unsigned int> & UpdateFieldMeshSizeAtBaseLevel,
+  void AddBSplineSyNTransform( RealType GradientStep, std::vector<unsigned int> & UpdateFieldMeshSizeAtBaseLevel,
                                std::vector<unsigned int> & TotalFieldMeshSizeAtBaseLevel, unsigned int SplineOrder );
 
   /**
    * add an exponential transform
    */
-  void AddExponentialTransform( double GradientStep, double UpdateFieldVarianceInVarianceSpace,
-                                double VelocityFieldVarianceInVarianceSpace, unsigned int NumberOfIntegrationSteps );
+  void AddExponentialTransform( RealType GradientStep, RealType UpdateFieldVarianceInVarianceSpace,
+                                RealType VelocityFieldVarianceInVarianceSpace, unsigned int NumberOfIntegrationSteps );
 
   /**
    * add a B-spline exponential transform
    */
-  void AddBSplineExponentialTransform( double GradientStep, std::vector<unsigned int> & UpdateFieldMeshSizeAtBaseLevel,
+  void AddBSplineExponentialTransform( RealType GradientStep, std::vector<unsigned int> & UpdateFieldMeshSizeAtBaseLevel,
                                        std::vector<unsigned int> & VelocityFieldMeshSizeAtBaseLevel,
                                        unsigned int NumberOfIntegrationSteps, unsigned int SplineOrder );
 
@@ -484,7 +484,7 @@ public:
   /**
    * Add the collected convergence thresholds
    */
-  void SetConvergenceThresholds( const std::vector<double> & thresholds );
+  void SetConvergenceThresholds( const std::vector<RealType> & thresholds );
 
   /**
    * Add the collected convergence window sizes
@@ -634,7 +634,7 @@ private:
   MetricListType                          m_Metrics;
   TransformMethodListType                 m_TransformMethods;
   std::vector<std::vector<unsigned int> > m_Iterations;
-  std::vector<double>                     m_ConvergenceThresholds;
+  std::vector<RealType>                   m_ConvergenceThresholds;
   std::vector<unsigned int>               m_ConvergenceWindowSizes;
   std::vector<std::vector<float> >        m_SmoothingSigmas;
   std::vector<bool>                       m_SmoothingSigmasAreInPhysicalUnits;
@@ -642,8 +642,8 @@ private:
   bool                                    m_UseHistogramMatching;
   bool                                    m_WinsorizeImageIntensities;
   bool                                    m_DoEstimateLearningRateAtEachIteration;
-  double                                  m_LowerQuantile;
-  double                                  m_UpperQuantile;
+  RealType                                m_LowerQuantile;
+  RealType                                m_UpperQuantile;
   std::ostream *                          m_LogStream;
 
   void ApplyCompositeLinearTransformToImageHeader( const CompositeTransformType *, ImageBaseType * const,
@@ -666,13 +666,13 @@ private:
 // ##########################################################################
 
 // Provide common way of reading transforms.
-template <class T, unsigned VImageDimension>
-typename ants::RegistrationHelper<T, VImageDimension>::CompositeTransformType::Pointer
+template <class TComputeType, unsigned VImageDimension>
+typename ants::RegistrationHelper<TComputeType, VImageDimension>::CompositeTransformType::Pointer
 GetCompositeTransformFromParserOption( typename ParserType::Pointer & parser,
                                        typename ParserType::OptionType::Pointer initialTransformOption,
                                        std::vector<bool> & derivedTransforms, bool useStaticCastForR = false )
 {
-  typedef typename ants::RegistrationHelper<T, VImageDimension>      RegistrationHelperType;
+  typedef typename ants::RegistrationHelper<TComputeType, VImageDimension>      RegistrationHelperType;
   typedef typename RegistrationHelperType::CompositeTransformType CompositeTransformType;
   typename CompositeTransformType::Pointer compositeTransform = CompositeTransformType::New();
 
@@ -713,7 +713,7 @@ GetCompositeTransformFromParserOption( typename ParserType::Pointer & parser,
       unsigned short initializationFeature = parser->Convert<unsigned short>(
         initialTransformOption->GetFunction( n )->GetParameter( 2 ) );
 
-      typedef itk::AffineTransform<T, VImageDimension> TransformType;
+      typedef itk::AffineTransform<TComputeType, VImageDimension> TransformType;
 
       typename TransformType::Pointer transform = TransformType::New();
 
@@ -761,7 +761,7 @@ GetCompositeTransformFromParserOption( typename ParserType::Pointer & parser,
       initialTransformName += std::string( "fixed image: " ) + initialTransformOption->GetFunction( n )->GetParameter( 0 )
         + std::string( " and moving image: " ) + initialTransformOption->GetFunction( n )->GetParameter( 1 );
 
-      typedef itk::TranslationTransform<T, VImageDimension> TranslationTransformType;
+      typedef itk::TranslationTransform<TComputeType, VImageDimension> TranslationTransformType;
       typename TranslationTransformType::Pointer translationTransform = TranslationTransformType::New();
       translationTransform->SetOffset( transform->GetTranslation() );
 
@@ -797,20 +797,20 @@ GetCompositeTransformFromParserOption( typename ParserType::Pointer & parser,
       MatOffRegistered = true;
       // Register the matrix offset transform base class to the
       // transform factory for compatibility with the current ANTs.
-      typedef itk::MatrixOffsetTransformBase<T, VImageDimension, VImageDimension> MatrixOffsetTransformType;
+      typedef itk::MatrixOffsetTransformBase<TComputeType, VImageDimension, VImageDimension> MatrixOffsetTransformType;
       itk::TransformFactory<MatrixOffsetTransformType>::RegisterTransform();
       }
 
     if( !calculatedTransformFromImages )
       {
-      typedef ants::RegistrationHelper<T, VImageDimension>                       RegistrationHelperType;
+      typedef ants::RegistrationHelper<TComputeType, VImageDimension>                       RegistrationHelperType;
       typedef typename RegistrationHelperType::DisplacementFieldTransformType DisplacementFieldTransformType;
 
       typedef typename RegistrationHelperType::TransformType TransformType;
       typename TransformType::Pointer initialTransform;
       if( std::strcmp( initialTransformName.c_str(), "identity" ) == 0 || std::strcmp( initialTransformName.c_str(), "Identity" ) == 0 )
         {
-        typedef itk::MatrixOffsetTransformBase<T, VImageDimension, VImageDimension> MatrixOffsetTransformType;
+        typedef itk::MatrixOffsetTransformBase<TComputeType, VImageDimension, VImageDimension> MatrixOffsetTransformType;
         typename MatrixOffsetTransformType::Pointer identityTransform = MatrixOffsetTransformType::New();
         identityTransform->SetIdentity();
 
@@ -818,7 +818,7 @@ GetCompositeTransformFromParserOption( typename ParserType::Pointer & parser,
         }
       else
         {
-        initialTransform = itk::ants::ReadTransform<T, VImageDimension>( initialTransformName, useStaticCastForR );
+        initialTransform = itk::ants::ReadTransform<TComputeType, VImageDimension>( initialTransformName, useStaticCastForR );
         }
       if( initialTransform.IsNull() )
         {
@@ -838,8 +838,8 @@ GetCompositeTransformFromParserOption( typename ParserType::Pointer & parser,
       static const std::string CompositeTransformID("CompositeTransform");
       if( initialTransform->GetNameOfClass() == CompositeTransformID )
         {
-        const typename itk::CompositeTransform<T, VImageDimension>::ConstPointer tempComp =
-          dynamic_cast<const itk::CompositeTransform<T, VImageDimension> *>( initialTransform.GetPointer() );
+        const typename itk::CompositeTransform<TComputeType, VImageDimension>::ConstPointer tempComp =
+          dynamic_cast<const itk::CompositeTransform<TComputeType, VImageDimension> *>( initialTransform.GetPointer() );
         for( unsigned int i = 0; i < tempComp->GetNumberOfTransforms(); ++i )
           {
           std::stringstream tempstream;

--- a/Examples/itkantsRegistrationHelper.hxx
+++ b/Examples/itkantsRegistrationHelper.hxx
@@ -16,13 +16,13 @@ namespace ants
 /**
  * Transform traits to generalize the rigid transform
  */
-template <class T, unsigned int ImageDimension>
+template <class TComputeType, unsigned int ImageDimension>
 class RigidTransformTraits
 {
 // Don't worry about the fact that the default option is the
 // affine Transform, that one will not actually be instantiated.
 public:
-  typedef itk::AffineTransform<T, ImageDimension> TransformType;
+  typedef itk::AffineTransform<TComputeType, ImageDimension> TransformType;
 };
 
 template <>
@@ -57,13 +57,13 @@ public:
 typedef itk::Euler3DTransform<float> TransformType;
 };
 
-template <class T, unsigned int ImageDimension>
+template <class TComputeType, unsigned int ImageDimension>
 class SimilarityTransformTraits
 {
 // Don't worry about the fact that the default option is the
 // affine Transform, that one will not actually be instantiated.
 public:
-  typedef itk::AffineTransform<T, ImageDimension> TransformType;
+  typedef itk::AffineTransform<TComputeType, ImageDimension> TransformType;
 };
 
 template <>
@@ -94,13 +94,13 @@ public:
 typedef itk::Similarity3DTransform<float> TransformType;
 };
 
-template <class T, unsigned int ImageDimension>
+template <class TComputeType, unsigned int ImageDimension>
 class CompositeAffineTransformTraits
 {
 // Don't worry about the fact that the default option is the
 // affine Transform, that one will not actually be instantiated.
 public:
-  typedef itk::AffineTransform<T, ImageDimension> TransformType;
+  typedef itk::AffineTransform<TComputeType, ImageDimension> TransformType;
 };
 
 template <>
@@ -131,8 +131,8 @@ public:
 typedef itk::ANTSAffine3DTransform<float> TransformType;
 };
 
-template <class T, unsigned VImageDimension>
-RegistrationHelper<T, VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
+RegistrationHelper<TComputeType, VImageDimension>
 ::RegistrationHelper() :
   m_CompositeTransform( NULL ),
   m_FixedInitialTransform( NULL ),
@@ -159,8 +159,8 @@ RegistrationHelper<T, VImageDimension>
   this->m_Interpolator = linearInterpolator;
 }
 
-template <class T, unsigned VImageDimension>
-RegistrationHelper<T, VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
+RegistrationHelper<TComputeType, VImageDimension>
 ::~RegistrationHelper()
 {
 }
@@ -228,9 +228,9 @@ typename ImageType::Pointer PreprocessImage( typename ImageType::ConstPointer  i
   return outputImage;
 }
 
-template <class T, unsigned VImageDimension>
-typename RegistrationHelper<T, VImageDimension>::MetricEnumeration
-RegistrationHelper<T, VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
+typename RegistrationHelper<TComputeType, VImageDimension>::MetricEnumeration
+RegistrationHelper<TComputeType, VImageDimension>
 ::StringToMetricType(const std::string & str) const
 {
   if( str == "cc" )
@@ -260,9 +260,9 @@ RegistrationHelper<T, VImageDimension>
   return IllegalMetric;
 }
 
-template <class T, unsigned VImageDimension>
-typename RegistrationHelper<T, VImageDimension>::XfrmMethod
-RegistrationHelper<T, VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
+typename RegistrationHelper<TComputeType, VImageDimension>::XfrmMethod
+RegistrationHelper<TComputeType, VImageDimension>
 ::StringToXfrmMethod(const std::string & str) const
 {
   if( str == "rigid" )
@@ -331,18 +331,18 @@ RegistrationHelper<T, VImageDimension>
   return UnknownXfrm;
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
+RegistrationHelper<TComputeType, VImageDimension>
 ::AddMetric( MetricEnumeration metricType,
              typename ImageType::Pointer & fixedImage,
              typename ImageType::Pointer & movingImage,
              unsigned int stageID,
-             double weighting,
+             RealType weighting,
              SamplingStrategy samplingStrategy,
              int numberOfBins,
              unsigned int  radius,
-             double samplingPercentage )
+             RealType samplingPercentage )
 {
   Metric init( metricType, fixedImage, movingImage, stageID,
                weighting, samplingStrategy, numberOfBins,
@@ -352,9 +352,9 @@ RegistrationHelper<T, VImageDimension>
   this->m_Metrics.push_back( init );
 }
 
-template <class T, unsigned VImageDimension>
-typename RegistrationHelper<T, VImageDimension>::MetricListType
-RegistrationHelper<T, VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
+typename RegistrationHelper<TComputeType, VImageDimension>::MetricListType
+RegistrationHelper<TComputeType, VImageDimension>
 ::GetMetricListPerStage( unsigned int stageID )
 {
   MetricListType stageMetricList;
@@ -371,10 +371,10 @@ RegistrationHelper<T, VImageDimension>
   return stageMetricList;
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
-::AddRigidTransform(double GradientStep)
+RegistrationHelper<TComputeType, VImageDimension>
+::AddRigidTransform(RealType GradientStep)
 {
   TransformMethod init;
 
@@ -383,10 +383,10 @@ RegistrationHelper<T, VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
-::AddAffineTransform(double GradientStep)
+RegistrationHelper<TComputeType, VImageDimension>
+::AddAffineTransform(RealType GradientStep)
 {
   TransformMethod init;
 
@@ -395,10 +395,10 @@ RegistrationHelper<T, VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
-::AddCompositeAffineTransform(double GradientStep)
+RegistrationHelper<TComputeType, VImageDimension>
+::AddCompositeAffineTransform(RealType GradientStep)
 {
   TransformMethod init;
 
@@ -407,10 +407,10 @@ RegistrationHelper<T, VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
-::AddSimilarityTransform(double GradientStep)
+RegistrationHelper<TComputeType, VImageDimension>
+::AddSimilarityTransform(RealType GradientStep)
 {
   TransformMethod init;
 
@@ -419,10 +419,10 @@ RegistrationHelper<T, VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
-::AddTranslationTransform(double GradientStep)
+RegistrationHelper<TComputeType, VImageDimension>
+::AddTranslationTransform(RealType GradientStep)
 {
   TransformMethod init;
 
@@ -431,10 +431,10 @@ RegistrationHelper<T, VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
-::AddBSplineTransform(double GradientStep, std::vector<unsigned int> & MeshSizeAtBaseLevel)
+RegistrationHelper<TComputeType, VImageDimension>
+::AddBSplineTransform(RealType GradientStep, std::vector<unsigned int> & MeshSizeAtBaseLevel)
 {
   TransformMethod init;
 
@@ -444,11 +444,11 @@ RegistrationHelper<T, VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
-::AddGaussianDisplacementFieldTransform(double GradientStep, double UpdateFieldVarianceInVarianceSpace,
-                                        double TotalFieldVarianceInVarianceSpace)
+RegistrationHelper<TComputeType, VImageDimension>
+::AddGaussianDisplacementFieldTransform(RealType GradientStep, RealType UpdateFieldVarianceInVarianceSpace,
+                                        RealType TotalFieldVarianceInVarianceSpace)
 {
   TransformMethod init;
 
@@ -459,10 +459,10 @@ RegistrationHelper<T, VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
-::AddBSplineDisplacementFieldTransform(double GradientStep,
+RegistrationHelper<TComputeType, VImageDimension>
+::AddBSplineDisplacementFieldTransform(RealType GradientStep,
                                        std::vector<unsigned int> & UpdateFieldMeshSizeAtBaseLevel,
                                        std::vector<unsigned int> & TotalFieldMeshSizeAtBaseLevel,
                                        unsigned int SplineOrder)
@@ -477,15 +477,15 @@ RegistrationHelper<T, VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
-::AddTimeVaryingVelocityFieldTransform( double GradientStep,
+RegistrationHelper<TComputeType, VImageDimension>
+::AddTimeVaryingVelocityFieldTransform( RealType GradientStep,
                                         unsigned int NumberOfTimeIndices,
-                                        double UpdateFieldVarianceInVarianceSpace,
-                                        double UpdateFieldTimeSigma,
-                                        double TotalFieldVarianceInVarianceSpace,
-                                        double TotalFieldTimeSigma )
+                                        RealType UpdateFieldVarianceInVarianceSpace,
+                                        RealType UpdateFieldTimeSigma,
+                                        RealType TotalFieldVarianceInVarianceSpace,
+                                        RealType TotalFieldTimeSigma )
 {
   TransformMethod init;
 
@@ -499,10 +499,10 @@ RegistrationHelper<T, VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
-::AddTimeVaryingBSplineVelocityFieldTransform( double GradientStep, std::vector<unsigned int> VelocityFieldMeshSize,
+RegistrationHelper<TComputeType, VImageDimension>
+::AddTimeVaryingBSplineVelocityFieldTransform( RealType GradientStep, std::vector<unsigned int> VelocityFieldMeshSize,
                                                unsigned int NumberOfTimePointSamples, unsigned int SplineOrder )
 {
   TransformMethod init;
@@ -515,11 +515,11 @@ RegistrationHelper<T, VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
-::AddSyNTransform( double GradientStep, double UpdateFieldVarianceInVarianceSpace,
-                   double TotalFieldVarianceInVarianceSpace )
+RegistrationHelper<TComputeType, VImageDimension>
+::AddSyNTransform( RealType GradientStep, RealType UpdateFieldVarianceInVarianceSpace,
+                   RealType TotalFieldVarianceInVarianceSpace )
 {
   TransformMethod init;
 
@@ -530,10 +530,10 @@ RegistrationHelper<T, VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
-::AddBSplineSyNTransform( double GradientStep, std::vector<unsigned int> &  UpdateFieldMeshSizeAtBaseLevel,
+RegistrationHelper<TComputeType, VImageDimension>
+::AddBSplineSyNTransform( RealType GradientStep, std::vector<unsigned int> &  UpdateFieldMeshSizeAtBaseLevel,
                           std::vector<unsigned int> &  TotalFieldMeshSizeAtBaseLevel,
                           unsigned int SplineOrder )
 {
@@ -547,11 +547,11 @@ RegistrationHelper<T, VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
-::AddExponentialTransform( double GradientStep, double UpdateFieldVarianceInVarianceSpace,
-                           double VelocityFieldVarianceInVarianceSpace, unsigned int NumberOfIntegrationSteps )
+RegistrationHelper<TComputeType, VImageDimension>
+::AddExponentialTransform( RealType GradientStep, RealType UpdateFieldVarianceInVarianceSpace,
+                           RealType VelocityFieldVarianceInVarianceSpace, unsigned int NumberOfIntegrationSteps )
 {
   TransformMethod init;
 
@@ -564,10 +564,10 @@ RegistrationHelper<T, VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
-::AddBSplineExponentialTransform( double GradientStep, std::vector<unsigned int> &  UpdateFieldMeshSizeAtBaseLevel,
+RegistrationHelper<TComputeType, VImageDimension>
+::AddBSplineExponentialTransform( RealType GradientStep, std::vector<unsigned int> &  UpdateFieldMeshSizeAtBaseLevel,
                                   std::vector<unsigned int> & VelocityFieldMeshSizeAtBaseLevel,
                                   unsigned int NumberOfIntegrationSteps,
                                   unsigned int SplineOrder )
@@ -584,61 +584,61 @@ RegistrationHelper<T, VImageDimension>
   this->m_TransformMethods.push_back( init );
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
+RegistrationHelper<TComputeType, VImageDimension>
 ::SetIterations( const std::vector<std::vector<unsigned int> > & Iterations )
 {
   this->m_Iterations = Iterations;
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
-::SetConvergenceThresholds( const std::vector<double> & thresholds )
+RegistrationHelper<TComputeType, VImageDimension>
+::SetConvergenceThresholds( const std::vector<RealType> & thresholds )
 {
   this->m_ConvergenceThresholds = thresholds;
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
+RegistrationHelper<TComputeType, VImageDimension>
 ::SetConvergenceWindowSizes( const std::vector<unsigned int> & windowSizes )
 {
   this->m_ConvergenceWindowSizes = windowSizes;
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
+RegistrationHelper<TComputeType, VImageDimension>
 ::SetSmoothingSigmas( const std::vector<std::vector<float> > & SmoothingSigmas )
 {
   this->m_SmoothingSigmas = SmoothingSigmas;
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
+RegistrationHelper<TComputeType, VImageDimension>
 ::SetSmoothingSigmasAreInPhysicalUnits( const std::vector<bool> & SmoothingSigmasAreInPhysicalUnits )
 {
   this->m_SmoothingSigmasAreInPhysicalUnits = SmoothingSigmasAreInPhysicalUnits;
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
+RegistrationHelper<TComputeType, VImageDimension>
 ::SetShrinkFactors( const std::vector<std::vector<unsigned int> > & ShrinkFactors )
 {
   this->m_ShrinkFactors = ShrinkFactors;
 }
 
-template <class T, unsigned VImageDimension>
-typename RegistrationHelper<T, VImageDimension>::ShrinkFactorsPerDimensionContainerType
-RegistrationHelper<T, VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
+typename RegistrationHelper<TComputeType, VImageDimension>::ShrinkFactorsPerDimensionContainerType
+RegistrationHelper<TComputeType, VImageDimension>
 ::CalculateShrinkFactorsPerDimension( unsigned int factor, ImagePointer image )
 {
   typedef typename ImageType::SpacingType SpacingType;
-  typedef double                          SpacingValueType;
+  typedef RealType                          SpacingValueType;
 
   SpacingType spacing = image->GetSpacing();
 
@@ -665,7 +665,7 @@ RegistrationHelper<T, VImageDimension>
     if( shrinkFactorsPerDimension[n] == 0 )
       {
       SpacingValueType newMinSpacing = spacing[n] * static_cast<SpacingValueType>( factor );
-      double minDifferenceFromMinSpacing = vnl_math_abs( newMinSpacing - newSpacing[minIndex] );
+      RealType minDifferenceFromMinSpacing = vnl_math_abs( newMinSpacing - newSpacing[minIndex] );
       unsigned int minFactor = factor;
       for( unsigned int f = factor - 1; f > 0; f-- )
         {
@@ -684,9 +684,9 @@ RegistrationHelper<T, VImageDimension>
   return shrinkFactorsPerDimension;
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
+RegistrationHelper<TComputeType, VImageDimension>
 ::SetWinsorizeImageIntensities( bool Winsorize, float LowerQuantile, float UpperQuantile )
 {
   this->m_WinsorizeImageIntensities = Winsorize;
@@ -694,9 +694,9 @@ RegistrationHelper<T, VImageDimension>
   this->m_UpperQuantile = UpperQuantile;
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 int
-RegistrationHelper<T, VImageDimension>
+RegistrationHelper<TComputeType, VImageDimension>
 ::ValidateParameters()
 {
   if( this->m_NumberOfStages == 0 )
@@ -739,9 +739,9 @@ RegistrationHelper<T, VImageDimension>
   return EXIT_SUCCESS;
 }
 
-template <class T, unsigned VImageDimension>
-typename RegistrationHelper<T, VImageDimension>::ImageType::Pointer
-RegistrationHelper<T, VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
+typename RegistrationHelper<TComputeType, VImageDimension>::ImageType::Pointer
+RegistrationHelper<TComputeType, VImageDimension>
 ::GetWarpedImage() const
 {
   typename ImageType::Pointer fixedImage = this->m_Metrics[0].m_FixedImage;
@@ -761,9 +761,9 @@ RegistrationHelper<T, VImageDimension>
   return WarpedImage.GetPointer();
 }
 
-template <class T, unsigned VImageDimension>
-typename RegistrationHelper<T, VImageDimension>::ImageType::Pointer
-RegistrationHelper<T, VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
+typename RegistrationHelper<TComputeType, VImageDimension>::ImageType::Pointer
+RegistrationHelper<TComputeType, VImageDimension>
 ::GetInverseWarpedImage() const
 {
   typename ImageType::Pointer fixedImage = this->m_Metrics[0].m_FixedImage;
@@ -787,9 +787,9 @@ RegistrationHelper<T, VImageDimension>
   return InverseWarpedImage.GetPointer();
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
+RegistrationHelper<TComputeType, VImageDimension>
 ::SetFixedImageMask(typename MaskImageType::Pointer & fixedImageMask)
 {
   typename ImageMaskSpatialObjectType::Pointer so =
@@ -798,9 +798,9 @@ RegistrationHelper<T, VImageDimension>
   this->SetFixedImageMask(so);
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
+RegistrationHelper<TComputeType, VImageDimension>
 ::SetMovingImageMask(typename MaskImageType::Pointer & movingImageMask)
 {
   typename ImageMaskSpatialObjectType::Pointer so =
@@ -809,9 +809,9 @@ RegistrationHelper<T, VImageDimension>
   this->SetMovingImageMask(so);
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 int
-RegistrationHelper<T, VImageDimension>
+RegistrationHelper<TComputeType, VImageDimension>
 ::DoRegistration()
 {
   /** Can really impact performance */
@@ -872,7 +872,7 @@ RegistrationHelper<T, VImageDimension>
       }
     this->Logger() << std::endl;
 
-    const double convergenceThreshold = this->m_ConvergenceThresholds[currentStageNumber];
+    const RealType convergenceThreshold = this->m_ConvergenceThresholds[currentStageNumber];
     this->Logger() << "  convergence threshold = " << convergenceThreshold << std::endl;
     const unsigned int convergenceWindowSize = this->m_ConvergenceWindowSizes[currentStageNumber];
     this->Logger() << "  convergence window size = " << convergenceWindowSize << std::endl;
@@ -1012,7 +1012,7 @@ RegistrationHelper<T, VImageDimension>
           this->Logger() << "  using the CC metric (radius = "
                          << radiusOption << ", weight = "
                          << stageMetricList[currentMetricNumber].m_Weighting << ")" << std::endl;
-          typedef itk::ANTSNeighborhoodCorrelationImageToImageMetricv4<ImageType, ImageType, ImageType, T> CorrelationMetricType;
+          typedef itk::ANTSNeighborhoodCorrelationImageToImageMetricv4<ImageType, ImageType, ImageType, TComputeType> CorrelationMetricType;
           typename CorrelationMetricType::Pointer correlationMetric = CorrelationMetricType::New();
             {
             typename CorrelationMetricType::RadiusType radius;
@@ -1031,7 +1031,7 @@ RegistrationHelper<T, VImageDimension>
           this->Logger() << "  using the Mattes MI metric (number of bins = "
                          << binOption << ", weight = "
                          << stageMetricList[currentMetricNumber].m_Weighting << ")" << std::endl;
-          typedef itk::MattesMutualInformationImageToImageMetricv4<ImageType, ImageType, ImageType, T> MutualInformationMetricType;
+          typedef itk::MattesMutualInformationImageToImageMetricv4<ImageType, ImageType, ImageType, TComputeType> MutualInformationMetricType;
           typename MutualInformationMetricType::Pointer mutualInformationMetric = MutualInformationMetricType::New();
           mutualInformationMetric = mutualInformationMetric;
           mutualInformationMetric->SetNumberOfHistogramBins( binOption );
@@ -1048,7 +1048,7 @@ RegistrationHelper<T, VImageDimension>
                          << binOption << ", weight = "
                          << stageMetricList[currentMetricNumber].m_Weighting << ")" << std::endl;
           typedef itk::JointHistogramMutualInformationImageToImageMetricv4<ImageType, ImageType, ImageType,
-                                                                           T> MutualInformationMetricType;
+                                                                           TComputeType> MutualInformationMetricType;
           typename MutualInformationMetricType::Pointer mutualInformationMetric = MutualInformationMetricType::New();
           mutualInformationMetric = mutualInformationMetric;
           mutualInformationMetric->SetNumberOfHistogramBins( binOption );
@@ -1064,7 +1064,7 @@ RegistrationHelper<T, VImageDimension>
           this->Logger() << "  using the MeanSquares metric (weight = "
                          << stageMetricList[currentMetricNumber].m_Weighting << ")" << std::endl;
 
-          typedef itk::MeanSquaresImageToImageMetricv4<ImageType, ImageType, ImageType, T> MeanSquaresMetricType;
+          typedef itk::MeanSquaresImageToImageMetricv4<ImageType, ImageType, ImageType, TComputeType> MeanSquaresMetricType;
           typename MeanSquaresMetricType::Pointer meanSquaresMetric = MeanSquaresMetricType::New();
           meanSquaresMetric = meanSquaresMetric;
           metric = meanSquaresMetric;
@@ -1075,7 +1075,7 @@ RegistrationHelper<T, VImageDimension>
           this->Logger() << "  using the Demons metric (weight = "
                          << stageMetricList[currentMetricNumber].m_Weighting << ")" << std::endl;
 
-          typedef itk::DemonsImageToImageMetricv4<ImageType, ImageType, ImageType, T> DemonsMetricType;
+          typedef itk::DemonsImageToImageMetricv4<ImageType, ImageType, ImageType, TComputeType> DemonsMetricType;
           typename DemonsMetricType::Pointer demonsMetric = DemonsMetricType::New();
           demonsMetric = demonsMetric;
           metric = demonsMetric;
@@ -1085,7 +1085,7 @@ RegistrationHelper<T, VImageDimension>
           {
           this->Logger() << "  using the global correlation metric (weight = "
                          << stageMetricList[currentMetricNumber].m_Weighting << ")" << std::endl;
-          typedef itk::CorrelationImageToImageMetricv4<ImageType, ImageType, ImageType, T> corrMetricType;
+          typedef itk::CorrelationImageToImageMetricv4<ImageType, ImageType, ImageType, TComputeType> corrMetricType;
           typename corrMetricType::Pointer corrMetric = corrMetricType::New();
           metric = corrMetric;
           }
@@ -1150,7 +1150,7 @@ RegistrationHelper<T, VImageDimension>
     // Set up the optimizers.  To change the iteration number for each level we rely
     // on the command observer.
 
-    const double learningRate = this->m_TransformMethods[currentStageNumber].m_GradientStep;
+    const RealType learningRate = this->m_TransformMethods[currentStageNumber].m_GradientStep;
 
     // There's a scale issue here.  Currently we are using the first metric to estimate the
     // scales but we might need to change this.
@@ -1160,7 +1160,7 @@ RegistrationHelper<T, VImageDimension>
     scalesEstimator->SetMetric( singleMetric );
     scalesEstimator->SetTransformForward( true );
 
-    typedef itk::ConjugateGradientLineSearchOptimizerv4Template<T> ConjugateGradientDescentOptimizerType;
+    typedef itk::ConjugateGradientLineSearchOptimizerv4Template<TComputeType> ConjugateGradientDescentOptimizerType;
     typename ConjugateGradientDescentOptimizerType::Pointer optimizer = ConjugateGradientDescentOptimizerType::New();
     optimizer->SetLowerLimit( 0 );
     optimizer->SetUpperLimit( 2 );
@@ -1175,7 +1175,7 @@ RegistrationHelper<T, VImageDimension>
     optimizer->SetDoEstimateLearningRateAtEachIteration( this->m_DoEstimateLearningRateAtEachIteration );
     optimizer->SetDoEstimateLearningRateOnce( !this->m_DoEstimateLearningRateAtEachIteration );
 
-    typedef antsRegistrationOptimizerCommandIterationUpdate<T, VImageDimension,
+    typedef antsRegistrationOptimizerCommandIterationUpdate<TComputeType, VImageDimension,
                                                             ConjugateGradientDescentOptimizerType> OptimizerCommandType;
     typename OptimizerCommandType::Pointer optimizerObserver = OptimizerCommandType::New();
     optimizerObserver->SetLogStream( *this->m_LogStream );
@@ -1193,8 +1193,8 @@ RegistrationHelper<T, VImageDimension>
       optimizerObserver->SetCurrentStageNumber( currentStageNumber );
       }
 
-    typedef itk::GradientDescentLineSearchOptimizerv4Template<T> GradientDescentLSOptimizerType;
-    typedef itk::GradientDescentOptimizerv4Template<T>           GradientDescentOptimizerType;
+    typedef itk::GradientDescentLineSearchOptimizerv4Template<TComputeType> GradientDescentLSOptimizerType;
+    typedef itk::GradientDescentOptimizerv4Template<TComputeType>           GradientDescentOptimizerType;
     typename GradientDescentOptimizerType::Pointer optimizer2 = GradientDescentOptimizerType::New();
     //    optimizer2->SetLowerLimit( 0 );
     //    optimizer2->SetUpperLimit( 2 );
@@ -1209,7 +1209,7 @@ RegistrationHelper<T, VImageDimension>
     optimizer2->SetDoEstimateLearningRateAtEachIteration( this->m_DoEstimateLearningRateAtEachIteration );
     optimizer2->SetDoEstimateLearningRateOnce( !this->m_DoEstimateLearningRateAtEachIteration );
 
-    typedef antsRegistrationOptimizerCommandIterationUpdate<T, VImageDimension,
+    typedef antsRegistrationOptimizerCommandIterationUpdate<TComputeType, VImageDimension,
                                                             GradientDescentOptimizerType> OptimizerCommandType2;
     typename OptimizerCommandType2::Pointer optimizerObserver2 = OptimizerCommandType2::New();
     optimizerObserver2->SetLogStream( *this->m_LogStream );
@@ -1303,7 +1303,7 @@ RegistrationHelper<T, VImageDimension>
         break;
       case Rigid:
         {
-        typedef typename RigidTransformTraits<T, VImageDimension>::TransformType RigidTransformType;
+        typedef typename RigidTransformTraits<TComputeType, VImageDimension>::TransformType RigidTransformType;
 
         typedef itk::ImageRegistrationMethodv4<ImageType, ImageType, RigidTransformType> RigidRegistrationType;
         typename RigidRegistrationType::Pointer rigidRegistration = RigidRegistrationType::New();
@@ -1378,7 +1378,7 @@ RegistrationHelper<T, VImageDimension>
         break;
       case CompositeAffine:
         {
-        typedef typename CompositeAffineTransformTraits<T, VImageDimension>::TransformType CompositeAffineTransformType;
+        typedef typename CompositeAffineTransformTraits<TComputeType, VImageDimension>::TransformType CompositeAffineTransformType;
 
         typedef itk::ImageRegistrationMethodv4<ImageType, ImageType,
                                                CompositeAffineTransformType> CompositeAffineRegistrationType;
@@ -1454,7 +1454,7 @@ RegistrationHelper<T, VImageDimension>
         break;
       case Similarity:
         {
-        typedef typename SimilarityTransformTraits<T, VImageDimension>::TransformType SimilarityTransformType;
+        typedef typename SimilarityTransformTraits<TComputeType, VImageDimension>::TransformType SimilarityTransformType;
 
         typedef itk::ImageRegistrationMethodv4<ImageType, ImageType,
                                                SimilarityTransformType> SimilarityRegistrationType;
@@ -1815,7 +1815,7 @@ RegistrationHelper<T, VImageDimension>
           bsplineFieldTransformAdaptor->SetRequiredOrigin( shrinkFilter->GetOutput()->GetOrigin() );
           bsplineFieldTransformAdaptor->SetTransform( outputDisplacementFieldTransform );
 
-          // A good heuristic is to double the b-spline mesh resolution at each level
+          // A good heuristic is to RealType the b-spline mesh resolution at each level
           typename BSplineDisplacementFieldTransformType::ArrayType newUpdateMeshSize = updateMeshSize;
           typename BSplineDisplacementFieldTransformType::ArrayType newTotalMeshSize = totalMeshSize;
           for( unsigned int d = 0; d < VImageDimension; d++ )
@@ -1928,7 +1928,7 @@ RegistrationHelper<T, VImageDimension>
           shrinkFilter->SetInput( preprocessedFixedImagesPerStage[0] );
           shrinkFilter->Update();
 
-          // A good heuristic is to double the b-spline mesh resolution at each level
+          // A good heuristic is to RealType the b-spline mesh resolution at each level
 
           typename BSplineTransformType::MeshSizeType requiredMeshSize;
           for( unsigned int d = 0; d < VImageDimension; d++ )
@@ -2074,7 +2074,7 @@ RegistrationHelper<T, VImageDimension>
           this->m_TransformMethods[currentStageNumber].m_TotalFieldVarianceInVarianceSpace;
         RealType varianceForTotalFieldTime = this->m_TransformMethods[currentStageNumber].m_TotalFieldTimeSigma;
 
-        typedef itk::GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform <T, ImageType::ImageDimension>
+        typedef itk::GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform <TComputeType, ImageType::ImageDimension>
            TimeVaryingVelocityFieldOutputTransformType;
 
         typedef itk::TimeVaryingVelocityFieldImageRegistrationMethodv4<ImageType, ImageType,
@@ -2272,7 +2272,7 @@ RegistrationHelper<T, VImageDimension>
         typename TimeVaryingVelocityFieldControlPointLatticeType::SizeType initialTransformDomainMeshSize =
           transformDomainMeshSize;
 
-        typedef itk::TimeVaryingBSplineVelocityFieldTransform <T, ImageType::ImageDimension>
+        typedef itk::TimeVaryingBSplineVelocityFieldTransform <TComputeType, ImageType::ImageDimension>
           TimeVaryingBSplineVelocityFieldOutputTransformType;
 
         typedef itk::TimeVaryingBSplineVelocityFieldImageRegistrationMethod<ImageType, ImageType,
@@ -2649,7 +2649,7 @@ RegistrationHelper<T, VImageDimension>
           bsplineFieldTransformAdaptor->SetRequiredOrigin( shrinkFilter->GetOutput()->GetOrigin() );
           bsplineFieldTransformAdaptor->SetTransform( outputDisplacementFieldTransform );
 
-          // A good heuristic is to double the b-spline mesh resolution at each level
+          // A good heuristic is to RealType the b-spline mesh resolution at each level
           typename BSplineDisplacementFieldTransformType::ArrayType newUpdateMeshSize = updateMeshSize;
           typename BSplineDisplacementFieldTransformType::ArrayType newTotalMeshSize = totalMeshSize;
           for( unsigned int d = 0; d < VImageDimension; d++ )
@@ -2965,7 +2965,7 @@ RegistrationHelper<T, VImageDimension>
           bsplineFieldTransformAdaptor->SetRequiredOrigin( shrinkFilter->GetOutput()->GetOrigin() );
           bsplineFieldTransformAdaptor->SetTransform( outputDisplacementFieldTransform );
 
-          // A good heuristic is to double the b-spline mesh resolution at each level
+          // A good heuristic is to RealType the b-spline mesh resolution at each level
           typename BSplineDisplacementFieldTransformType::ArrayType newUpdateMeshSize = updateMeshSize;
           typename BSplineDisplacementFieldTransformType::ArrayType newVelocityMeshSize = velocityMeshSize;
           for( unsigned int d = 0; d < VImageDimension; d++ )
@@ -3065,9 +3065,9 @@ RegistrationHelper<T, VImageDimension>
   return EXIT_SUCCESS;
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
+RegistrationHelper<TComputeType, VImageDimension>
 ::SetMovingInitialTransform( const TransformType *initialTransform )
 {
   // Since the initial transform might be linear (or a composition of
@@ -3092,9 +3092,9 @@ RegistrationHelper<T, VImageDimension>
     }
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
+RegistrationHelper<TComputeType, VImageDimension>
 ::SetFixedInitialTransform( const TransformType *initialTransform  )
 {
   typename CompositeTransformType::Pointer compToAdd;
@@ -3132,9 +3132,9 @@ RegistrationHelper<T, VImageDimension>
     }
 }
 
-template <class T, unsigned VImageDimension>
-typename RegistrationHelper<T, VImageDimension>::AffineTransformType::Pointer
-RegistrationHelper<T, VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
+typename RegistrationHelper<TComputeType, VImageDimension>::AffineTransformType::Pointer
+RegistrationHelper<TComputeType, VImageDimension>
 ::CollapseLinearTransforms( const CompositeTransformType * compositeTransform )
 {
   if( !compositeTransform->IsLinear() )
@@ -3169,9 +3169,9 @@ RegistrationHelper<T, VImageDimension>
   return totalTransform;
 }
 
-template <class T, unsigned VImageDimension>
-typename RegistrationHelper<T, VImageDimension>::DisplacementFieldTransformPointer
-RegistrationHelper<T, VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
+typename RegistrationHelper<TComputeType, VImageDimension>::DisplacementFieldTransformPointer
+RegistrationHelper<TComputeType, VImageDimension>
 ::CollapseDisplacementFieldTransforms( const CompositeTransformType * compositeTransform )
 {
   if( compositeTransform->GetTransformCategory() != TransformType::DisplacementField  )
@@ -3244,9 +3244,9 @@ RegistrationHelper<T, VImageDimension>
   return totalTransform;
 }
 
-template <class T, unsigned VImageDimension>
-typename RegistrationHelper<T, VImageDimension>::CompositeTransformPointer
-RegistrationHelper<T, VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
+typename RegistrationHelper<TComputeType, VImageDimension>::CompositeTransformPointer
+RegistrationHelper<TComputeType, VImageDimension>
 ::CollapseCompositeTransform( const CompositeTransformType * compositeTransform )
 {
   CompositeTransformPointer collapsedCompositeTransform = CompositeTransformType::New();
@@ -3340,9 +3340,9 @@ RegistrationHelper<T, VImageDimension>
   return collapsedCompositeTransform;
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
+RegistrationHelper<TComputeType, VImageDimension>
 ::ApplyCompositeLinearTransformToImageHeader( const CompositeTransformType * compositeTransform,
                                               ImageBaseType * const image,
                                               const bool applyInverse )
@@ -3357,16 +3357,16 @@ RegistrationHelper<T, VImageDimension>
   typename ImageType::PointType origin = image->GetOrigin();
   typename ImageType::DirectionType direction = image->GetDirection();
 
-  // Image direction matrix is type of double.
+  // Image direction matrix is type of RealType.
   // It should be converted to the current InternalComputationType before it is used to set transfrom parameters.
-  vnl_matrix<double> DoubleLocalDirection( VImageDimension, VImageDimension );
-  vnl_matrix<T> localDirection( VImageDimension, VImageDimension );
+  vnl_matrix<typename ImageType::DirectionType::ValueType> DoubleLocalDirection( VImageDimension, VImageDimension );
+  vnl_matrix<TComputeType> localDirection( VImageDimension, VImageDimension );
   DoubleLocalDirection = direction.GetVnlMatrix();
   vnl_copy( DoubleLocalDirection, localDirection );
 
-  // Image origin is an itk point of type double.
+  // Image origin is an itk point of type RealType.
   // It should be converted to the current InternalComputationType before it is used to set the offset parameters of transform.
-  typename itk::Point<T, VImageDimension> localOrigin;
+  typename itk::Point<TComputeType, VImageDimension> localOrigin;
   localOrigin.CastFrom(origin);
 
   typename AffineTransformType::Pointer imageTransform = AffineTransformType::New();
@@ -3391,7 +3391,7 @@ RegistrationHelper<T, VImageDimension>
       origin[d] = inverseOffset[d];
       }
     //direction = inverseMatrix; // Does not work because they probably have different types!
-    vnl_matrix<T> localInverseMatrix( VImageDimension, VImageDimension );
+    vnl_matrix<TComputeType> localInverseMatrix( VImageDimension, VImageDimension );
     localInverseMatrix = inverseMatrix.GetVnlMatrix();
     vnl_copy(localInverseMatrix, DoubleLocalDirection);
     direction = DoubleLocalDirection;
@@ -3407,7 +3407,7 @@ RegistrationHelper<T, VImageDimension>
       origin[d] = offset[d];
       }
     //direction = matrix; // Does not work because they probably have different types!
-    vnl_matrix<T> localMatrix( VImageDimension, VImageDimension );
+    vnl_matrix<TComputeType> localMatrix( VImageDimension, VImageDimension );
     localMatrix = matrix.GetVnlMatrix();
     vnl_copy(localMatrix, DoubleLocalDirection);
     direction = DoubleLocalDirection;
@@ -3417,9 +3417,9 @@ RegistrationHelper<T, VImageDimension>
   image->SetOrigin( origin );
 }
 
-template <class T, unsigned VImageDimension>
+template <class TComputeType, unsigned VImageDimension>
 void
-RegistrationHelper<T, VImageDimension>
+RegistrationHelper<TComputeType, VImageDimension>
 ::PrintState() const
 {
   this->Logger() << "Dimension = " << Self::ImageDimension << std::endl


### PR DESCRIPTION
Avoid implicit conversions between the requested type and "hard coded double" type.  If the registration is requested to be done in floating point, then we should respect that and use flloating point for all aspects of the registration. (there may be accumulators that would be OK to be in double, but normal operations should stay consistent.)
