### PR TITLE
RegroupCommandLineArguments ignores argv[0]

### DIFF
--- a/Utilities/antsCommandLineParser.cxx
+++ b/Utilities/antsCommandLineParser.cxx
@@ -216,7 +216,7 @@ CommandLineParser
   std::string currentArg( "" );
   bool        isArgOpen = false;
 
-  for( unsigned int n = 0; n < argc; n++ )
+  for( unsigned int n = 1; n < argc; n++ )
     {
     std::string a( argv[n] );
 


### PR DESCRIPTION
A command line specification should not apply to argv[0] (program name).
if argv[0] is "c:\Program Files (x86)\product\executable.exe", a semantically meaningless command line specification is avoided and an obscure runtime error is avoided too.
"c:\Program Files (x86)\XXX\yyy.exe" is a standar pattern for win32 software(XXX) installed on win64 machines.
