### PR TITLE
Add option -y 0 to remove rigid components of the average affine transfo...

### DIFF
--- a/Scripts/antsLongitudinalCorticalThickness.sh
+++ b/Scripts/antsLongitudinalCorticalThickness.sh
@@ -524,12 +524,22 @@ for(( i=1; i < ${NUMBER_OF_MODALITIES}; i++ ))
   done
 
 TEMPLATE_Z_IMAGES=''
-for(( i=0; i < ${NUMBER_OF_MODALITIES}; i++ ))
-  do
-    TEMPLATE_Z_IMAGES="${TEMPLATE_Z_IMAGES} -z ${ANATOMICAL_IMAGES[$i]}"
-  done
 
 OUTPUT_DIRECTORY_FOR_SINGLE_SUBJECT_TEMPLATE="${OUTPUT_PREFIX}SingleSubjectTemplate/"
+
+logCmd mkdir -p ${OUTPUT_DIRECTORY_FOR_SINGLE_SUBJECT_TEMPLATE}
+
+# Pad initial template image to avoid problems with SST drifting out of FOV
+for(( i=0; i < ${NUMBER_OF_MODALITIES}; i++ ))
+  do
+    TEMPLATE_INPUT_IMAGE="${OUTPUT_DIRECTORY_FOR_SINGLE_SUBJECT_TEMPLATE}initTemplateModality${i}.nii.gz"
+ 
+    logCmd ${ANTSPATH}/ImageMath 3 ${TEMPLATE_INPUT_IMAGE} PadImage ${ANATOMICAL_IMAGES[$i]} 5
+
+    TEMPLATE_Z_IMAGES="${TEMPLATE_Z_IMAGES} -z ${TEMPLATE_INPUT_IMAGE}"
+  done
+
+
 SINGLE_SUBJECT_TEMPLATE=${OUTPUT_DIRECTORY_FOR_SINGLE_SUBJECT_TEMPLATE}T_template0.nii.gz
 
 time_start_sst_creation=`date +%s`
@@ -557,6 +567,7 @@ if [[ ! -f $SINGLE_SUBJECT_TEMPLATE ]];
 #       -l 1 \
 #       -m CC[4] \
 #       -t SyN \
+#       -y 0 \
 #       ${TEMPLATE_Z_IMAGES} \
 #       ${ANATOMICAL_IMAGES[@]}
 
@@ -575,6 +586,7 @@ if [[ ! -f $SINGLE_SUBJECT_TEMPLATE ]];
       -r 1 \
       -s CC \
       -t GR \
+      -y 0 \
       ${TEMPLATE_Z_IMAGES} \
       ${ANATOMICAL_IMAGES[@]}
 
@@ -599,6 +611,7 @@ logCmd rm -f ${OUTPUT_DIRECTORY_FOR_SINGLE_SUBJECT_TEMPLATE}T_*GenericAffine*
 logCmd rm -f ${OUTPUT_DIRECTORY_FOR_SINGLE_SUBJECT_TEMPLATE}T_template0warp.nii.gz
 logCmd rm -f ${OUTPUT_DIRECTORY_FOR_SINGLE_SUBJECT_TEMPLATE}T_template0Affine.txt
 logCmd rm -f ${OUTPUT_DIRECTORY_FOR_SINGLE_SUBJECT_TEMPLATE}T_templatewarplog.txt
+logCmd rm -f ${OUTPUT_DIRECTORY_FOR_SINGLE_SUBJECT_TEMPLATE}initTemplateModality*.nii.gz
 
 # Need to change the number of iterations to  -q \
 


### PR DESCRIPTION
Add option -y 0 to remove rigid components of the average affine transform when updating the template.

Made -y 1 the default for backwards compatibility with template construction scripts.

Hard coded -y 0 into antsLongitudinalCorticalThickness.sh. Because the number of images in this template construction call is small, the average translation / rotation can be substantial. If the input images have different origins, the resulting translation can cause the template to be shifted out of the field of view. 

Also in antsLongitudinalCorticalThickness.sh, added a 5 voxel pad to the SST. If the top of the brain is cut off, or if there are varying amounts of spine / neck at the bottom of the images, padding the fixed image can improve affine alignment.
