### PR TITLE
COMP: Changes needed to build with Visual Studio 2010

### DIFF
--- a/Examples/ImageMath.cxx
+++ b/Examples/ImageMath.cxx
@@ -14877,7 +14877,7 @@ private:
         {
         MajorityVoting<3>(argc, argv);
         }
-      else if( strcmp(operation.c_str(), "MostLikely") == 0 )
+      if( strcmp(operation.c_str(), "MostLikely") == 0 )
         {
         MostLikely<3>(argc, argv);
         }

--- a/Examples/sccan.cxx
+++ b/Examples/sccan.cxx
@@ -1447,7 +1447,7 @@ int SCCA_vnl( itk::ants::CommandLineParser *sccanparser, unsigned int permct, un
     sccanparser->GetOption( "mask" );
   if( !initOpt || initOpt->GetNumberOfFunctions() == 0 ||  !maskOpt || maskOpt->GetNumberOfFunctions() == 0 )
     {
-    itkDebugMacro( "Warning:  no Q initialization set, will use data-driven approach." << std::endl );
+    itkDebugStatement(std::cerr << "Warning:  no Q initialization set, will use data-driven approach." << std::endl );
     }
   else
     {
@@ -1466,7 +1466,7 @@ int SCCA_vnl( itk::ants::CommandLineParser *sccanparser, unsigned int permct, un
     sccanparser->GetOption( "mask2" );
   if( !init2Opt || init2Opt->GetNumberOfFunctions() == 0 ||  !mask2Opt || mask2Opt->GetNumberOfFunctions() == 0 )
     {
-    itkDebugMacro( "Warning:  no Q initialization set, will use data-driven approach." << std::endl );
+    itkDebugStatement(std::cerr << "Warning:  no Q initialization set, will use data-driven approach." << std::endl );
     }
   else
     {

--- a/ExternalApplications/MALF/CorrectiveLearning/segAdapter.cxx
+++ b/ExternalApplications/MALF/CorrectiveLearning/segAdapter.cxx
@@ -498,10 +498,14 @@ int main( int argc, char * * argv )
             {
             for( l = -DZ; l < DZ + 1; l++ )
               {
-              X[C++] = autosegnit.GetPixel( (NeighborhoodIteratorType::OffsetType) {{j, k, l}});
+              NeighborhoodIteratorType::OffsetType offset;
+              offset[0] = j;
+              offset[1] = k;
+              offset[2] = l;
+              X[C++] = autosegnit.GetPixel(offset);
               for( size_t it = 0; it < ims.size(); it++ )
                 {
-                X[C++] = imnits[it].GetPixel( (NeighborhoodIteratorType::OffsetType) {{j, k, l}});
+                X[C++] = imnits[it].GetPixel(offset);
                 }
               }
             }

--- a/ExternalApplications/MALF/JointFusion/LabelFusion.cxx
+++ b/ExternalApplications/MALF/JointFusion/LabelFusion.cxx
@@ -327,7 +327,7 @@ int lfapp(int argc, char *argv[])
     cout<<"MaxV: "<<MaxV<<endl;
     if ((int)GroupSet.size()!=MaxV+1)
     {
-      int tmap[MaxV+1];
+      int *tmap = new int[MaxV+1];
       int tc=-1;
       for (set<int>::iterator it = GroupSet.begin(); it != GroupSet.end(); ++it)
       {
@@ -339,7 +339,7 @@ int lfapp(int argc, char *argv[])
         p.AtlasGroupID[i] = tmap[p.AtlasGroupID[i]];
         cout<<p.AtlasGroupID[i]<<" : ";
       }
-//      delete tmap;
+      delete [] tmap;
     }
 cout<<999<<endl;
     if (p.GroupWeight.size()!=GroupSet.size())

--- a/ExternalApplications/MALF/JointFusion/WeightedVotingLabelFusionImageFilter.txx
+++ b/ExternalApplications/MALF/JointFusion/WeightedVotingLabelFusionImageFilter.txx
@@ -4,7 +4,7 @@
   Module:    $Id: WeightedVotingLabelFusionImageFilter.txx,v 1.1 2012/09/05 14:39:51 zhuzhu771 Exp $
   Language:  C++ program
   Copyright (c) 2012 Paul A. Yushkevich, University of Pennsylvania
-  
+
   This file is part of ASHS
 
   ASHS is free software: you can redistribute it and/or modify
@@ -15,22 +15,22 @@
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details. 
+  GNU General Public License for more details.
   You should have received a copy of the GNU General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-  =================================================================== 
-  
+  ===================================================================
+
   CITATION:
 
     This program implements the method described in the paper
 
-    H. Wang, J. W. Suh, S. Das, J. Pluta, C. Craige, P. Yushkevich, 
-    "Multi-atlas segmentation with joint label fusion," IEEE Trans. 
+    H. Wang, J. W. Suh, S. Das, J. Pluta, C. Craige, P. Yushkevich,
+    "Multi-atlas segmentation with joint label fusion," IEEE Trans.
     on Pattern Analysis and Machine Intelligence, 35(3), 611-623, 2013
 
   =================================================================== */
-   
+
 #include <itkNeighborhoodIterator.h>
 #include <itkImageRegionIteratorWithIndex.h>
 #include <vnl/vnl_matrix.h>
@@ -102,9 +102,9 @@ template<class TInputImage, class TOutputImage>
 void
 WeightedVotingLabelFusionImageFilter<TInputImage, TOutputImage>
 ::ComputeOffsetTable(
-  const InputImageType *image, 
-  const SizeType &radius, 
-  int **offset, 
+  const InputImageType *image,
+  const SizeType &radius,
+  int **offset,
   size_t &nPatch,
   int **manhattan)
 {
@@ -118,7 +118,7 @@ WeightedVotingLabelFusionImageFilter<TInputImage, TOutputImage>
     iCenter[i] = r.GetIndex(i) + r.GetSize(i)/2;
   itTempPatch.SetLocation(iCenter);
 
-  // Compute the offsets 
+  // Compute the offsets
   nPatch = itTempPatch.Size();
   (*offset) = new int[nPatch];
   if(manhattan)
@@ -163,9 +163,9 @@ WeightedVotingLabelFusionImageFilter<TInputImage, TOutputImage>
   // Construct offset tables for all the images (these can be different because they
   // depend on the buffered region)
   size_t nPatch, nSearch;
-  int *offPatchTarget, 
+  int *offPatchTarget,
       **offPatchAtlas = new int *[n],
-      **offPatchSeg = new int *[n], 
+      **offPatchSeg = new int *[n],
       **offSearchAtlas = new int *[n],
       *manhattan;
 
@@ -209,7 +209,7 @@ WeightedVotingLabelFusionImageFilter<TInputImage, TOutputImage>
     m_PosteriorMap[*sit]->FillBuffer(0.0f);
     }
 
-  std::cout<<m_RetainVotingWeight<<endl;  
+  std::cout<<m_RetainVotingWeight<<endl;
   if (m_RetainVotingWeight)
   {
     m_VotingWeight.clear();
@@ -220,7 +220,7 @@ WeightedVotingLabelFusionImageFilter<TInputImage, TOutputImage>
       m_VotingWeight[i]->SetRequestedRegion(this->GetOutput()->GetRequestedRegion());
       m_VotingWeight[i]->SetBufferedRegion(this->GetOutput()->GetRequestedRegion());
       m_VotingWeight[i]->Allocate();
-      m_VotingWeight[i]->FillBuffer(0.0f);      
+      m_VotingWeight[i]->FillBuffer(0.0f);
     }
   }
   PosteriorImagePtr countermap = PosteriorImage::New();
@@ -252,7 +252,7 @@ WeightedVotingLabelFusionImageFilter<TInputImage, TOutputImage>
     apd[i] = new InputImagePixelType[nPatch * m_Modality];
 
   // Also an array of pointers to the segmentations of different atlases
-  const InputImagePixelType **patchSeg = new const InputImagePixelType*[n]; 
+  const InputImagePixelType **patchSeg = new const InputImagePixelType*[n];
 
   // Create an array for storing the normalized target patch to save more time
   InputImagePixelType *xNormTargetPatch = new InputImagePixelType[nPatch * m_Modality];
@@ -287,7 +287,7 @@ WeightedVotingLabelFusionImageFilter<TInputImage, TOutputImage>
       for(unsigned int i = 0; i < nPatch; i++)
         xNormTargetPatch[toff + i] = (*(pTargetCurrent + offPatchTarget[i]) - mu) / sigma;
     }
-    
+
     // In each atlas, search for a patch that matches our patch
     for(int i = 0; i < n; i++)
       {
@@ -296,7 +296,7 @@ WeightedVotingLabelFusionImageFilter<TInputImage, TOutputImage>
       int *offPatch = offPatchAtlas[i], *offSearch = offSearchAtlas[i];
 
       const InputImageType *tatlas = m_Atlases[toff];
-      
+
       // Get the requested region for the tatlas
       RegionType rr = tatlas->GetRequestedRegion();
 
@@ -316,8 +316,13 @@ WeightedVotingLabelFusionImageFilter<TInputImage, TOutputImage>
       const InputImagePixelType **bestMatchPtr = new const InputImagePixelType *[m_Modality];
       const InputImagePixelType **tMatchPtr = new const InputImagePixelType *[m_Modality];
 
-      InputImagePixelType bestMatchSum[m_Modality], bestMatchSSQ[m_Modality],bestMatchMean[m_Modality],bestMatchVar[m_Modality],bestMatchSD[m_Modality];
-      InputImagePixelType MatchSum[m_Modality], MatchSSQ[m_Modality];
+      InputImagePixelType *bestMatchSum =  new InputImagePixelType[m_Modality];
+      InputImagePixelType *bestMatchSSQ =  new InputImagePixelType[m_Modality];
+      InputImagePixelType *bestMatchMean = new InputImagePixelType[m_Modality];
+      InputImagePixelType *bestMatchVar =  new InputImagePixelType[m_Modality];
+      InputImagePixelType *bestMatchSD =   new InputImagePixelType[m_Modality];
+      InputImagePixelType *MatchSum =      new InputImagePixelType[m_Modality];
+      InputImagePixelType *MatchSSQ =      new InputImagePixelType[m_Modality];
 
       int bestK = 0;
       for(unsigned int k = 0; k < nSearch; k++)
@@ -377,15 +382,22 @@ WeightedVotingLabelFusionImageFilter<TInputImage, TOutputImage>
 
       // Store the best found neighborhood
       patchSeg[i] = (bestMatchPtr[0] - m_Atlases[toff]->GetBufferPointer()) + seg->GetBufferPointer();
+      delete [] bestMatchSum;
+      delete [] bestMatchSSQ;
+      delete [] bestMatchMean;
+      delete [] bestMatchVar;
+      delete [] bestMatchSD;
+      delete [] MatchSum;
+      delete [] MatchSSQ;
       }
 
     // Allocate Mx
     MatrixType Mx(n, n);
 
     // Now we can compute Mx
-    for(int i = 0; i < n; i++) 
+    for(int i = 0; i < n; i++)
       {
-      for(int k = 0; k <= i; k++) 
+      for(int k = 0; k <= i; k++)
         {
         // Multiply through the apd arrays
         InputImagePixelType mxval = 0.0;
@@ -393,7 +405,7 @@ WeightedVotingLabelFusionImageFilter<TInputImage, TOutputImage>
           mxval += apd[i][m] * apd[k][m];
 
         mxval /= (nPatch - 1);
-        
+
         if(m_Beta == 2)
           mxval *= mxval;
         else
@@ -498,7 +510,7 @@ WeightedVotingLabelFusionImageFilter<TInputImage, TOutputImage>
   // Clear posterior maps
   if(!m_RetainPosteriorMaps)
     m_PosteriorMap.clear();
-  
+
   for(OutIter it(this->GetOutput(), this->GetOutput()->GetBufferedRegion()); !it.IsAtEnd(); ++it)
   {
     IndexType idx = it.GetIndex();
@@ -517,7 +529,7 @@ WeightedVotingLabelFusionImageFilter<TInputImage, TOutputImage>
     {
       for (int i=0; i < n; i++)
         m_VotingWeight[i]->SetPixel(idx,m_VotingWeight[i]->GetPixel(idx)/countermap->GetPixel(idx));
-    }  
+    }
   }
 }
 
@@ -544,7 +556,7 @@ WeightedVotingLabelFusionImageFilter<TInputImage, TOutputImage>
 
 /**
  * This function computes similarity between a normalized patch (normtrg) and a patch
- * that has not been normalized (psearch). It can be shown that the sum of squared 
+ * that has not been normalized (psearch). It can be shown that the sum of squared
  * differences between a normalized patch u and a unnormalized patch v is equal to
  *
  * 2 [ (n-1) - (\Sum u_i v_i ) / \sigma_v ]
@@ -559,10 +571,10 @@ template <class TInputImage, class TOutputImage>
 double
 WeightedVotingLabelFusionImageFilter<TInputImage, TOutputImage>
 ::PatchSimilarity(
-  const InputImagePixelType *psearch, 
+  const InputImagePixelType *psearch,
   const InputImagePixelType *normtrg,
-  int offset, 
-  size_t n, 
+  int offset,
+  size_t n,
   int *offsets,
   InputImagePixelType &sum_psearch,
   InputImagePixelType &ssq_psearch)

--- a/Utilities/itkGeometricJacobianDeterminantImageFilter.hxx
+++ b/Utilities/itkGeometricJacobianDeterminantImageFilter.hxx
@@ -181,13 +181,13 @@ GeometricJacobianDeterminantImageFilter<TInputImage, TRealType, TOutputImage>
   this->m_DeltaTriangularPointB.Fill( 0.0 );
   this->m_DeltaTriangularPointC.Fill( 0.0 );
 
-  this->m_DeltaTriangularPointA[1] = 0.25 * vcl_sqrt( 3 ) * spacing[1];
+  this->m_DeltaTriangularPointA[1] = 0.25 * vcl_sqrt( 3.0 ) * spacing[1];
 
   this->m_DeltaTriangularPointB[0] = -0.5 * spacing[0];
-  this->m_DeltaTriangularPointB[1] = -0.25 * vcl_sqrt( 3 ) * spacing[1];
+  this->m_DeltaTriangularPointB[1] = -0.25 * vcl_sqrt( 3.0 ) * spacing[1];
 
   this->m_DeltaTriangularPointC[0] = 0.5 * spacing[0];
-  this->m_DeltaTriangularPointC[1] = -0.25 * vcl_sqrt( 3 ) * spacing[1];
+  this->m_DeltaTriangularPointC[1] = -0.25 * vcl_sqrt( 3.0 ) * spacing[1];
 }
 
 


### PR DESCRIPTION
Changes were reported to be necessary for building with Visual Studio 2010.

There was also a compiler error where itkDebugMacro was used outside of an ITK class, which I fixed by replacing it with itkDebugStatement.
