### PR TITLE
BF: remove custom path to Rscript

### DIFF
--- a/Scripts/cbf_pasl_robust_batch.R
+++ b/Scripts/cbf_pasl_robust_batch.R
@@ -1,4 +1,4 @@
-#!/share/apps/R/R-3.0.2/bin/Rscript --vanilla --slave
+#!Rscript --vanilla --slave
 
 library( "ANTsR" )
 library("extremevalues" )


### PR DESCRIPTION
was not sure if --slave is mandatory, so that is why didn't make it just a `#!/usr/bin/env Rscript` as in the other scripts
