### PR TITLE
BF: explicitly specify to use bash instead of generic POSIX compliant sh

### DIFF
--- a/Scripts/ANTSAverage2DAffine.sh
+++ b/Scripts/ANTSAverage2DAffine.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 NUMPARAM=$#
 if [ $NUMPARAM -lt 2 ] ; then
 echo " Usage "

--- a/Scripts/ANTSAverage3DAffine.sh
+++ b/Scripts/ANTSAverage3DAffine.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 NUMPARAM=$#
 if [ $NUMPARAM -lt 2 ] ; then
 echo " Usage "

--- a/Scripts/antsaffine.sh
+++ b/Scripts/antsaffine.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 if [ ${#ANTSPATH} -le 3 ] ; then
   echo we guess at your ants path
   export ANTSPATH=${ANTSPATH:="$HOME/bin/ants/"} # EDIT THIS

--- a/Scripts/guidedregistration.sh
+++ b/Scripts/guidedregistration.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 if [ $# -lt 7  ]
 then
 echo " USAGE \n  sh command.sh  fixed.nii fixedhipp.nii  moving.nii movinghipp.nii outputname  iterations DIM "

--- a/Scripts/landmarkmatch.sh
+++ b/Scripts/landmarkmatch.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 if [ $# -lt 6  ]
 then
 echo " USAGE \n  sh $0  fixed.nii fixedhipp.nii  moving.nii movinghipp.nii  ITERATIONS LandmarkWeight "

--- a/Scripts/lohmann.sh
+++ b/Scripts/lohmann.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 NUMPARAMS=$#
 MAXITERATIONS=30x90x20

--- a/Scripts/optimalsmooth.sh
+++ b/Scripts/optimalsmooth.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo  " sh $0 outputprefix "
 if [ $# -lt 1 ] ; then

--- a/Scripts/phantomstudy.sh
+++ b/Scripts/phantomstudy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ANTSPATH="/Users/stnava/Code/bin/ants/"
 

--- a/Scripts/submitexperimentalbuild.sh
+++ b/Scripts/submitexperimentalbuild.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # request Bourne shell as shell for job
 
 ctest -D ExperimentalStart

--- a/Scripts/sygnccavg.sh
+++ b/Scripts/sygnccavg.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 TNAME=$1
 GRADSTEP=$2

--- a/Scripts/thickstudy.sh
+++ b/Scripts/thickstudy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 count=0
 for x in  phantomA phantomB phantomC phantomD phantomE phantomF phantomG phantomH

--- a/Scripts/weightedaverage.sh
+++ b/Scripts/weightedaverage.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo "Usage: \n sh  weightedaverage.sh  \"Faces*tiff\" \n "
 


### PR DESCRIPTION
As reported in http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=690622 some scripts have "bashisms" -- features which are present only in bash but not in a limited, but still POSIX compliant shells such as dash (default on many systems nowadays to speed up boot etc).

Here is a current list from running bashishsms tool

```
possible bashism in Scripts/ANTSAverage2DAffine.sh line 22 (let ...):
for x in $LL ; do  PARAM1=` awk -v a=$PARAM1 -v b=$x 'BEGIN{print (a + b)}' ` ;  let NFILES=$NFILES+1  ; done
possible bashism in Scripts/ANTSAverage3DAffine.sh line 29 (let ...):
for x in $LL ; do  PARAM1=` awk -v a=$PARAM1 -v b=$x 'BEGIN{print (a + b)}' ` ;  let NFILES=$NFILES+1  ; done
possible bashism in Scripts/guidedregistration.sh line 4 (unsafe echo with backslash):
echo " USAGE \n  sh command.sh  fixed.nii fixedhipp.nii  moving.nii movinghipp.nii outputname  iterations DIM "
possible bashism in Scripts/landmarkmatch.sh line 4 (unsafe echo with backslash):
echo " USAGE \n  sh $0  fixed.nii fixedhipp.nii  moving.nii movinghipp.nii  ITERATIONS LandmarkWeight "
possible bashism in Scripts/landmarkmatch.sh line 28 (let ...):
let DD=MM-NN
possible bashism in Scripts/landmarkmatch.sh line 37 (let ...):
let DD=MM-NN
possible bashism in Scripts/lohmann.sh line 45 (alternative test command ([[ foo ]] should be [ foo ])):
if [[ ! -s ${OUTPUTNAME}repaired.nii.gz ]] ; then
possible bashism in Scripts/lohmann.sh line 51 (alternative test command ([[ foo ]] should be [ foo ])):
if [[ ! -s $WM ]] ; then
possible bashism in Scripts/lohmann.sh line 57 (alternative test command ([[ foo ]] should be [ foo ])):
if [[ ! -s  ${OUT}max.nii.gz ]] ; then
possible bashism in Scripts/weightedaverage.sh line 3 (unsafe echo with backslash):
echo "Usage: \n sh  weightedaverage.sh  \"Faces*tiff\" \n "
```

although alternative is to fix the scripts, but IMHO it would be better just to
switch to use bash (present everywhere anyways) for the shell interpreter for those scripts.
