### PR TITLE
Improve command line processing

### DIFF
--- a/Examples/ANTSConformalMapping.cxx
+++ b/Examples/ANTSConformalMapping.cxx
@@ -525,7 +525,10 @@ private:
   parser->SetCommandDescription( commandDescription );
   InitializeCommandLineOptions( parser );
 
-  parser->Parse( argc, argv );
+  if( parser->Parse( argc, argv ) == EXIT_FAILURE )
+    {
+    return EXIT_FAILURE;
+    }
 
   if( argc < 2 || parser->Convert<bool>(
         parser->GetOption( "help" )->GetFunction() ) )

--- a/Examples/Atropos.cxx
+++ b/Examples/Atropos.cxx
@@ -1607,7 +1607,10 @@ private:
   parser->SetCommandDescription( commandDescription );
   AtroposInitializeCommandLineOptions( parser );
 
-  parser->Parse( argc, argv );
+  if( parser->Parse( argc, argv ) == EXIT_FAILURE )
+    {
+    return EXIT_FAILURE;
+    }
 
   if( argc == 1 )
     {

--- a/Examples/CreateDTICohort.cxx
+++ b/Examples/CreateDTICohort.cxx
@@ -1116,7 +1116,10 @@ private:
   parser->SetCommandDescription( commandDescription );
   InitializeCommandLineOptions( parser );
 
-  parser->Parse( argc, argv );
+  if( parser->Parse( argc, argv ) == EXIT_FAILURE )
+    {
+    return EXIT_FAILURE;
+    }
 
   if( argc < 2 || parser->Convert<bool>( parser->GetOption( "help" )->GetFunction()->GetName() ) )
     {

--- a/Examples/CreateTiledMosaic.cxx
+++ b/Examples/CreateTiledMosaic.cxx
@@ -1045,7 +1045,10 @@ private:
   parser->SetCommandDescription( commandDescription );
   InitializeCommandLineOptions( parser );
 
-  parser->Parse( argc, argv );
+  if( parser->Parse( argc, argv ) == EXIT_FAILURE )
+    {
+    return EXIT_FAILURE;
+    }
 
   if( argc == 1 )
     {

--- a/Examples/KellyKapowski.cxx
+++ b/Examples/KellyKapowski.cxx
@@ -648,7 +648,10 @@ private:
   parser->SetCommandDescription( commandDescription );
   KellyKapowskiInitializeCommandLineOptions( parser );
 
-  parser->Parse( argc, argv );
+  if( parser->Parse( argc, argv ) == EXIT_FAILURE )
+    {
+    return EXIT_FAILURE;
+    }
 
   if( argc == 1 )
     {

--- a/Examples/N4BiasFieldCorrection.cxx
+++ b/Examples/N4BiasFieldCorrection.cxx
@@ -781,7 +781,10 @@ private:
   parser->SetCommandDescription( commandDescription );
   N4InitializeCommandLineOptions( parser );
 
-  parser->Parse( argc, argv );
+  if( parser->Parse( argc, argv ) == EXIT_FAILURE )
+    {
+    return EXIT_FAILURE;
+    }
 
   if( argc == 1 )
     {

--- a/Examples/TimeSCCAN.cxx
+++ b/Examples/TimeSCCAN.cxx
@@ -833,7 +833,10 @@ private:
   parser->SetCommandDescription( commandDescription );
   InitializeCommandLineOptions( parser );
 
-  parser->Parse( argc, argv );
+  if( parser->Parse( argc, argv ) == EXIT_FAILURE )
+    {
+    return EXIT_FAILURE;
+    }
 
   // Print the entire help menu
   itk::ants::CommandLineParser::OptionType::Pointer shortHelpOption =

--- a/Examples/antsAlignOrigin.cxx
+++ b/Examples/antsAlignOrigin.cxx
@@ -275,7 +275,10 @@ private:
   parser->SetCommandDescription( commandDescription );
   InitializeCommandLineOptions( parser );
 
-  parser->Parse( argc, argv );
+  if( parser->Parse( argc, argv ) == EXIT_FAILURE )
+    {
+    return EXIT_FAILURE;
+    }
 
   if( argc < 2 || ( parser->GetOption( "help" ) &&
                     ( parser->Convert<bool>( parser->GetOption( "help" )->GetFunction()->GetName() ) ) ) )

--- a/Examples/antsApplyTransforms.cxx
+++ b/Examples/antsApplyTransforms.cxx
@@ -830,7 +830,10 @@ private:
   parser->SetCommandDescription( commandDescription );
   antsApplyTransformsInitializeCommandLineOptions( parser );
 
-  parser->Parse( argc, argv );
+  if( parser->Parse( argc, argv ) == EXIT_FAILURE )
+    {
+    return EXIT_FAILURE;
+    }
 
   if( argc == 1 )
     {

--- a/Examples/antsApplyTransformsToPoints.cxx
+++ b/Examples/antsApplyTransformsToPoints.cxx
@@ -361,7 +361,10 @@ private:
   parser->SetCommandDescription( commandDescription );
   antsApplyTransformsToPointsInitializeCommandLineOptions( parser );
 
-  parser->Parse( argc, argv );
+  if( parser->Parse( argc, argv ) == EXIT_FAILURE )
+    {
+    return EXIT_FAILURE;
+    }
 
   if( argc < 2 || ( parser->GetOption( "help" ) &&
                     ( parser->Convert<bool>( parser->GetOption( "help" )->GetFunction()->GetName() ) ) ) )

--- a/Examples/antsMotionCorr.cxx
+++ b/Examples/antsMotionCorr.cxx
@@ -1660,7 +1660,10 @@ private:
   parser->SetCommandDescription( commandDescription );
   antsMotionCorrInitializeCommandLineOptions( parser );
 
-  parser->Parse( argc, argv );
+  if( parser->Parse( argc, argv ) == EXIT_FAILURE )
+    {
+    return EXIT_FAILURE;
+    }
 
   if( argc < 2 || parser->Convert<bool>( parser->GetOption( "help" )->GetFunction()->GetName() ) )
     {

--- a/Examples/antsRegistration.cxx
+++ b/Examples/antsRegistration.cxx
@@ -503,7 +503,11 @@ private:
     parser->SetCommandDescription( commandDescription );
     antsRegistrationInitializeCommandLineOptions( parser );
 
-    parser->Parse( argc, argv );
+    if( parser->Parse( argc, argv ) == EXIT_FAILURE )
+      {
+      return EXIT_FAILURE;
+      }
+    std::cout << "All_Command_lines_OK" << std::endl;
 
     if( argc == 1 )
       {

--- a/Examples/antsRegistrationTemplateHeader.h
+++ b/Examples/antsRegistrationTemplateHeader.h
@@ -937,6 +937,9 @@ DoRegistration(typename ParserType::Pointer & parser)
     return EXIT_FAILURE;
     }
 
+
+
+
   // write out transforms stored in the composite
   typename CompositeTransformType::Pointer resultTransform = regHelper->GetModifiableCompositeTransform();
   unsigned int numTransforms = resultTransform->GetNumberOfTransforms();

--- a/Examples/antsSliceRegularizedRegistration.cxx
+++ b/Examples/antsSliceRegularizedRegistration.cxx
@@ -1207,7 +1207,10 @@ private:
   parser->SetCommandDescription( commandDescription );
   antsSliceRegularizedRegistrationInitializeCommandLineOptions( parser );
 
-  parser->Parse( argc, argv );
+  if( ! parser->Parse( argc, argv ) )
+    {
+    return EXIT_FAILURE;
+    }
 
   if( argc < 2 || parser->Convert<bool>( parser->GetOption( "help" )->GetFunction()->GetName() ) )
     {

--- a/Examples/antsSurf.cxx
+++ b/Examples/antsSurf.cxx
@@ -882,7 +882,10 @@ private:
   parser->SetCommandDescription( commandDescription );
   InitializeCommandLineOptions( parser );
 
-  parser->Parse( argc, argv );
+  if( parser->Parse( argc, argv ) == EXIT_FAILURE )
+    {
+    return EXIT_FAILURE;
+    }
 
   if( argc == 1 )
     {

--- a/Examples/itkCommandLineParserTest.cxx
+++ b/Examples/itkCommandLineParserTest.cxx
@@ -92,7 +92,10 @@ private:
 
   parser->AddOption( dirOption );
 
-  parser->Parse( argc, argv );
+  if( parser->Parse( argc, argv ) == EXIT_FAILURE )
+    {
+    return EXIT_FAILURE;
+    }
 
   if( !parser->GetOption( "directionality" ) )
     {

--- a/Examples/sccan.cxx
+++ b/Examples/sccan.cxx
@@ -2846,7 +2846,10 @@ private:
     sccanparser->AddOption( option );
     }
 
-  sccanparser->Parse( argc, argv );
+  if( sccanparser->Parse( argc, argv ) == EXIT_FAILURE )
+    {
+    return EXIT_FAILURE;
+    }
 
   // Print the entire help menu
   itk::ants::CommandLineParser::OptionType::Pointer shortHelpOption =

--- a/Utilities/antsCommandLineParser.cxx
+++ b/Utilities/antsCommandLineParser.cxx
@@ -93,7 +93,7 @@ CommandLineParser
   return s2.length() <= s1.length() && s1.compare(0, s2.length(), s2) == 0;
 }
 
-void
+int
 CommandLineParser
 ::Parse( unsigned int argc, char * *argv )
 {
@@ -102,6 +102,7 @@ CommandLineParser
 
   unsigned int n = 0;
   unsigned int order = 0;
+  bool allFlagsAreValid = true;
 
   if ( arguments.size() > 1 )
     {
@@ -123,6 +124,7 @@ CommandLineParser
       name = argument.substr( 1, 2 );
       }
 
+    allFlagsAreValid &= this->ValidateFlag(name);
     if( !( name.empty() ) && !atof( name.c_str() ) )
       {
       OptionType::Pointer option = this->GetOption( name );
@@ -198,8 +200,13 @@ CommandLineParser
         }
       }
     }
-
+  if( ! allFlagsAreValid )
+    {
+    std::cerr << "ERROR:  Invalid command line flags found! Aborting exectution." << std::endl;
+    return EXIT_FAILURE;
+    }
   this->AssignStages();
+  return EXIT_SUCCESS;
 }
 
 std::vector<std::string>
@@ -342,6 +349,27 @@ CommandLineParser
       }
     }
   return NULL;
+}
+
+bool
+CommandLineParser::
+ValidateFlag(const std::string & currentFlag)
+{
+  bool validFlagFound = false;
+  for( OptionListType::const_iterator it = this->m_Options.begin(); it != this->m_Options.end(); ++it )
+    {
+    const char shortName = (*it)->GetShortName();
+    const std::string longName  = (*it)->GetLongName();
+    if( ( currentFlag.size() == 1 && shortName == currentFlag[0] ) || (longName == currentFlag ) )
+      {
+      validFlagFound = true;
+      }
+    }
+  if ( ! validFlagFound )
+    {
+    std::cout << "ERROR:  Invalid flag provided " << currentFlag << std::endl;
+    }
+  return validFlagFound;
 }
 
 void

--- a/Utilities/antsCommandLineParser.h
+++ b/Utilities/antsCommandLineParser.h
@@ -81,7 +81,8 @@ public:
   OptionType::Pointer GetOption( std::string );
 
   bool starts_with( const std::string &, const std::string & );
-  void Parse( unsigned int, char * * );
+  int Parse( unsigned int, char * * );
+  bool ValidateFlag(const std::string & currentFlag);
 
   void AddOption( OptionType::Pointer );
 


### PR DESCRIPTION
If a minor command line typo is made, it was easy to have days of processing occur without realizing that the intended behavior was not occuring due to a command line option not changing the behavior.
