### PR TITLE
COMP: Silence GCC 4.9.1 warning.

### DIFF
--- a/Examples/ANTSIntegrateVectorField.cxx
+++ b/Examples/ANTSIntegrateVectorField.cxx
@@ -28,7 +28,6 @@ typename TImage::Pointer
 GetVectorComponent(typename TField::Pointer field, unsigned int index)
 {
   // Initialize the Moving to the displacement field
-  typedef TField FieldType;
   typedef TImage ImageType;
 
   typename ImageType::Pointer sfield = AllocImage<ImageType>(field);
@@ -106,10 +105,7 @@ float IntegrateLength( typename TImage::Pointer gmsurf,  typename TImage::Pointe
                        float starttime, const float deltaTime, typename TInterp::Pointer vinterp,
                        typename TImage::SpacingType spacing, float vecsign, float timesign, float gradsign )
 {
-  typedef   TField                                                 TimeVaryingVelocityFieldType;
   typedef typename TField::PixelType                               VectorType;
-  typedef itk::ImageRegionIteratorWithIndex<TField>                FieldIterator;
-  typedef typename TField::IndexType                               DIndexType;
   typedef typename TField::PointType                               DPointType;
   typedef itk::VectorLinearInterpolateImageFunction<TField, float> DefaultInterpolatorType;
 
@@ -286,10 +282,6 @@ int IntegrateVectorField(int argc, char *argv[])
   typedef itk::Vector<float, ImageDimension>     VectorType;
   typedef itk::Image<VectorType, ImageDimension> DisplacementFieldType;
   typedef itk::Image<PixelType, ImageDimension>  ImageType;
-  typedef itk::ImageFileReader<ImageType>        readertype;
-  typedef itk::ImageFileWriter<ImageType>        writertype;
-  typedef typename  ImageType::IndexType         IndexType;
-  typedef typename  ImageType::SizeType          SizeType;
   typedef typename  ImageType::SpacingType       SpacingType;
 
   const float deltaTime = 0.001;
@@ -333,13 +325,8 @@ int IntegrateVectorField(int argc, char *argv[])
     timesign = -1.0;
     }
   typedef   DisplacementFieldType                                                        TimeVaryingVelocityFieldType;
-  typedef itk::ImageRegionIteratorWithIndex<DisplacementFieldType>                       FieldIterator;
-  typedef typename DisplacementFieldType::IndexType                                      DIndexType;
   typedef typename DisplacementFieldType::PointType                                      DPointType;
-  typedef typename TimeVaryingVelocityFieldType::IndexType                               VIndexType;
-  typedef typename TimeVaryingVelocityFieldType::PointType                               VPointType;
   typedef itk::VectorLinearInterpolateImageFunction<TimeVaryingVelocityFieldType, float> DefaultInterpolatorType;
-  typedef itk::VectorLinearInterpolateImageFunction<DisplacementFieldType, float>        DefaultInterpolatorType2;
   typename DefaultInterpolatorType::Pointer vinterp =  DefaultInterpolatorType::New();
   typedef itk::LinearInterpolateImageFunction<ImageType, float> ScalarInterpolatorType;
   VectorType zero;

--- a/Examples/ANTSIntegrateVelocityField.cxx
+++ b/Examples/ANTSIntegrateVelocityField.cxx
@@ -63,14 +63,10 @@ int IntegrateVelocityField(int argc, char *argv[])
   typedef itk::Image<VectorType, ImageDimension>      DisplacementFieldType;
   typedef itk::Image<VectorType, ImageDimension + 1>  TimeVaryingVelocityFieldType;
   typedef itk::Image<PixelType, ImageDimension>       ImageType;
-  typedef typename  ImageType::IndexType              IndexType;
-  typedef typename  ImageType::SizeType               SizeType;
-  typedef typename  ImageType::SpacingType            SpacingType;
-  typedef TimeVaryingVelocityFieldType                tvt;
-  typedef itk::ImageFileReader<tvt>                   readertype;
-  typedef itk::ImageFileWriter<DisplacementFieldType> writertype;
+
   typename ImageType::Pointer image;
   ReadImage<ImageType>(image, imgfn.c_str() );
+  typedef TimeVaryingVelocityFieldType                tvt;
   typename tvt::Pointer timeVaryingVelocity;
   ReadImage<tvt>(timeVaryingVelocity, vectorfn.c_str() );
 
@@ -83,12 +79,6 @@ int IntegrateVelocityField(int argc, char *argv[])
     {
     std::cerr << " No TV Field " << std::endl;  return EXIT_FAILURE;
     }
-  typedef itk::ImageRegionIteratorWithIndex<DisplacementFieldType> FieldIterator;
-  typedef itk::ImageRegionIteratorWithIndex<tvt>                   TVFieldIterator;
-  typedef typename DisplacementFieldType::IndexType                DIndexType;
-  typedef typename DisplacementFieldType::PointType                DPointType;
-  typedef typename TimeVaryingVelocityFieldType::IndexType         VIndexType;
-  typedef typename TimeVaryingVelocityFieldType::PointType         VPointType;
 
   if( starttime < 0 )
     {

--- a/Examples/ANTSJacobian.cxx
+++ b/Examples/ANTSJacobian.cxx
@@ -264,7 +264,6 @@ ComputeJacobian(TDisplacementField* field, char* fnm, char* maskfn, bool uselog 
   unsigned int posoff = 1;
   float        space = 1.0;
 
-  typedef itk::Vector<float, ImageDimension> VectorType;
 
   typename FieldType::PixelType dPix;
   typename FieldType::PixelType lpix;
@@ -501,12 +500,6 @@ int Jacobian(int argc, char *argv[])
   typedef itk::Vector<float, ImageDimension>                     VectorType;
   typedef itk::Image<VectorType, ImageDimension>                 FieldType;
   typedef itk::Image<PixelType, ImageDimension>                  ImageType;
-  typedef itk::ImageFileReader<ImageType>                        readertype;
-  typedef itk::ImageFileWriter<ImageType>                        writertype;
-  typedef typename  ImageType::IndexType                         IndexType;
-  typedef typename  ImageType::SizeType                          SizeType;
-  typedef typename  ImageType::SpacingType                       SpacingType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double> InterpolatorType;
 
   typedef itk::ImageFileReader<FieldType> ReaderType;
   // std::cout << "read warp " << std::string(argv[1]) << std::endl;

--- a/Examples/ANTSUseDeformationFieldToGetAffineTransform.cxx
+++ b/Examples/ANTSUseDeformationFieldToGetAffineTransform.cxx
@@ -202,7 +202,6 @@ void GetRigidTransformFromTwoPointSets3D(PointContainerType & fixedLandmarks, Po
   const unsigned int Dimension = 3;
   typedef itk::Image<PixelType, Dimension> FixedImageType;
   typedef itk::Image<PixelType, Dimension> MovingImageType;
-  typedef itk::Image<PixelType, Dimension> ImageType;
 
   typedef itk::LandmarkBasedTransformInitializer<TransformType,
                                                  FixedImageType, MovingImageType> TransformInitializerType;
@@ -233,7 +232,6 @@ void FetchLandmarkMappingFromDisplacementField(const std::string& deformation_fi
 
   typedef typename PointContainerType::value_type PointType;
 
-  typedef itk::Image<float, ImageDimension>           ImageType;
   typedef itk::Vector<float, ImageDimension>          VectorType;
   typedef itk::Image<VectorType, ImageDimension>      DisplacementFieldType;
   typedef itk::ImageFileReader<DisplacementFieldType> FieldReaderType;

--- a/Examples/ClusterImageStatistics.cxx
+++ b/Examples/ClusterImageStatistics.cxx
@@ -47,24 +47,11 @@ int  ClusterStatistics(unsigned int argc, char *argv[])
 {
   typedef float PixelType;
 //  const unsigned int ImageDimension = AvantsImageDimension;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   // typedef itk::ImageRegionIteratorWithIndex<ImageType> Iterator;
 
-  typedef float                                                            InternalPixelType;
   typedef unsigned long                                                    ULPixelType;
   typedef itk::Image<ULPixelType, ImageDimension>                          labelimagetype;
-  typedef ImageType                                                        InternalImageType;
-  typedef ImageType                                                        OutputImageType;
   typedef itk::ConnectedComponentImageFilter<ImageType, labelimagetype>    FilterType;
   typedef itk::RelabelComponentImageFilter<labelimagetype, labelimagetype> RelabelType;
 

--- a/Examples/CompositeTransformUtil.cxx
+++ b/Examples/CompositeTransformUtil.cxx
@@ -53,7 +53,6 @@ Disassemble(itk::TransformBaseTemplate<double> *transform, const std::string & t
   typedef itk::CompositeTransform<double, VImageDimension>                  CompositeTransformType;
   typedef typename CompositeTransformType::TransformTypePointer             TransformPointer;
   typedef typename itk::DisplacementFieldTransform<double, VImageDimension> DisplacementFieldTransformType;
-  typedef typename DisplacementFieldTransformType::DisplacementFieldType    DisplacementFieldType;
 
   CompositeTransformType *composite = dynamic_cast<CompositeTransformType *>(transform);
   if( composite == 0 )

--- a/Examples/ConvertScalarImageToRGB.cxx
+++ b/Examples/ConvertScalarImageToRGB.cxx
@@ -35,13 +35,11 @@ namespace ants
 template <unsigned int ImageDimension>
 int ConvertScalarImageToRGB( int argc, char *argv[] )
 {
-  typedef unsigned int                 PixelType;
   typedef itk::RGBPixel<unsigned char> RGBPixelType;
 //  typedef itk::RGBAPixel<unsigned char> RGBPixelType;
 
   typedef float RealType;
 
-  typedef itk::Image<PixelType, ImageDimension>    ImageType;
   typedef itk::Image<float, ImageDimension>        RealImageType;
   typedef itk::Image<RGBPixelType, ImageDimension> RGBImageType;
 

--- a/Examples/CopyImageHeaderInformation.cxx
+++ b/Examples/CopyImageHeaderInformation.cxx
@@ -35,14 +35,9 @@ namespace ants
 template <unsigned int ImageDimension>
 int CopyImageHeaderInformation(int argc, char *argv[])
 {
-  typedef  float                                     outPixelType;
-  typedef  float                                     floatPixelType;
   typedef  float                                     inPixelType;
   typedef itk::Image<inPixelType, ImageDimension>    ImageType;
-  typedef itk::Image<floatPixelType, ImageDimension> IntermediateType;
-  typedef itk::Image<outPixelType, ImageDimension>   OutImageType;
   typedef itk::ImageFileReader<ImageType>            readertype;
-  typedef itk::ImageFileWriter<OutImageType>         writertype;
 
   typename readertype::Pointer reader = readertype::New();
   reader->SetFileName(argv[1]);

--- a/Examples/DeNrrd.cxx
+++ b/Examples/DeNrrd.cxx
@@ -109,8 +109,6 @@ private:
 
   typedef float                             PixelType;
   typedef itk::VectorImage<PixelType,3>	    DiffusionImageType;
-  typedef DiffusionImageType::Pointer	    DiffusionImagePointer;
-  typedef itk::Image<PixelType,4>           OutputImageType;
 
   typedef itk::ImageFileReader<DiffusionImageType,
   itk::DefaultConvertPixelTraits< PixelType > > FileReaderType;

--- a/Examples/ImageMath.cxx
+++ b/Examples/ImageMath.cxx
@@ -261,15 +261,7 @@ void ClosestSimplifiedHeaderMatrix(int argc, char *argv[])
     std::cout << " need more args -- see usage   " << std::endl;
     }
   typedef float                                        PixelType;
-  typedef itk::Vector<float, ImageDimension>           VectorType;
-  typedef itk::Image<VectorType, ImageDimension>       FieldType;
   typedef itk::Image<PixelType, ImageDimension>        ImageType;
-  typedef itk::ImageFileReader<ImageType>              readertype;
-  typedef itk::ImageFileWriter<ImageType>              writertype;
-  typedef typename ImageType::IndexType                IndexType;
-  typedef typename ImageType::SizeType                 SizeType;
-  typedef typename ImageType::SpacingType              SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension> AffineTransformType;
   typedef double RealType;
   typedef itk::Matrix<RealType, ImageDimension, ImageDimension>                           MatrixType;
   int               argct = 2;
@@ -314,14 +306,7 @@ void ReflectionMatrix(int argc, char *argv[])
     std::cout << " need more args -- see usage   " << std::endl;
     }
   typedef float                                        PixelType;
-  typedef itk::Vector<float, ImageDimension>           VectorType;
-  typedef itk::Image<VectorType, ImageDimension>       FieldType;
   typedef itk::Image<PixelType, ImageDimension>        ImageType;
-  typedef itk::ImageFileReader<ImageType>              readertype;
-  typedef itk::ImageFileWriter<ImageType>              writertype;
-  typedef typename ImageType::IndexType                IndexType;
-  typedef typename ImageType::SizeType                 SizeType;
-  typedef typename ImageType::SpacingType              SpacingType;
   typedef itk::AffineTransform<double, ImageDimension> AffineTransformType;
   int               argct = 2;
   const std::string outname = std::string(argv[argct]);
@@ -373,17 +358,7 @@ template <unsigned int ImageDimension>
 int GetLargestComponent(int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
@@ -406,12 +381,8 @@ int GetLargestComponent(int argc, char *argv[])
     volumeelement *= spacing[i];
     }
 
-  typedef float InternalPixelType;
-  //  typedef unsigned long PixelType;
-  //  typedef Image<PixelType,ImageDimension>  labelimagetype;
   typedef itk::Image<unsigned long, ImageDimension>                          labelimagetype;
   typedef ImageType                                                          InternalImageType;
-  typedef ImageType                                                          OutputImageType;
   typedef itk::BinaryThresholdImageFilter<InternalImageType, labelimagetype> ThresholdFilterType;
   typedef itk::ConnectedComponentImageFilter<labelimagetype, labelimagetype> FilterType;
   typedef itk::RelabelComponentImageFilter<labelimagetype, ImageType>        RelabelType;
@@ -526,22 +497,10 @@ template <unsigned int ImageDimension>
 int ClusterThresholdVariate(int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   typedef unsigned long                                                    ULPixelType;
   typedef itk::Image<ULPixelType, ImageDimension>                          labelimagetype;
-  typedef ImageType                                                        InternalImageType;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                     fIterator;
   typedef itk::ImageRegionIteratorWithIndex<labelimagetype>                labIterator;
   typedef itk::ConnectedComponentImageFilter<ImageType, labelimagetype>    FilterType;
@@ -651,19 +610,8 @@ int ExtractSlice(int argc, char *argv[])
     return 1;
     }
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
   typedef itk::Image<PixelType, ImageDimension - 1>                       OutImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
   const std::string outname = std::string(argv[argct]);
@@ -675,8 +623,6 @@ int ExtractSlice(int argc, char *argv[])
   typename OutImageType::Pointer outimage = NULL;
 
   typedef itk::ExtractImageFilter<ImageType, OutImageType> ExtractFilterType;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>     ImageIt;
-  typedef itk::ImageRegionIteratorWithIndex<OutImageType>  SliceIt;
 
   if( fn1.length() > 3 )
     {
@@ -736,17 +682,7 @@ template <unsigned int ImageDimension>
 int Finite(int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
@@ -781,17 +717,7 @@ template <unsigned int ImageDimension>
 int ThresholdAtMean(int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
@@ -846,17 +772,7 @@ template <unsigned int ImageDimension>
 int FlattenImage(int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
@@ -1049,16 +965,7 @@ template <unsigned int ImageDimension>
 int TileImages(unsigned int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
@@ -1224,17 +1131,8 @@ template <unsigned int ImageDimension>
 int TriPlanarView(unsigned int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
   typedef itk::Image<PixelType, 2>                                        MatrixImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   unsigned int argct = 2;
@@ -1399,17 +1297,8 @@ template <unsigned int ImageDimension>
 int ConvertVectorToImage(unsigned int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
   typedef itk::Image<PixelType, 2>                                        MatrixImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
   typedef itk::ImageRegionIteratorWithIndex<MatrixImageType>              vIterator;
 
@@ -1466,17 +1355,7 @@ template <unsigned int ImageDimension>
 int CorruptImage(int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
@@ -1525,17 +1404,7 @@ template <unsigned int ImageDimension>
 int Where(int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int         argct = 4;
@@ -1590,18 +1459,7 @@ template <unsigned int ImageDimension>
 int SetOrGetPixel(int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
   const std::string outname = std::string(argv[argct]);
@@ -1752,7 +1610,6 @@ int RescaleImage( int argc, char * argv[] )
 
   typedef float                                                  PixelType;
   typedef itk::Image<PixelType, ImageDimension>                  ImageType;
-  typedef itk::RescaleIntensityImageFilter<ImageType, ImageType> RescalerType;
 
   // Usage:  ImageMath 3 output.nii.gz RescaleImage input.nii.gz min max
 
@@ -1865,17 +1722,7 @@ template <unsigned int ImageDimension>
 int PadImage(int /*argc */, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
@@ -1975,8 +1822,6 @@ int SigmoidImage(int argc, char *argv[])
 {
   typedef float                                 PixelType;
   typedef itk::Image<PixelType, ImageDimension> ImageType;
-  typedef itk::ImageFileReader<ImageType>       ReaderType;
-  typedef itk::ImageFileWriter<ImageType>       WriterType;
 
   int               argct = 2;
   const std::string outname = std::string( argv[argct++] );
@@ -2024,8 +1869,6 @@ int SharpenImage(int argc, char *argv[])
 
   typedef float                                 PixelType;
   typedef itk::Image<PixelType, ImageDimension> ImageType;
-  typedef itk::ImageFileReader<ImageType>       ReaderType;
-  typedef itk::ImageFileWriter<ImageType>       WriterType;
 
   const std::string outputFilename = std::string( argv[2] );
   const std::string inputFilename = std::string( argv[4] );
@@ -2047,11 +1890,6 @@ int CenterImage2inImage1(int argc, char *argv[])
 {
   typedef float                                        PixelType;
   typedef itk::Image<PixelType, ImageDimension>        ImageType;
-  typedef itk::ImageFileReader<ImageType>              readertype;
-  typedef itk::ImageFileWriter<ImageType>              writertype;
-  typedef typename ImageType::IndexType                IndexType;
-  typedef typename ImageType::SizeType                 SizeType;
-  typedef typename ImageType::SpacingType              SpacingType;
   typedef itk::ImageRegionIteratorWithIndex<ImageType> Iterator;
 
   int               argct = 2;
@@ -2144,7 +1982,6 @@ int TimeSeriesMask( int argc, char *argv[] )
   typedef float                                            PixelType;
   typedef itk::Image<PixelType, ImageDimension>            ImageType;
   typedef itk::Image<PixelType, ImageDimension - 1>        MaskImageType;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>     TimeIterator;
   typedef itk::ImageRegionIteratorWithIndex<MaskImageType> Iterator;
 
   int               argct = 2;
@@ -2198,16 +2035,8 @@ int TimeSeriesDisassemble(int argc, char *argv[])
     }
 
   typedef float                                        PixelType;
-  typedef itk::Vector<float, ImageDimension>           VectorType;
-  typedef itk::Image<VectorType, ImageDimension>       FieldType;
   typedef itk::Image<PixelType, ImageDimension>        ImageType;
   typedef itk::Image<PixelType, ImageDimension - 1>    OutImageType;
-  typedef itk::ImageFileReader<ImageType>              readertype;
-  typedef itk::ImageFileWriter<ImageType>              writertype;
-  typedef typename ImageType::IndexType                IndexType;
-  typedef typename ImageType::SizeType                 SizeType;
-  typedef typename ImageType::SpacingType              SpacingType;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType> Iterator;
 
   int               argct = 2;
   const std::string outname = std::string(argv[argct]);
@@ -2218,8 +2047,6 @@ int TimeSeriesDisassemble(int argc, char *argv[])
   typename OutImageType::Pointer outimage = NULL;
 
   typedef itk::ExtractImageFilter<ImageType, OutImageType> ExtractFilterType;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>     ImageIt;
-  typedef itk::ImageRegionIteratorWithIndex<OutImageType>  SliceIt;
 
   if( fn1.length() > 3 )
     {
@@ -2284,12 +2111,6 @@ int TimeSeriesAssemble(int argc, char *argv[])
   typedef float                                        PixelType;
   typedef itk::Image<PixelType, ImageDimension - 1>    ImageType;
   typedef itk::Image<PixelType, ImageDimension>        OutImageType;
-  typedef itk::ImageFileReader<ImageType>              readertype;
-  typedef itk::ImageFileWriter<ImageType>              writertype;
-  typedef typename ImageType::IndexType                IndexType;
-  typedef typename ImageType::SizeType                 SizeType;
-  typedef typename ImageType::SpacingType              SpacingType;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType> Iterator;
 
   int               argct = 2;
   const std::string outname = std::string(argv[argct]);
@@ -2300,7 +2121,6 @@ int TimeSeriesAssemble(int argc, char *argv[])
   typename OutImageType::Pointer outimage = OutImageType::New();
 
   typedef itk::ImageRegionIteratorWithIndex<ImageType>    ImageIt;
-  typedef itk::ImageRegionIteratorWithIndex<OutImageType> SliceIt;
 
   std::cout << " Merging " << argc - 6 << " subvolumes " << std::endl;
   std::cout << " time spacing: " << time << std::endl;
@@ -2375,16 +2195,8 @@ int TimeSeriesSubset(int argc, char *argv[])
     }
 
   typedef float                                        PixelType;
-  typedef itk::Vector<float, ImageDimension>           VectorType;
-  typedef itk::Image<VectorType, ImageDimension>       FieldType;
   typedef itk::Image<PixelType, ImageDimension>        ImageType;
   typedef itk::Image<PixelType, ImageDimension - 1>    OutImageType;
-  typedef itk::ImageFileReader<ImageType>              readertype;
-  typedef itk::ImageFileWriter<ImageType>              writertype;
-  typedef typename ImageType::IndexType                IndexType;
-  typedef typename ImageType::SizeType                 SizeType;
-  typedef typename ImageType::SpacingType              SpacingType;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType> Iterator;
 
   int               argct = 2;
   const std::string outname = std::string(argv[argct]);
@@ -2401,8 +2213,6 @@ int TimeSeriesSubset(int argc, char *argv[])
   typename OutImageType::Pointer outimage = NULL;
 
   typedef itk::ExtractImageFilter<ImageType, OutImageType> ExtractFilterType;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>     ImageIt;
-  typedef itk::ImageRegionIteratorWithIndex<OutImageType>  SliceIt;
 
   if( fn1.length() > 3 )
     {
@@ -3319,17 +3129,10 @@ int ComputeTimeSeriesLeverage(int argc, char *argv[])
     return 1;
     }
   typedef float                                        PixelType;
-  typedef itk::Vector<float, ImageDimension>           VectorType;
-  typedef itk::Image<VectorType, ImageDimension>       FieldType;
   typedef itk::Image<PixelType, ImageDimension>        ImageType;
   typedef itk::Image<PixelType, ImageDimension - 1>    OutImageType;
   typedef typename OutImageType::IndexType             OutIndexType;
-  typedef itk::ImageFileReader<ImageType>              readertype;
-  typedef itk::ImageFileWriter<ImageType>              writertype;
   typedef typename ImageType::IndexType                IndexType;
-  typedef typename ImageType::SizeType                 SizeType;
-  typedef typename ImageType::SpacingType              SpacingType;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType> Iterator;
 
   typedef double                                            Scalar;
   typedef itk::ants::antsMatrixUtilities<ImageType, Scalar> matrixOpType;
@@ -3367,7 +3170,6 @@ int ComputeTimeSeriesLeverage(int argc, char *argv[])
   typename OutImageType::Pointer outimage = extractFilter->GetOutput();
   outimage->FillBuffer(0);
 
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>    ImageIt;
   typedef itk::ImageRegionIteratorWithIndex<OutImageType> SliceIt;
 
   // step 1.  compute , for each image in the time series, the effect on the average.
@@ -3460,18 +3262,11 @@ int TimeSeriesToMatrix(int argc, char *argv[])
     return 1;
     }
   typedef float                                        PixelType;
-  typedef itk::Vector<float, ImageDimension>           VectorType;
-  typedef itk::Image<VectorType, ImageDimension>       FieldType;
   typedef itk::Image<PixelType, ImageDimension>        ImageType;
   typedef itk::Image<PixelType, 2>                     MatrixImageType;
   typedef itk::Image<PixelType, ImageDimension - 1>    OutImageType;
   typedef typename OutImageType::IndexType             OutIndexType;
-  typedef itk::ImageFileReader<ImageType>              readertype;
-  typedef itk::ImageFileWriter<ImageType>              writertype;
   typedef typename ImageType::IndexType                IndexType;
-  typedef typename ImageType::SizeType                 SizeType;
-  typedef typename ImageType::SpacingType              SpacingType;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType> Iterator;
 
   typedef double                                            Scalar;
   typedef itk::ants::antsMatrixUtilities<ImageType, Scalar> matrixOpType;
@@ -3542,7 +3337,6 @@ int TimeSeriesToMatrix(int argc, char *argv[])
   typename OutImageType::Pointer outimage = extractFilter->GetOutput();
   outimage->FillBuffer(0);
 
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>    ImageIt;
   typedef itk::ImageRegionIteratorWithIndex<OutImageType> SliceIt;
 
   typedef vnl_vector<Scalar> timeVectorType;
@@ -3630,17 +3424,10 @@ int PASL(int argc, char *argv[])
     }
 
   typedef float                                        PixelType;
-  typedef itk::Vector<float, ImageDimension>           VectorType;
-  typedef itk::Image<VectorType, ImageDimension>       FieldType;
   typedef itk::Image<PixelType, ImageDimension>        ImageType;
   typedef itk::Image<PixelType, ImageDimension - 1>    OutImageType;
-  typedef itk::ImageFileReader<ImageType>              readertype;
-  typedef itk::ImageFileWriter<ImageType>              writertype;
   typedef typename ImageType::IndexType                IndexType;
   typedef typename OutImageType::IndexType             OutIndexType;
-  typedef typename ImageType::SizeType                 SizeType;
-  typedef typename ImageType::SpacingType              SpacingType;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType> Iterator;
   typedef double                                       RealType;
   typedef vnl_vector<RealType>                         timeVectorType;
   int               argct = 2;
@@ -3659,8 +3446,6 @@ int PASL(int argc, char *argv[])
   typename OutImageType::Pointer M0image = NULL;
 
   typedef itk::ExtractImageFilter<ImageType, OutImageType> ExtractFilterType;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>     ImageIt;
-  typedef itk::ImageRegionIteratorWithIndex<OutImageType>  SliceIt;
 
   // RealType M0W = 1300; // FIXME
   // RealType TE = 4000;
@@ -3832,17 +3617,10 @@ int pCASL(int argc, char *argv[])
     }
 
   typedef float                                        PixelType;
-  typedef itk::Vector<float, ImageDimension>           VectorType;
-  typedef itk::Image<VectorType, ImageDimension>       FieldType;
   typedef itk::Image<PixelType, ImageDimension>        ImageType;
   typedef itk::Image<PixelType, ImageDimension - 1>    OutImageType;
-  typedef itk::ImageFileReader<ImageType>              readertype;
-  typedef itk::ImageFileWriter<ImageType>              writertype;
   typedef typename ImageType::IndexType                IndexType;
   typedef typename OutImageType::IndexType             OutIndexType;
-  typedef typename ImageType::SizeType                 SizeType;
-  typedef typename ImageType::SpacingType              SpacingType;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType> Iterator;
   typedef double                                       RealType;
   typedef vnl_vector<RealType>                         timeVectorType;
   int               argct = 2;
@@ -3861,8 +3639,6 @@ int pCASL(int argc, char *argv[])
   typename OutImageType::Pointer M0image;
 
   typedef itk::ExtractImageFilter<ImageType, OutImageType> ExtractFilterType;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>     ImageIt;
-  typedef itk::ImageRegionIteratorWithIndex<OutImageType>  SliceIt;
 
   if( fn1.length() > 3 )
     {
@@ -4086,17 +3862,10 @@ int CompCorrAuto(int argc, char *argv[])
     }
 
   typedef float                                        PixelType;
-  typedef itk::Vector<float, ImageDimension>           VectorType;
-  typedef itk::Image<VectorType, ImageDimension>       FieldType;
   typedef itk::Image<PixelType, ImageDimension>        ImageType;
   typedef itk::Image<PixelType, ImageDimension - 1>    OutImageType;
   typedef typename OutImageType::IndexType             OutIndexType;
-  typedef itk::ImageFileReader<ImageType>              readertype;
-  typedef itk::ImageFileWriter<ImageType>              writertype;
   typedef typename ImageType::IndexType                IndexType;
-  typedef typename ImageType::SizeType                 SizeType;
-  typedef typename ImageType::SpacingType              SpacingType;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType> Iterator;
 
   typedef double                                            Scalar;
   typedef itk::ants::antsMatrixUtilities<ImageType, Scalar> matrixOpType;
@@ -4124,8 +3893,6 @@ int CompCorrAuto(int argc, char *argv[])
   typename OutImageType::Pointer label_image = NULL;
   typename OutImageType::Pointer var_image = NULL;
 
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>    ImageIt;
-  typedef itk::ImageRegionIteratorWithIndex<OutImageType> SliceIt;
 
   if( fn1.length() > 3 )
     {
@@ -4385,17 +4152,10 @@ int ThreeTissueConfounds(int argc, char *argv[])
     return 1;
     }
   typedef float                                        PixelType;
-  typedef itk::Vector<float, ImageDimension>           VectorType;
-  typedef itk::Image<VectorType, ImageDimension>       FieldType;
   typedef itk::Image<PixelType, ImageDimension>        ImageType;
   typedef itk::Image<PixelType, ImageDimension - 1>    OutImageType;
   typedef typename OutImageType::IndexType             OutIndexType;
-  typedef itk::ImageFileReader<ImageType>              readertype;
-  typedef itk::ImageFileWriter<ImageType>              writertype;
   typedef typename ImageType::IndexType                IndexType;
-  typedef typename ImageType::SizeType                 SizeType;
-  typedef typename ImageType::SpacingType              SpacingType;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType> Iterator;
 
   typedef double                                            Scalar;
   typedef itk::ants::antsMatrixUtilities<ImageType, Scalar> matrixOpType;
@@ -4429,8 +4189,6 @@ int ThreeTissueConfounds(int argc, char *argv[])
   typename OutImageType::Pointer label_image = NULL;
   typename OutImageType::Pointer var_image = NULL;
 
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>    ImageIt;
-  typedef itk::ImageRegionIteratorWithIndex<OutImageType> SliceIt;
 
   if( fn1.length() > 3 )
     {
@@ -4760,17 +4518,7 @@ int StackImage(int argc, char *argv[])
     return 1;
     }
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
@@ -4853,18 +4601,7 @@ int Stack2Images(int argc, char *argv[])
     return 1;
     }
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
   const std::string outname = std::string(argv[argct]);
@@ -4908,18 +4645,7 @@ template <unsigned int ImageDimension>
 int MakeImage(int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
   const std::string outname = std::string(argv[argct]);
@@ -5324,17 +5050,8 @@ int ImageMath(int argc, char *argv[])
 {
   typedef float PixelType;
   //  const unsigned int ImageDimension = AvantsImageDimension;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
   typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
@@ -5512,14 +5229,7 @@ int VImageMath(int argc, char *argv[])
   typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef FieldType                                                       ImageType;
   typedef typename ImageType::PixelType                                   PixelType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
   typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
@@ -5689,15 +5399,11 @@ int TensorFunctions(int argc, char *argv[])
   typedef typename TensorImageType::IndexType                IndexType;
   typedef itk::Image<PixelType, ImageDimension>              ImageType;
   typedef itk::Image<RGBType, ImageDimension>                ColorImageType;
-  typedef itk::ImageFileReader<ImageType>                    readertype;
-  typedef itk::ImageFileWriter<ImageType>                    writertype;
   typedef itk::ImageFileWriter<ColorImageType>               ColorWriterType;
   typedef itk::ImageRegionIteratorWithIndex<TensorImageType> Iterator;
 
   typedef itk::Vector<float, ImageDimension>                 VectorType;
   typedef itk::Image<VectorType, ImageDimension>             VectorImageType;
-  typedef itk::ImageRegionIteratorWithIndex<VectorImageType> vecIterator;
-  typedef itk::Matrix<float, 3, 3>                           MatrixType;
 
   int               argct = 2;
   const std::string outname = std::string(argv[argct]); argct++;
@@ -6235,17 +5941,8 @@ int CompareHeadersAndImages(int argc, char *argv[])
 {
   typedef float PixelType;
   //  const unsigned int ImageDimension = AvantsImageDimension;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
   typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
@@ -6930,17 +6627,8 @@ template <unsigned int ImageDimension>
 int NegativeImage(int /*argc */, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
   typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
@@ -7605,18 +7293,7 @@ template <unsigned int ImageDimension>
 int SmoothImage(int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
   const std::string outname = std::string(argv[argct]);
@@ -7674,18 +7351,7 @@ template <unsigned int ImageDimension>
 int MorphImage(int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
   const std::string outname = std::string(argv[argct]); argct++;
@@ -7750,14 +7416,6 @@ int MorphImage(int argc, char *argv[])
 template <unsigned int ImageDimension>
 int FastMarchingSegmentation( unsigned int argc, char *argv[] )
 {
-  typedef float                                         InternalPixelType;
-  typedef itk::Image<InternalPixelType, ImageDimension> InternalImageType;
-  typedef itk::Image<InternalPixelType, ImageDimension> ImageType;
-
-  typedef unsigned char                               OutputPixelType;
-  typedef itk::Image<OutputPixelType, ImageDimension> OutputImageType;
-
-  //  option->SetUsageOption( 0, "[speedImage,seedImage,<stoppingValue=max>,<topologyCheck=0>]" );
   unsigned int      argct = 2;
   const std::string outname = std::string(argv[argct]);
   std::cout << outname << argc << " This function has been disabled --- see PropagateLabelsThroughMask " << std::endl;
@@ -7769,17 +7427,7 @@ template <unsigned int ImageDimension>
 int PropagateLabelsThroughMask(int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
   float             thresh = 0.5;
   int               argct = 2;
@@ -7949,17 +7597,7 @@ template <unsigned int ImageDimension>
 int itkPropagateLabelsThroughMask(int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
   float             thresh = 1.e-9;
   int               argct = 2;
@@ -8059,7 +7697,6 @@ int itkPropagateLabelsThroughMask(int argc, char *argv[])
       }
     typedef typename FastMarchingFilterType::NodePairContainerType NodeContainer;
     typedef typename FastMarchingFilterType::NodePairType      NodePairType;
-    typedef typename FastMarchingFilterType::NodeType      NodeType;
     typename NodeContainer::Pointer seeds = NodeContainer::New();
     seeds->Initialize();
     typename NodeContainer::Pointer alivePoints = NodeContainer::New();
@@ -8125,18 +7762,7 @@ template <unsigned int ImageDimension>
 int DistanceMap(int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int argct = 2;
   if( argc < 5 )
@@ -8212,19 +7838,8 @@ template <unsigned int ImageDimension>
 int FillHoles(int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
   typedef itk::Image<int, ImageDimension>                                 LabelImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
   typedef itk::CastImageFilter<ImageType, LabelImageType>                 CastFilterType;
 
   int               argct = 2;
@@ -8384,17 +7999,7 @@ template <unsigned int ImageDimension>
 int NormalizeImage(int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
@@ -8457,14 +8062,8 @@ int NormalizeImage(int argc, char *argv[])
 template <unsigned int ImageDimension>
 int PrintHeader(int argc, char *argv[])
 {
-  typedef  float                                     outPixelType;
-  typedef  float                                     floatPixelType;
   typedef  float                                     inPixelType;
   typedef itk::Image<inPixelType, ImageDimension>    ImageType;
-  typedef itk::Image<floatPixelType, ImageDimension> IntermediateType;
-  typedef itk::Image<outPixelType, ImageDimension>   OutImageType;
-  typedef itk::ImageFileReader<ImageType>            readertype;
-  typedef itk::ImageFileWriter<OutImageType>         writertype;
 
   int         argct = 4;
   std::string fn1 = std::string(argv[argct]);
@@ -8497,18 +8096,7 @@ template <unsigned int ImageDimension>
 int GradientImage(      int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
   const std::string outname = std::string(argv[argct]);
@@ -8561,18 +8149,7 @@ template <unsigned int ImageDimension>
 int LaplacianImage(      int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
   const std::string outname = std::string(argv[argct]);
@@ -8777,18 +8354,7 @@ RemoveLabelInterfaces(int argc, char *argv[])
     std::cout << " too few options " << std::endl; return;
     }
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
   const std::string outname = std::string(argv[argct]);
@@ -8888,17 +8454,7 @@ void
 EnumerateLabelInterfaces(int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
@@ -8959,7 +8515,6 @@ EnumerateLabelInterfaces(int argc, char *argv[])
   typename myInterfaceImageType::Pointer colorimage =
     AllocImage<myInterfaceImageType>(region, spacing, origin, direction, 0);
 
-  typedef itk::ImageRegionIteratorWithIndex<myInterfaceImageType> FIterator;
 
 // we can use this to compute a 4-coloring of the brain
 
@@ -9151,18 +8706,7 @@ template <unsigned int ImageDimension>
 int CountVoxelDifference(      int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::Image<unsigned char, ImageDimension>                       ByteImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ByteImageType>                             writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
@@ -9225,18 +8769,7 @@ template <unsigned int ImageDimension>
 int DiceAndMinDistSum(      int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::Image<unsigned char, ImageDimension>                       ByteImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ByteImageType>                             writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
@@ -9828,18 +9361,7 @@ template <unsigned int ImageDimension>
 int LabelStats(      int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::Image<unsigned char, ImageDimension>                       ByteImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ByteImageType>                             writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
@@ -10007,18 +9529,7 @@ template <unsigned int ImageDimension>
 int LabelThickness(      int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::Image<unsigned char, ImageDimension>                       ByteImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ByteImageType>                             writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
   if( argc < 5 )
     {
@@ -10226,18 +9737,7 @@ template <unsigned int ImageDimension>
 int ROIStatistics(      int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::Image<unsigned char, ImageDimension>                       ByteImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ByteImageType>                             writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   //  if(grade_list.find("Tim") == grade_list.end()) {  std::cout<<"Tim is not in the map!"<<endl; }
@@ -10586,19 +10086,8 @@ template <unsigned int ImageDimension>
 int ByteImage(      int /*argc */, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
   typedef itk::Image<unsigned char, ImageDimension>                       ByteImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ByteImageType>                             writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
   const std::string outname = std::string(argv[argct]);
@@ -10624,18 +10113,7 @@ template <unsigned int ImageDimension>
 int PValueImage(      int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::Image<unsigned char, ImageDimension>                       ByteImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
@@ -10692,17 +10170,8 @@ template <unsigned int ImageDimension>
 int ConvertImageSetToMatrix(unsigned int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
   typedef itk::Image<PixelType, 2>                                        MatrixImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int argct = 2;
@@ -10886,17 +10355,7 @@ template <unsigned int ImageDimension>
 int RandomlySampleImageSetToCSV(unsigned int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::Image<PixelType, 2>                                        MatrixImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRandomConstIteratorWithIndex<ImageType>               Iterator;
 
   int argct = 2;
@@ -10990,17 +10449,7 @@ template <unsigned int ImageDimension>
 int ConvertImageSetToEigenvectors(unsigned int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::Image<PixelType, 2>                                        MatrixImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int argct = 2;
@@ -11192,19 +10641,7 @@ template <unsigned int ImageDimension>
 int ConvertImageToFile(      int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::Image<unsigned char, ImageDimension>                       ByteImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
   int               argct = 2;
   const std::string outname = std::string(argv[argct]);
   argct += 2;
@@ -11255,19 +10692,7 @@ template <unsigned int ImageDimension>
 int CorrelationUpdate(      int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::Image<unsigned char, ImageDimension>                       ByteImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
   int               argct = 2;
   const std::string outname = std::string(argv[argct]);
   argct += 2;
@@ -11347,8 +10772,6 @@ int MajorityVoting( int argc, char *argv[] )
 {
   typedef int                                           PixelType;
   typedef itk::Image<PixelType, ImageDimension>         ImageType;
-  typedef itk::ImageFileReader<ImageType>               ImageReaderType;
-  typedef itk::ImageFileWriter<ImageType>               ImageWriterType;
   typedef itk::MinimumMaximumImageCalculator<ImageType> CalculatorType;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>  IteratorType;
 
@@ -11420,7 +10843,6 @@ int MostLikely( int argc, char *argv[] )
   typedef float                                               PixelType;
   typedef itk::Image<PixelType, ImageDimension>               ImageType;
   typedef itk::Image<int, ImageDimension>                     LabeledImageType;
-  typedef itk::MinimumMaximumImageCalculator<ImageType>       CalculatorType;
   typedef itk::ImageRegionIteratorWithIndex<LabeledImageType> IteratorType;
 
   if( argc < 5 )
@@ -11484,7 +10906,6 @@ int STAPLE( int argc, char *argv[] )
   typedef itk::Image<float, ImageDimension>     OutputImageType;
 
   typedef itk::MinimumMaximumImageCalculator<ImageType>      CalculatorType;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>       IteratorType;
   typedef itk::STAPLEImageFilter<ImageType, OutputImageType> StapleFilterType;
 
   if( argc < 5 )
@@ -11626,9 +11047,6 @@ int CorrelationVoting( int argc, char *argv[] )
   typedef int                                                LabelType;
   typedef itk::Image<PixelType, ImageDimension>              ImageType;
   typedef itk::Image<LabelType, ImageDimension>              LabelImageType;
-  typedef itk::ImageFileReader<ImageType>                    ImageReaderType;
-  typedef itk::ImageFileReader<LabelImageType>               LabelImageReaderType;
-  typedef itk::ImageFileWriter<LabelImageType>               LabelImageWriterType;
   typedef itk::MinimumMaximumImageCalculator<LabelImageType> CalculatorType;
   typedef itk::ImageRegionIteratorWithIndex<LabelImageType>  IteratorType;
   typedef itk::NeighborhoodIterator<ImageType>               NeighborhoodIteratorType;
@@ -12113,11 +11531,8 @@ int MinMaxMean( int argc, char *argv[] )
 {
   typedef float                                         PixelType;
   typedef itk::Image<PixelType, ImageDimension>         ImageType;
-  typedef itk::ImageFileReader<ImageType>               ImageReaderType;
-  typedef itk::ImageFileWriter<ImageType>               ImageWriterType;
   typedef itk::MinimumMaximumImageCalculator<ImageType> CalculatorType;
   typedef itk::ImageMomentsCalculator<ImageType>        MomentsCalculatorType;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>  IteratorType;
 
   if( argc < 5 )
     {
@@ -12359,7 +11774,6 @@ int PureTissueN4WeightMask( int argc, char *argv[] )
   typedef float PixelType;
 
   typedef itk::Image<PixelType, ImageDimension> ImageType;
-  typedef itk::ImageFileReader<ImageType>       ReaderType;
 
   std::vector<typename ImageType::Pointer> images;
   for( int n = 4; n < argc; n++ )
@@ -12405,18 +11819,7 @@ template <unsigned int ImageDimension>
 int PMSmoothImage(int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   int               argct = 2;
   const std::string outname = std::string(argv[argct]);
@@ -12463,17 +11866,7 @@ template <unsigned int ImageDimension>
 int InPaint(int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
   int               argct = 2;
   const std::string outname = std::string(argv[argct]);
@@ -12589,17 +11982,7 @@ int InPaint2(int argc, char *argv[])
 {
   //  I_t = \nabla ( \Delta I ) \cdot N   where N is \perpto the normal direction
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
   int               argct = 2;
   const std::string outname = std::string(argv[argct]);
@@ -12734,9 +12117,7 @@ int Check3TissueLabeling( int argc, char *argv[] )
   const unsigned int NumberOfLabels = 3;
 
   typedef itk::Image<PixelType, ImageDimension> ImageType;
-  typedef itk::ImageFileReader<ImageType>       ReaderType;
   typedef itk::Image<LabelType, ImageDimension> LabelImageType;
-  typedef itk::ImageFileReader<LabelImageType>  LabelReaderType;
 
   typename LabelImageType::Pointer labelImage;
   ReadImage<LabelImageType>( labelImage, argv[2] );
@@ -12938,12 +12319,6 @@ void getBlobCorrespondenceMatrix( unsigned int radval, typename TImage::Pointer 
   typedef float                                                                   PixelType;
   typedef float                                                                   RealType;
   typedef itk::Image<PixelType, ImageDimension>                                   ImageType;
-  typedef itk::ImageFileReader<ImageType>                                         ImageReaderType;
-  typedef itk::ImageFileWriter<ImageType>                                         ImageWriterType;
-  typedef itk::MinimumMaximumImageCalculator<ImageType>                           CalculatorType;
-  typedef itk::ImageMomentsCalculator<ImageType>                                  MomentsCalculatorType;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>                            IteratorType;
-  typedef itk::SurfaceImageCurvature<ImageType>                                   ParamType;
   typedef itk::CovariantVector<RealType, ImageDimension>                          GradientPixelType;
   typedef itk::Image<GradientPixelType, ImageDimension>                           GradientImageType;
   typedef itk::SmartPointer<GradientImageType>                                    GradientImagePointer;
@@ -13063,17 +12438,7 @@ int BlobDetector( int argc, char *argv[] )
   typedef float                                                                   PixelType;
   typedef float                                                                   RealType;
   typedef itk::Image<PixelType, ImageDimension>                                   ImageType;
-  typedef itk::ImageFileReader<ImageType>                                         ImageReaderType;
-  typedef itk::ImageFileWriter<ImageType>                                         ImageWriterType;
-  typedef itk::MinimumMaximumImageCalculator<ImageType>                           CalculatorType;
-  typedef itk::ImageMomentsCalculator<ImageType>                                  MomentsCalculatorType;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>                            IteratorType;
-  typedef itk::SurfaceImageCurvature<ImageType>                                   ParamType;
-  typedef itk::CovariantVector<RealType, ImageDimension>                          GradientPixelType;
-  typedef itk::Image<GradientPixelType, ImageDimension>                           GradientImageType;
-  typedef itk::SmartPointer<GradientImageType>                                    GradientImagePointer;
-  typedef itk::GradientRecursiveGaussianImageFilter<ImageType, GradientImageType> GradientImageFilterType;
-  typedef typename GradientImageFilterType::Pointer                               GradientImageFilterPointer;
+
   if( argc < 5 )
     {
     std::cout << " Not enough inputs " << std::endl;
@@ -13321,15 +12686,7 @@ int MatchBlobs( int argc, char *argv[] )
   typedef float                                                      PixelType;
   typedef float                                                      RealType;
   typedef itk::Image<PixelType, ImageDimension>                      ImageType;
-  typedef itk::ImageFileReader<ImageType>                            ImageReaderType;
-  typedef itk::ImageFileWriter<ImageType>                            ImageWriterType;
-  typedef itk::MinimumMaximumImageCalculator<ImageType>              CalculatorType;
-  typedef itk::ImageMomentsCalculator<ImageType>                     MomentsCalculatorType;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>               IteratorType;
-  typedef itk::SurfaceImageCurvature<ImageType>                      ParamType;
-  typedef itk::CovariantVector<RealType, ImageDimension>             GradientPixelType;
-  typedef itk::Image<GradientPixelType, ImageDimension>              GradientImageType;
-  typedef itk::SmartPointer<GradientImageType>                       GradientImagePointer;
   typedef itk::MultiScaleLaplacianBlobDetectorImageFilter<ImageType> BlobFilterType;
   typedef typename BlobFilterType::BlobPointer                       BlobPointer;
   typedef typename BlobFilterType::BlobRadiusImageType               BlobRadiusImageType;

--- a/Examples/ImageSetStatistics.cxx
+++ b/Examples/ImageSetStatistics.cxx
@@ -627,17 +627,9 @@ template <unsigned int ImageDimension>
 int ImageSetStatistics(int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
   typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
   typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
   unsigned int mch = 0;
   int          argct = 2;

--- a/Examples/KellySlater.cxx
+++ b/Examples/KellySlater.cxx
@@ -39,7 +39,6 @@ typename TImage::Pointer
 GetVectorComponent(typename TField::Pointer field, unsigned int index)
 {
   // Initialize the Moving to the displacement field
-  typedef TField FieldType;
   typedef TImage ImageType;
 
   typename ImageType::Pointer sfield = AllocImage<ImageType>(field);
@@ -145,7 +144,6 @@ template <class TImage, class TDisplacementField>
 typename TImage::Pointer
 CopyImage(TDisplacementField* field )
 {
-  typedef TImage ImageType;
   enum { ImageDimension = TImage::ImageDimension };
   //  unsigned int row=0;
   // unsigned int col=0;
@@ -327,8 +325,6 @@ template <class TImage, class TField>
 typename TField::Pointer
 DiReCTCompose(typename TField::Pointer velofield, typename TField::Pointer diffmap )
 {
-  typedef TImage                     ImageType;
-  typedef TField                     DisplacementFieldType;
   typedef typename TField::PixelType PixelType;
   typename TField::PixelType zero, disp;
   enum { ImageDimension = TImage::ImageDimension };
@@ -368,7 +364,6 @@ InvertField( typename TField::Pointer field,
 
   typedef typename DisplacementFieldType::PixelType                VectorType;
   typedef typename DisplacementFieldType::IndexType                IndexType;
-  typedef typename VectorType::ValueType                           ScalarType;
   typedef itk::ImageRegionIteratorWithIndex<DisplacementFieldType> Iterator;
 
   typedef itk::ANTSImageRegistrationOptimizer<ImageDimension, double> ROType;
@@ -557,12 +552,7 @@ int LaplacianThicknessExpDiff2(int argc, char *argv[])
   typedef itk::Vector<RealType, ImageDimension>                         VectorType;
   typedef itk::Image<VectorType, ImageDimension>                        DisplacementFieldType;
   typedef itk::Image<PixelType, ImageDimension>                         ImageType;
-  typedef itk::ImageFileReader<ImageType>                               readertype;
-  typedef itk::ImageFileWriter<ImageType>                               writertype;
   typedef typename  ImageType::IndexType                                IndexType;
-  typedef typename  ImageType::SizeType                                 SizeType;
-  typedef typename  ImageType::SpacingType                              SpacingType;
-  typedef itk::Image<VectorType, ImageDimension + 1>                    tvt;
   typedef itk::ANTSImageRegistrationOptimizer<ImageDimension, RealType> ROType;
   typename ROType::Pointer m_MFR = ROType::New();
 
@@ -630,13 +620,8 @@ int LaplacianThicknessExpDiff2(int argc, char *argv[])
 
   typedef   DisplacementFieldType
     TimeVaryingVelocityFieldType;
-  typedef itk::ImageRegionIteratorWithIndex<DisplacementFieldType>                          FieldIterator;
-  typedef typename DisplacementFieldType::IndexType                                         DIndexType;
   typedef typename DisplacementFieldType::PointType                                         DPointType;
-  typedef typename TimeVaryingVelocityFieldType::IndexType                                  VIndexType;
-  typedef typename TimeVaryingVelocityFieldType::PointType                                  VPointType;
   typedef itk::VectorLinearInterpolateImageFunction<TimeVaryingVelocityFieldType, RealType> DefaultInterpolatorType;
-  typedef itk::VectorLinearInterpolateImageFunction<DisplacementFieldType, RealType>        DefaultInterpolatorType2;
   typename DefaultInterpolatorType::Pointer vinterp =  DefaultInterpolatorType::New();
   vinterp->SetInputImage(lapgrad);
   typedef itk::LinearInterpolateImageFunction<ImageType, RealType> ScalarInterpolatorType;

--- a/Examples/LabelClustersUniquely.cxx
+++ b/Examples/LabelClustersUniquely.cxx
@@ -45,28 +45,14 @@ template <unsigned int ImageDimension>
 int  LabelUniquely(int argc, char *argv[])
 {
   typedef float PixelType;
-//  const unsigned int ImageDimension = AvantsImageDimension;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
-  typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
-  // typedef itk::ImageRegionIteratorWithIndex<ImageType> Iterator;
 
-  typedef float                                            InternalPixelType;
+  typedef itk::Image<PixelType, ImageDimension>                           ImageType;
+
   typedef int                                              ULPixelType;
   typedef itk::Image<ULPixelType, ImageDimension>          labelimagetype;
   typedef itk::CastImageFilter<ImageType, labelimagetype>  CastFilterType;
   typedef itk::CastImageFilter< labelimagetype, ImageType> CastFilterType2;
 
-  typedef ImageType                                                          InternalImageType;
-  typedef ImageType                                                          OutputImageType;
   typedef itk::ConnectedComponentImageFilter<labelimagetype, labelimagetype> FilterType;
   typedef itk::RelabelComponentImageFilter<labelimagetype, labelimagetype>   RelabelType;
 

--- a/Examples/LaplacianThickness.cxx
+++ b/Examples/LaplacianThickness.cxx
@@ -25,7 +25,6 @@ typename TImage::Pointer
 GetVectorComponent(typename TField::Pointer field, unsigned int index)
 {
   // Initialize the Moving to the displacement field
-  typedef TField FieldType;
   typedef TImage ImageType;
 
   typename ImageType::Pointer sfield =
@@ -409,10 +408,7 @@ float IntegrateLength( typename TImage::Pointer /* gmsurf */,  typename TImage::
                        float priorthickval,  typename TImage::Pointer smooththick, bool printprobability,
                        typename TImage::Pointer /* sulci */ )
 {
-  typedef   TField                                                 TimeVaryingVelocityFieldType;
   typedef typename TField::PixelType                               VectorType;
-  typedef itk::ImageRegionIteratorWithIndex<TField>                FieldIterator;
-  typedef typename TField::IndexType                               DIndexType;
   typedef typename TField::PointType                               DPointType;
   typedef itk::VectorLinearInterpolateImageFunction<TField, float> DefaultInterpolatorType;
 
@@ -657,12 +653,7 @@ int LaplacianThickness(int argc, char *argv[])
   typedef itk::Vector<float, ImageDimension>         VectorType;
   typedef itk::Image<VectorType, ImageDimension>     DisplacementFieldType;
   typedef itk::Image<PixelType, ImageDimension>      ImageType;
-  typedef itk::ImageFileReader<ImageType>            readertype;
-  typedef itk::ImageFileWriter<ImageType>            writertype;
-  typedef typename  ImageType::IndexType             IndexType;
-  typedef typename  ImageType::SizeType              SizeType;
   typedef typename  ImageType::SpacingType           SpacingType;
-  typedef itk::Image<VectorType, ImageDimension + 1> tvt;
 
   //  typename tvt::Pointer gWarp;
   // ReadImage<tvt>( gWarp, ifn.c_str() );
@@ -778,13 +769,8 @@ int LaplacianThickness(int argc, char *argv[])
     }
   unsigned int m_NumberOfTimePoints = 2;
   typedef   DisplacementFieldType                                                        TimeVaryingVelocityFieldType;
-  typedef itk::ImageRegionIteratorWithIndex<DisplacementFieldType>                       FieldIterator;
-  typedef typename DisplacementFieldType::IndexType                                      DIndexType;
   typedef typename DisplacementFieldType::PointType                                      DPointType;
-  typedef typename TimeVaryingVelocityFieldType::IndexType                               VIndexType;
-  typedef typename TimeVaryingVelocityFieldType::PointType                               VPointType;
   typedef itk::VectorLinearInterpolateImageFunction<TimeVaryingVelocityFieldType, float> DefaultInterpolatorType;
-  typedef itk::VectorLinearInterpolateImageFunction<DisplacementFieldType, float>        DefaultInterpolatorType2;
   typename DefaultInterpolatorType::Pointer vinterp =  DefaultInterpolatorType::New();
   typedef itk::LinearInterpolateImageFunction<ImageType, float> ScalarInterpolatorType;
   typename ScalarInterpolatorType::Pointer sinterp =  ScalarInterpolatorType::New();

--- a/Examples/MeasureImageSimilarity.cxx
+++ b/Examples/MeasureImageSimilarity.cxx
@@ -38,14 +38,7 @@ int MeasureImageSimilarity(unsigned int argc, char *argv[])
   typedef itk::Image<PixelType, ImageDimension>                  ImageType;
   typedef itk::ImageFileWriter<ImageType>                        writertype;
   typedef typename ImageType::IndexType                          IndexType;
-  typedef typename ImageType::SizeType                           SizeType;
-  typedef typename ImageType::SpacingType                        SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>           AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double> InterpolatorType1;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>           Iterator;
-
-  typedef itk::Image<float, 2>                JointHistType;
-  typedef itk::ImageFileWriter<JointHistType> jhwritertype;
 
 // get command line params
   unsigned int argct = 2;

--- a/Examples/MeasureMinMaxMean.cxx
+++ b/Examples/MeasureMinMaxMean.cxx
@@ -27,14 +27,6 @@ int MeasureMinMaxMean(int argc, char *argv[])
 {
   typedef itk::Vector<float, NVectorComponents>                           PixelType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef typename ImageType::IndexType                                   IndexType;
-  typedef typename ImageType::SizeType                                    SizeType;
-  typedef typename ImageType::SpacingType                                 SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   typename ImageType::Pointer image = NULL;

--- a/Examples/MemoryTest.cxx
+++ b/Examples/MemoryTest.cxx
@@ -35,16 +35,7 @@ int MemoryTest(unsigned int argc, char *argv[])
   typedef itk::Vector<float, ImageDimension>                     VectorType;
   typedef itk::Image<VectorType, ImageDimension>                 FieldType;
   typedef itk::Image<PixelType, ImageDimension>                  ImageType;
-  typedef itk::ImageFileWriter<ImageType>                        writertype;
-  typedef typename ImageType::IndexType                          IndexType;
-  typedef typename ImageType::SizeType                           SizeType;
-  typedef typename ImageType::SpacingType                        SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>           AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double> InterpolatorType1;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>           Iterator;
-
-  typedef itk::Image<float, 2>                JointHistType;
-  typedef itk::ImageFileWriter<JointHistType> jhwritertype;
 
 // get command line params
   unsigned int argct = 2;
@@ -63,7 +54,6 @@ int MemoryTest(unsigned int argc, char *argv[])
   typename ImageType::Pointer image2 = NULL;
   ReadImage<ImageType>(image2, fn2.c_str() );
 
-  typedef itk::ImageRegionIteratorWithIndex<FieldType> VIterator;
   std::vector<typename FieldType::Pointer> fieldvec;
   for( unsigned int i = 0; i < numberoffields; i++ )
     {

--- a/Examples/PermuteFlipImageOrientationAxes.cxx
+++ b/Examples/PermuteFlipImageOrientationAxes.cxx
@@ -35,11 +35,9 @@ template <unsigned int Dimension>
 int PermuteFlipImageOrientationAxes( int argc, char * argv[] )
 {
   typedef   float InputPixelType;
-  typedef   float InternalPixelType;
   typedef   float OutputPixelType;
 
   typedef itk::Image<InputPixelType,    Dimension> InputImageType;
-  typedef itk::Image<InternalPixelType, Dimension> InternalImageType;
   typedef itk::Image<OutputPixelType,   Dimension> OutputImageType;
 
   typename InputImageType::Pointer inputImage = NULL;

--- a/Examples/PrintHeader.cxx
+++ b/Examples/PrintHeader.cxx
@@ -114,14 +114,9 @@ get_rai_code(itk::SpatialOrientation::ValidCoordinateOrientationFlags code)
 template <unsigned int ImageDimension>
 int PrintHeader(int argc, char *argv[])
 {
-  typedef  float                                     outPixelType;
-  typedef  float                                     floatPixelType;
   typedef  float                                     inPixelType;
   typedef itk::Image<inPixelType, ImageDimension>    ImageType;
-  typedef itk::Image<floatPixelType, ImageDimension> IntermediateType;
-  typedef itk::Image<outPixelType, ImageDimension>   OutImageType;
   typedef itk::ImageFileReader<ImageType>            readertype;
-  typedef itk::ImageFileWriter<OutImageType>         writertype;
 
   typename readertype::Pointer reader = readertype::New();
   if( argc < 2 )

--- a/Examples/RebaseTensorImage.cxx
+++ b/Examples/RebaseTensorImage.cxx
@@ -99,7 +99,6 @@ private:
   typedef itk::Image<PixelType, 3>       TensorImageType;
   typedef itk::Image<float, 3>           ImageType;
 
-  typedef itk::ImageFileReader<ImageType> ImageFileReaderType;
 
   // No reason to use log-euclidean space
   TensorImageType::Pointer img_mov;

--- a/Examples/ReorientTensorImage.cxx
+++ b/Examples/ReorientTensorImage.cxx
@@ -80,7 +80,6 @@ static bool ReorientTensorImage_ParseInput(int argc, char * *argv, char *& movin
 template <int ImageDimension>
 void ReorientTensorImage(char *moving_image_filename, char *output_image_filename, TRAN_OPT_QUEUE & opt_queue)
 {
-  typedef itk::DiffusionTensor3D<double>                                         TensorType;
   typedef itk::DiffusionTensor3D<double>                                         PixelType;
   typedef itk::Image<PixelType, ImageDimension>                                  TensorImageType;
   typedef itk::Image<float, ImageDimension>                                      ImageType;

--- a/Examples/ResampleImage.cxx
+++ b/Examples/ResampleImage.cxx
@@ -83,8 +83,6 @@ int ResampleImage( int argc, char *argv[] )
   typename Sinc3InterpolatorType::Pointer sl_interpolator = Sinc3InterpolatorType::New();
   sl_interpolator->SetInputImage( reader->GetOutput() );
 
-  typedef itk::WindowedSincInterpolateImageFunction<ImageType, 3,
-                                                    itk::Function::BlackmanWindowFunction<3> > Sinc4InterpolatorType;
   typename Sinc3InterpolatorType::Pointer sb_interpolator = Sinc3InterpolatorType::New();
   sb_interpolator->SetInputImage( reader->GetOutput() );
 

--- a/Examples/ResetDirection.cxx
+++ b/Examples/ResetDirection.cxx
@@ -46,10 +46,8 @@ int ResetDirection(int argc, char *argv[])
     }
 
   typedef  float                                     outPixelType;
-  typedef  float                                     floatPixelType;
   typedef  float                                     inPixelType;
   typedef itk::Image<inPixelType, ImageDimension>    ImageType;
-  typedef itk::Image<floatPixelType, ImageDimension> IntermediateType;
   typedef itk::Image<outPixelType, ImageDimension>   OutImageType;
   typedef itk::ImageFileReader<ImageType>            readertype;
   typedef itk::ImageFileWriter<OutImageType>         writertype;

--- a/Examples/SetDirectionByMatrix.cxx
+++ b/Examples/SetDirectionByMatrix.cxx
@@ -53,10 +53,8 @@ int ResetDirection(int argc, char *argv[])
     }
 
   typedef  float                                     outPixelType;
-  typedef  float                                     floatPixelType;
   typedef  float                                     inPixelType;
   typedef itk::Image<inPixelType, ImageDimension>    ImageType;
-  typedef itk::Image<floatPixelType, ImageDimension> IntermediateType;
   typedef itk::Image<outPixelType, ImageDimension>   OutImageType;
   typedef itk::ImageFileReader<ImageType>            readertype;
   typedef itk::ImageFileWriter<OutImageType>         writertype;

--- a/Examples/SetOrigin.cxx
+++ b/Examples/SetOrigin.cxx
@@ -35,10 +35,8 @@ template <unsigned int ImageDimension>
 int SetOrigin(int argc, char *argv[])
 {
   typedef  float                                     outPixelType;
-  typedef  float                                     floatPixelType;
   typedef  float                                     inPixelType;
   typedef itk::Image<inPixelType, ImageDimension>    ImageType;
-  typedef itk::Image<floatPixelType, ImageDimension> IntermediateType;
   typedef itk::Image<outPixelType, ImageDimension>   OutImageType;
   typedef itk::ImageFileReader<ImageType>            readertype;
   typedef itk::ImageFileWriter<OutImageType>         writertype;

--- a/Examples/SetSpacing.cxx
+++ b/Examples/SetSpacing.cxx
@@ -42,10 +42,8 @@ template <unsigned int ImageDimension>
 int SetSpacing(int argc, char *argv[])
 {
   typedef  float                                     outPixelType;
-  typedef  float                                     floatPixelType;
   typedef  float                                     inPixelType;
   typedef itk::Image<inPixelType, ImageDimension>    ImageType;
-  typedef itk::Image<floatPixelType, ImageDimension> IntermediateType;
   typedef itk::Image<outPixelType, ImageDimension>   OutImageType;
   typedef itk::ImageFileReader<ImageType>            readertype;
   typedef itk::ImageFileWriter<OutImageType>         writertype;

--- a/Examples/SmoothImage.cxx
+++ b/Examples/SmoothImage.cxx
@@ -29,18 +29,7 @@ template <unsigned int ImageDimension>
 int SmoothImage(int argc, char *argv[])
 {
   typedef float                                                           PixelType;
-  typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef itk::ImageFileReader<ImageType>                                 readertype;
-  typedef itk::ImageFileWriter<ImageType>                                 writertype;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
 
   std::vector<float> sigmaVector = ConvertVector<float>( argv[3] );
 

--- a/Examples/StackSlices.cxx
+++ b/Examples/StackSlices.cxx
@@ -93,12 +93,10 @@ private:
 
   typedef itk::ImageFileReader<ImageType> ReaderType;
   typedef itk::ImageFileReader<ImageSeriesType> Reader4DType;
-  typedef itk::ImageFileWriter<ImageType> WriterType;
 
   typedef itk::ExtractImageFilter<ImageType, SliceType> ExtractFilterType;
   typedef itk::ExtractImageFilter<ImageSeriesType, SliceType> ExtractFilterType2;
 
-  typedef itk::ImageRegionIteratorWithIndex<ImageType> ImageIt;
   typedef itk::ImageRegionIteratorWithIndex<SliceType> SliceIt;
 
   // Check for valid input parameters

--- a/Examples/SurfaceBasedSmoothing.cxx
+++ b/Examples/SurfaceBasedSmoothing.cxx
@@ -70,8 +70,6 @@ private:
   typedef itk::SurfaceImageCurvature<ImageType> ParamType;
   ParamType::Pointer Parameterizer = ParamType::New();
 
-  typedef  itk::ImageFileReader<ImageType> ReaderType;
-  typedef  ImageType::PixelType            PixType;
 
 //  std::string fn="C://Data//brain15labelimage.img";
   float opt = 0;

--- a/Examples/SurfaceCurvature.cxx
+++ b/Examples/SurfaceCurvature.cxx
@@ -125,7 +125,6 @@ private:
   enum { ImageDimension = ImageType::ImageDimension };
   typedef itk::SurfaceImageCurvature<ImageType> ParamType;
   ParamType::Pointer Parameterizer = ParamType::New();
-  typedef  ImageType::PixelType PixType;
 
   int   opt = 0;
   float sig = 1.0;

--- a/Examples/ThresholdImage.cxx
+++ b/Examples/ThresholdImage.cxx
@@ -155,7 +155,6 @@ typename TImage::Pointer OtsuThreshold(
 {
   std::cout << " Otsu Thresh with " << NumberOfThresholds << " thresholds" << std::endl;
 
-  typedef typename TImage::PixelType PixelType;
   // Begin Threshold Image
   typedef itk::OtsuMultipleThresholdsImageFilter<TImage, TImage> InputThresholderType;
   typename InputThresholderType::Pointer inputThresholder =

--- a/Examples/TimeSCCAN.cxx
+++ b/Examples/TimeSCCAN.cxx
@@ -266,8 +266,6 @@ bool RegionAveraging(typename NetworkType::Pointer network, typename NetworkType
 {
 
   typedef vnl_vector<float>                                     VectorType;
-  typedef VectorType*                                           VectorPointerType;
-  typedef itk::VectorContainer<unsigned int, VectorPointerType> VectorContainerType;
   typedef vnl_matrix<float>                                     MatrixType;
 
   // Determine the number of regions to examine
@@ -391,8 +389,6 @@ int timesccan( itk::ants::CommandLineParser *parser )
 {
 
   typedef itk::Image<float,2>               NetworkType;
-  typedef itk::ImageFileReader<NetworkType> NetworkReaderType;
-  typedef itk::ImageFileWriter<NetworkType> NetworkWriterType;
 
 
   std::string                                       outname = "output.nii.gz";

--- a/Examples/WarpTimeSeriesImageMultiTransform.cxx
+++ b/Examples/WarpTimeSeriesImageMultiTransform.cxx
@@ -243,7 +243,6 @@ void WarpImageMultiTransformFourD(char *moving_image_filename, char *output_imag
 
   itk::TransformFactory<AffineTransformType>::RegisterTransform();
 
-  typedef itk::ImageFileReader<ImageType> ImageFileReaderType;
 
   typename VectorImageType::Pointer img_mov;
 
@@ -256,8 +255,6 @@ void WarpImageMultiTransformFourD(char *moving_image_filename, char *output_imag
     }
 
   typedef itk::ExtractImageFilter<VectorImageType, ImageType> ExtractFilterType;
-  typedef itk::ImageRegionIteratorWithIndex<VectorImageType>  ImageIt;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>        SliceIt;
 
   // ORIENTATION ALERT -- the way this code sets up
   // transformedvecimage doesn't really make complete sense to me. In

--- a/Examples/antsAffineInitializer.cxx
+++ b/Examples/antsAffineInitializer.cxx
@@ -141,19 +141,9 @@ int antsAffineInitializerImp(int argc, char *argv[])
 
   typedef itk::TransformFileWriter                                        TransformWriterType;
   typedef itk::Vector<float, ImageDimension>                              VectorType;
-  typedef itk::Image<VectorType, ImageDimension>                          FieldType;
   typedef itk::Image<PixelType, ImageDimension>                           ImageType;
-  typedef  typename ImageType::IndexType                                  IndexType;
-  typedef  typename ImageType::SizeType                                   SizeType;
-  typedef  typename ImageType::SpacingType                                SpacingType;
-  typedef itk::AffineTransform<double, ImageDimension>                    AffineTransformType;
-  typedef itk::LinearInterpolateImageFunction<ImageType, double>          InterpolatorType1;
-  typedef itk::NearestNeighborInterpolateImageFunction<ImageType, double> InterpolatorType2;
-  typedef itk::ImageRegionIteratorWithIndex<ImageType>                    Iterator;
   typedef typename itk::ImageMomentsCalculator<ImageType>                 ImageCalculatorType;
   typedef itk::AffineTransform<RealType, ImageDimension>                  AffineType;
-  typedef itk::CompositeTransform<RealType, ImageDimension>               CompositeType;
-  typedef itk::AffineTransform<RealType>                                  EulerTransformType;
   typedef typename ImageCalculatorType::MatrixType                        MatrixType;
   if( argc < 2 )
     {
@@ -322,7 +312,6 @@ int antsAffineInitializerImp(int argc, char *argv[])
   affinesearch->SetIdentity();
   affinesearch->SetCenter( trans2 );
   typedef  itk::MultiStartOptimizerv4         OptimizerType;
-  typedef  typename OptimizerType::ScalesType ScalesType;
   typename OptimizerType::Pointer  mstartOptimizer = OptimizerType::New();
   typedef itk::MattesMutualInformationImageToImageMetricv4
     <ImageType, ImageType, ImageType> MetricType;

--- a/Examples/antsAlignOrigin.cxx
+++ b/Examples/antsAlignOrigin.cxx
@@ -35,9 +35,7 @@ int antsAlignOriginImplementation( itk::ants::CommandLineParser::Pointer & parse
     std::cerr << "inputImageType is not used, therefore only mode 0 is supported at the momemnt." << std::endl;
     return EXIT_FAILURE;
     }
-  typedef double                           RealType;
   typedef double                           PixelType;
-  typedef itk::Vector<RealType, Dimension> VectorType;
 
   typedef itk::Image<PixelType, Dimension> ImageType;
 
@@ -137,7 +135,6 @@ int antsAlignOriginImplementation( itk::ants::CommandLineParser::Pointer & parse
 
 static void InitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
 {
-  typedef itk::ants::CommandLineParser::OptionType OptionType;
 
     {
     std::string description =

--- a/Examples/antsApplyTransforms.cxx
+++ b/Examples/antsApplyTransforms.cxx
@@ -69,7 +69,6 @@ CorrectImageVectorDirection( DisplacementFieldType * movingVectorImage, ImageTyp
     movingVectorImage->GetDirection().GetTranspose() * referenceImage->GetDirection().GetVnlMatrix();
 
   typedef typename DisplacementFieldType::PixelType VectorType;
-  typedef typename VectorType::ComponentType        ComponentType;
 
   const unsigned int dimension = ImageType::ImageDimension;
 
@@ -127,7 +126,6 @@ int antsApplyTransforms( itk::ants::CommandLineParser::Pointer & parser, unsigne
   typedef typename ants::RegistrationHelper<T, Dimension>         RegistrationHelperType;
   typedef typename RegistrationHelperType::AffineTransformType    AffineTransformType;
   typedef typename RegistrationHelperType::CompositeTransformType CompositeTransformType;
-  typedef typename CompositeTransformType::TransformType          TransformType;
 
   typedef itk::SymmetricSecondRankTensor<RealType, Dimension> TensorPixelType;
   typedef itk::Image<TensorPixelType, Dimension>              TensorImageType;
@@ -593,7 +591,6 @@ int antsApplyTransforms( itk::ants::CommandLineParser::Pointer & parser, unsigne
 
 static void antsApplyTransformsInitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
 {
-  typedef itk::ants::CommandLineParser::OptionType OptionType;
 
     {
     std::string description =

--- a/Examples/antsApplyTransformsToPoints.cxx
+++ b/Examples/antsApplyTransformsToPoints.cxx
@@ -192,7 +192,6 @@ int antsApplyTransformsToPoints( itk::ants::CommandLineParser::Pointer & parser 
 
 static void antsApplyTransformsToPointsInitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
 {
-  typedef itk::ants::CommandLineParser::OptionType OptionType;
 
     {
     std::string description =

--- a/Examples/antsMotionCorr.cxx
+++ b/Examples/antsMotionCorr.cxx
@@ -169,7 +169,6 @@ typename ImageType::Pointer PreprocessImage( ImageType * inputImage,
   typedef itk::Statistics::ImageToHistogramFilter<ImageType>   HistogramFilterType;
   typedef typename HistogramFilterType::InputBooleanObjectType InputBooleanObjectType;
   typedef typename HistogramFilterType::HistogramSizeType      HistogramSizeType;
-  typedef typename HistogramFilterType::HistogramType          HistogramType;
 
   HistogramSizeType histogramSize( 1 );
   histogramSize[0] = 256;
@@ -390,7 +389,6 @@ AverageTimeImages( typename TImageIn::Pointer image_in,  typename TImageOut::Poi
   typedef TImageIn  ImageType;
   typedef TImageOut OutImageType;
   enum { ImageDimension = ImageType::ImageDimension };
-  typedef typename TImageIn::PixelType                    PixelType;
   typedef itk::ImageRegionIteratorWithIndex<OutImageType> Iterator;
   image_avg->FillBuffer(0);
   unsigned int timedims = image_in->GetLargestPossibleRegion().GetSize()[ImageDimension - 1];
@@ -770,17 +768,17 @@ int ants_motion( itk::ants::CommandLineParser *parser )
         moving_time_slice = extractFilter2->GetOutput();
         }
 
-      bool directionmatricesok = true;
-      for( unsigned int i = 0; i < ImageDimension; i++ )
-        {
-        for( unsigned int j = 0; j < ImageDimension; j++ )
-          {
-          if( fabs( moving_time_slice->GetDirection()[i][j] - fixed_time_slice->GetDirection()[i][j] ) > 1.e-6 )
-            {
-            directionmatricesok = false;
-            }
-          }
-        }
+      // bool directionmatricesok = true;
+      // for( unsigned int i = 0; i < ImageDimension; i++ )
+      //   {
+      //   for( unsigned int j = 0; j < ImageDimension; j++ )
+      //     {
+      //     if( fabs( moving_time_slice->GetDirection()[i][j] - fixed_time_slice->GetDirection()[i][j] ) > 1.e-6 )
+      //       {
+      //       directionmatricesok = false;
+      //       }
+      //     }
+      //   }
 
       typename FixedImageType::Pointer preprocessFixedImage =
         PreprocessImage<FixedImageType>( fixed_time_slice, 0,

--- a/Examples/antsMotionCorrDiffusionDirection.cxx
+++ b/Examples/antsMotionCorrDiffusionDirection.cxx
@@ -153,13 +153,9 @@ int ants_motion_directions( itk::ants::CommandLineParser *parser )
 
   const unsigned int ImageDimension = 3;
 
-  typedef float                                     PixelType;
   typedef double                                    RealType;
-  typedef itk::Image<PixelType, ImageDimension>     FixedIOImageType;
   typedef itk::Image<RealType, ImageDimension>      FixedImageType;
   typedef itk::ImageFileReader<FixedImageType>      ImageReaderType;
-  typedef itk::Image<PixelType, ImageDimension + 1> MovingIOImageType;
-  typedef itk::Image<RealType, ImageDimension + 1>  MovingImageType;
   typedef vnl_matrix<RealType>                      vMatrix;
   vMatrix param_values;
   typedef itk::CompositeTransform<RealType, ImageDimension> CompositeTransformType;

--- a/Examples/antsMotionCorrStats.cxx
+++ b/Examples/antsMotionCorrStats.cxx
@@ -38,7 +38,6 @@ int ants_motion_stats( itk::ants::CommandLineParser *parser )
 
   const unsigned int ImageDimension = 3;
 
-  typedef float                                     PixelType;
   typedef double                                    RealType;
 
   typedef itk::Image<RealType, ImageDimension>      ImageType;

--- a/Examples/antsRegistration.cxx
+++ b/Examples/antsRegistration.cxx
@@ -26,7 +26,6 @@ namespace ants
 
 static void antsRegistrationInitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
 {
-  typedef itk::ants::CommandLineParser::OptionType OptionType;
 
   // short names in use-  a:b:c:d:f:g:h:i:l:m:n:o:q:r:s:t:u::w:x:z
 

--- a/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
+++ b/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
@@ -246,7 +246,6 @@ public:
       // We cast the metric's transform to a composite transform, so we can copy each
       // of its sub transforms to a new instance.
       // Notice that the metric transform will not be changed inside this fuction.
-      typedef typename ImageMetricType::FixedTransformType FixedTransformType;
       typename CompositeTransformType::ConstPointer inputFixedTransform =
                                           dynamic_cast<CompositeTransformType *>( inputMetric->GetModifiableFixedTransform() );
       const unsigned int N = inputFixedTransform->GetNumberOfTransforms();
@@ -279,7 +278,6 @@ public:
       }
 
     // Same procedure for the moving transform. Moving transform is always a Composite transform.
-    typedef typename ImageMetricType::MovingTransformType MovingTransformType;
     typename CompositeTransformType::Pointer movingTransform = CompositeTransformType::New();
 
     typename CompositeTransformType::ConstPointer inputMovingTransform =
@@ -314,7 +312,6 @@ public:
     typename ImageMetricType::Pointer inputMetric( dynamic_cast<ImageMetricType *>( myOptimizer->GetModifiableMetric() ) );
 
     // First, compute the moving transform
-    typedef typename ImageMetricType::MovingTransformType MovingTransformType;
     typename CompositeTransformType::Pointer movingTransform = CompositeTransformType::New();
 
     typename CompositeTransformType::ConstPointer inputMovingTransform =

--- a/Examples/antsSliceRegularizedRegistration.cxx
+++ b/Examples/antsSliceRegularizedRegistration.cxx
@@ -170,7 +170,6 @@ typename ImageType::Pointer sliceRegularizedPreprocessImage( ImageType * inputIm
   typedef itk::Statistics::ImageToHistogramFilter<ImageType>   HistogramFilterType;
   typedef typename HistogramFilterType::InputBooleanObjectType InputBooleanObjectType;
   typedef typename HistogramFilterType::HistogramSizeType      HistogramSizeType;
-  typedef typename HistogramFilterType::HistogramType          HistogramType;
 
   HistogramSizeType histogramSize( 1 );
   histogramSize[0] = 256;
@@ -390,7 +389,6 @@ int ants_slice_regularized_registration( itk::ants::CommandLineParser *parser )
 
   bool                doEstimateLearningRateOnce(true);
 
-  unsigned int   nparams = 2;
   itk::TimeProbe totalTimer;
   totalTimer.Start();
   typedef itk::TranslationTransform<RealType, ImageDimension-1> TranslationTransformType;
@@ -402,7 +400,6 @@ int ants_slice_regularized_registration( itk::ants::CommandLineParser *parser )
   std::vector<SingleTransformItemType>                     transformUList;
   std::vector<typename FixedImageType::Pointer>            fixedSliceList;
   std::vector<typename FixedImageType::Pointer>            movingSliceList;
-  typedef itk::ImageMaskSpatialObject<ImageDimension>      ImageMaskSpatialObjectType;
   typename FixedIOImageType::Pointer                       maskImage;
   typedef itk::Image< unsigned char, ImageDimension-1 >    ImageMaskType;
   typename ImageMaskType::Pointer mask_time_slice = NULL;
@@ -670,7 +667,6 @@ int ants_slice_regularized_registration( itk::ants::CommandLineParser *parser )
         transformOption->GetFunction( currentStage )->GetParameter(  0 ) );
 
       typedef itk::ConjugateGradientLineSearchOptimizerv4 OptimizerType;
-      typedef itk::GradientDescentOptimizerv4 OptimizerType1;
       typename OptimizerType::Pointer optimizer = OptimizerType::New();
       optimizer->SetNumberOfIterations( iterations[0] );
       optimizer->SetMinimumConvergenceValue( 1.e-7 );
@@ -689,7 +685,7 @@ int ants_slice_regularized_registration( itk::ants::CommandLineParser *parser )
       typename TranslationRegistrationType::Pointer translationRegistration = TranslationRegistrationType::New();
       if( std::strcmp( whichTransform.c_str(), "translation" ) == 0 )
         {
-        nparams = transformList[timedim]->GetNumberOfParameters();
+        transformList[timedim]->GetNumberOfParameters();
         metric->SetFixedImage( preprocessFixedImage );
         metric->SetVirtualDomainFromImage( preprocessFixedImage );
         metric->SetMovingImage( preprocessMovingImage );
@@ -861,8 +857,9 @@ int ants_slice_regularized_registration( itk::ants::CommandLineParser *parser )
     displacementinv->FillBuffer( displacementout->GetPixel( dind ) );
     for( unsigned int timedim = 0; timedim < timedims; timedim++ )
       {
-      typedef typename itk::TransformToDisplacementFieldFilter<DisplacementFieldType, RealType> ConverterType;
-      typename ConverterType::Pointer converter = ConverterType::New();
+      typedef typename itk::TransformToDisplacementFieldFilter<DisplacementFieldType, RealType>
+               _ConverterType;
+      typename _ConverterType::Pointer converter = _ConverterType::New();
       converter->SetOutputOrigin( fixedSliceList[timedim]->GetOrigin() );
       converter->SetOutputStartIndex( fixedSliceList[timedim]->GetBufferedRegion().GetIndex() );
       converter->SetSize( fixedSliceList[timedim]->GetBufferedRegion().GetSize() );
@@ -909,8 +906,9 @@ int ants_slice_regularized_registration( itk::ants::CommandLineParser *parser )
 // now apply to the inverse mapﬁ
       for( unsigned int timedim = 0; timedim < timedims; timedim++ )
         {
-        typedef typename itk::TransformToDisplacementFieldFilter<DisplacementFieldType, RealType> ConverterType;
-        typename ConverterType::Pointer converter = ConverterType::New();
+        typedef typename itk::TransformToDisplacementFieldFilter<DisplacementFieldType, RealType>
+          _ConverterType;
+        typename _ConverterType::Pointer converter = _ConverterType::New();
         converter->SetOutputOrigin( movingSliceList[timedim]->GetOrigin() );
         converter->SetOutputStartIndex( movingSliceList[timedim]->GetBufferedRegion().GetIndex() );
         converter->SetSize( movingSliceList[timedim]->GetBufferedRegion().GetSize() );

--- a/Examples/antsUtilities.h
+++ b/Examples/antsUtilities.h
@@ -391,7 +391,6 @@ void GetAffineTransformFromImage(const typename ImageType::Pointer& img,
 {
   typedef typename ImageType::DirectionType         DirectionType;
   typedef typename ImageType::PointType             PointType;
-  typedef typename ImageType::SpacingType           SpacingType;
   typedef typename AffineTransform::TranslationType VectorType;
 
   DirectionType direction = img->GetDirection();
@@ -418,7 +417,6 @@ void GetLargestSizeAfterWarp(typename WarperType::Pointer & warper,
                              typename ImageType::SizeType & largest_size,
                              typename ImageType::PointType & origin_warped)
 {
-  typedef typename ImageType::SizeType  SizeType;
   typedef typename ImageType::PointType PointType;
 
   const int ImageDimension = ImageType::GetImageDimension();

--- a/Examples/itkantsRegistrationHelper.h
+++ b/Examples/itkantsRegistrationHelper.h
@@ -1044,7 +1044,6 @@ GetCompositeTransformFromParserOption( typename ParserType::Pointer & parser,
 
     if( !calculatedTransformFromImages )
       {
-      typedef typename RegistrationHelperType::DisplacementFieldTransformType DisplacementFieldTransformType;
 
       typedef typename RegistrationHelperType::TransformType TransformType;
       typename TransformType::Pointer initialTransform;

--- a/Examples/itkantsRegistrationHelper.hxx
+++ b/Examples/itkantsRegistrationHelper.hxx
@@ -59,7 +59,6 @@ typename ImageType::Pointer PreprocessImage( typename ImageType::ConstPointer  i
   typedef itk::Statistics::ImageToHistogramFilter<ImageType>   HistogramFilterType;
   typedef typename HistogramFilterType::InputBooleanObjectType InputBooleanObjectType;
   typedef typename HistogramFilterType::HistogramSizeType      HistogramSizeType;
-  typedef typename HistogramFilterType::HistogramType          HistogramType;
 
   HistogramSizeType histogramSize( 1 );
   histogramSize[0] = 256;
@@ -1214,7 +1213,6 @@ RegistrationHelper<TComputeType, VImageDimension>
       optimizerObserver->SetCurrentStageNumber( currentStageNumber );
       }
 
-    typedef itk::GradientDescentLineSearchOptimizerv4Template<TComputeType> GradientDescentLSOptimizerType;
     typedef itk::GradientDescentOptimizerv4Template<TComputeType>           GradientDescentOptimizerType;
     typename GradientDescentOptimizerType::Pointer optimizer2 = GradientDescentOptimizerType::New();
     //    optimizer2->SetLowerLimit( 0 );
@@ -1993,8 +1991,6 @@ RegistrationHelper<TComputeType, VImageDimension>
 
         // Create the transform adaptors
 
-        typedef itk::BSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor<
-            BSplineDisplacementFieldTransformType> DisplacementFieldTransformAdaptorType;
         typename DisplacementFieldRegistrationType::TransformParametersAdaptorsContainerType adaptors;
 
         // Extract parameters
@@ -2170,7 +2166,6 @@ RegistrationHelper<TComputeType, VImageDimension>
 
         // Create the transform adaptors
 
-        typedef itk::BSplineTransformParametersAdaptor<BSplineTransformType> BSplineTransformAdaptorType;
         typename BSplineRegistrationType::TransformParametersAdaptorsContainerType adaptors;
         // Create the transform adaptors specific to B-splines
         for( unsigned int level = 0; level < numberOfLevels; level++ )
@@ -2960,9 +2955,6 @@ RegistrationHelper<TComputeType, VImageDimension>
         typename BSplineDisplacementFieldTransformType::Pointer outputDisplacementFieldTransform = displacementFieldRegistration->GetModifiableTransform();
 
         // Create the transform adaptors
-
-        typedef itk::BSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor<
-            BSplineDisplacementFieldTransformType> DisplacementFieldTransformAdaptorType;
         typename DisplacementFieldRegistrationType::TransformParametersAdaptorsContainerType adaptors;
 
         // Extract parameters
@@ -3315,9 +3307,6 @@ RegistrationHelper<TComputeType, VImageDimension>
 
         // Create the transform adaptors
 
-        typedef itk::BSplineSmoothingOnUpdateDisplacementFieldTransformParametersAdaptor<
-            BSplineDisplacementFieldTransformType>
-          DisplacementFieldTransformAdaptorType;
         typename DisplacementFieldRegistrationType::TransformParametersAdaptorsContainerType adaptors;
 
         // Extract parameters

--- a/ExternalApplications/MALF/JointFusion/LabelFusion.cxx
+++ b/ExternalApplications/MALF/JointFusion/LabelFusion.cxx
@@ -469,7 +469,7 @@ cout<<999<<endl;
 
   // Make sure the region is inside bounds
   itk::ImageRegion<VDim> rOut = targetl[0]->GetLargestPossibleRegion();
-  for(int d = 0; d < 3; d++)
+  for(unsigned int d = 0; d < VDim; d++)
     {
     rOut.SetIndex(d, p.r_patch[d] + p.r_search[d] + rOut.GetIndex(d));
     rOut.SetSize(d, rOut.GetSize(d) - 2 * (p.r_search[d] + p.r_patch[d]));

--- a/ImageRegistration/ANTS_affine_registration2.h
+++ b/ImageRegistration/ANTS_affine_registration2.h
@@ -101,7 +101,6 @@ public:
 template <class TAffineTransform, class TMaskImage>
 std::ostream & operator<<(std::ostream& os, const OptAffine<TAffineTransform,  TMaskImage>& p)
 {
-  typedef OptAffine<TAffineTransform, TMaskImage> OptAffineType;
   os << "OptAffine: ";
   os << "metric_type=";
 
@@ -285,7 +284,6 @@ void GetAffineTransformFromImage(const ImageTypePointer& img, AffineTransformPoi
   typedef typename ImageTypePointer::ObjectType                        ImageType;
   typedef typename ImageType::DirectionType                            DirectionType;
   typedef typename ImageType::PointType                                PointType;
-  typedef typename ImageType::SpacingType                              SpacingType;
   typedef typename AffineTransformPointer::ObjectType::TranslationType VectorType;
 
   DirectionType direction = img->GetDirection();
@@ -440,9 +438,7 @@ void ComputeSingleAffineTransform2D3D(typename ImageType::Pointer & fixed_image,
 
   typedef std::vector<typename ImageType::Pointer>               ImagePyramidType;
   typedef itk::ImageMaskSpatialObject<ImageDimension>            ImageMaskSpatialObjectType;
-  typedef typename ImageMaskSpatialObjectType::Pointer           MaskObjectPointerType;
   typedef itk::LinearInterpolateImageFunction<ImageType, double> InterpolatorType;
-  typedef typename InterpolatorType::Pointer                     InterpolatorPointerType;
 
   typedef typename TransformType::ParametersType ParaType;
 
@@ -926,11 +922,8 @@ template <class ImagePointerType, class OptAffineType, class RunningAffineCacheT
 void InitializeRunningAffineCache(ImagePointerType & fixed_image, ImagePointerType & moving_image, OptAffineType & opt,
                                   RunningAffineCacheType & running_cache)
 {
-  typedef typename ImagePointerType::ObjectType ImageType;
-  // typedef itk::LinearInterpolateImageFunction<ImageType, double> InterpolatorType;
   typedef typename RunningAffineCacheType::InterpolatorType InterpolatorType;
   typedef typename RunningAffineCacheType::MetricType       MetricType;
-  // typedef itk::MattesMutualInformationImageToImageMetric<ImageType, ImageType> MetricType;
 
   BuildImagePyramid(fixed_image, opt.number_of_levels, running_cache.fixed_image_pyramid);
   BuildImagePyramid(moving_image, opt.number_of_levels, running_cache.moving_image_pyramid);
@@ -945,7 +938,6 @@ template <class ImagePointerType, class OptAffineType>
 void  InitializeAffineTransform(ImagePointerType & fixed_image, ImagePointerType & moving_image, OptAffineType& opt)
 {
   typedef typename OptAffineType::AffineTransformType TransformType;
-  typedef typename TransformType::ParametersType      ParaType;
   typedef typename TransformType::InputPointType      PointType;
   typedef typename TransformType::OutputVectorType    VectorType;
 

--- a/ImageRegistration/itkANTSImageRegistrationOptimizer.cxx
+++ b/ImageRegistration/itkANTSImageRegistrationOptimizer.cxx
@@ -466,18 +466,12 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>
     }
   typedef typename DisplacementFieldType::PixelType DispVectorType;
 
-  typedef itk::WarpImageFilter<ImageType, ImageType, DisplacementFieldType> WarperType;
-  typedef DisplacementFieldType                                             FieldType;
 
   typedef itk::ImageRegionIteratorWithIndex<DisplacementFieldType> FieldIterator;
-  typedef ImageType                                                TRealImageType;
-
-  typedef itk::ImageFileWriter<ImageType> writertype;
 
   typedef typename DisplacementFieldType::IndexType DispIndexType;
 
   typedef itk::VectorLinearInterpolateImageFunction<DisplacementFieldType, TReal>   DefaultInterpolatorType;
-  typedef itk::VectorGaussianInterpolateImageFunction<DisplacementFieldType, TReal> DefaultInterpolatorType2;
   typename DefaultInterpolatorType::Pointer vinterp =  DefaultInterpolatorType::New();
   vinterp->SetInputImage(field);
   //    vinterp->SetParameters(NULL,1);
@@ -1912,12 +1906,7 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>
                       zero);
     }
 
-  typedef itk::ImageRegionIteratorWithIndex<DisplacementFieldType> FieldIterator;
   typedef itk::ImageRegionIteratorWithIndex<tvt>                   TVFieldIterator;
-  typedef typename DisplacementFieldType::IndexType                DIndexType;
-  typedef typename DisplacementFieldType::PointType                DPointType;
-  typedef typename TimeVaryingVelocityFieldType::IndexType         VIndexType;
-  typedef typename TimeVaryingVelocityFieldType::PointType         VPointType;
 
   TVFieldIterator m_FieldIter( this->m_TimeVaryingVelocity, this->m_TimeVaryingVelocity->GetLargestPossibleRegion() );
   for(  m_FieldIter.GoToBegin(); !m_FieldIter.IsAtEnd(); ++m_FieldIter )
@@ -1952,12 +1941,8 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>
 {
   typedef TimeVaryingVelocityFieldType tvt;
   VectorType zero;
-  typedef itk::ImageRegionIteratorWithIndex<DisplacementFieldType> FieldIterator;
   typedef itk::ImageRegionIteratorWithIndex<tvt>                   TVFieldIterator;
-  typedef typename DisplacementFieldType::IndexType                DIndexType;
-  typedef typename DisplacementFieldType::PointType                DPointType;
-  typedef typename TimeVaryingVelocityFieldType::IndexType         VIndexType;
-  typedef typename TimeVaryingVelocityFieldType::PointType         VPointType;
+
   int tpupdate = (unsigned int) ( ( (TReal) this->m_NTimeSteps - 1.0) * timept + 0.5);
   // std::cout <<"  add to " << tpupdate << std::endl;
   TReal           tmag = 0;
@@ -2405,14 +2390,6 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>
     }
 
 //  std::cout << " st " << starttimein << " ft " << finishtimein << std::endl;
-  typedef TReal PixelType;
-//   typedef itk::Vector<TReal, TDimension>     VectorType;
-//   typedef itk::Image<VectorType, TDimension> DisplacementFieldType;
-//   typedef itk::Image<PixelType, TDimension>  ImageType;
-//   typedef typename  ImageType::IndexType     IndexType;
-  typedef typename  ImageType::SizeType    SizeType;
-  typedef typename  ImageType::SpacingType SpacingType;
-  typedef TimeVaryingVelocityFieldType     tvt;
 
   bool dothick = false;
   if(  finishtimein > starttimein  && this->m_ComputeThickness )
@@ -2451,11 +2428,6 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>
   this->m_VelocityFieldInterpolator->SetInputImage(this->m_TimeVaryingVelocity);
 
   typedef itk::ImageRegionIteratorWithIndex<DisplacementFieldType> FieldIterator;
-  typedef itk::ImageRegionIteratorWithIndex<tvt>                   TVFieldIterator;
-  typedef typename DisplacementFieldType::IndexType                DIndexType;
-  typedef typename DisplacementFieldType::PointType                DPointType;
-  typedef typename TimeVaryingVelocityFieldType::IndexType         VIndexType;
-  typedef typename TimeVaryingVelocityFieldType::PointType         VPointType;
 
   if( starttimein < 0 )
     {
@@ -2523,7 +2495,6 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>
                                                                        TReal>
                                ::ImagePointer /* refimage */ )
 {
-  typedef TimeVaryingVelocityFieldType tvt;
 
   VectorType zero;
   zero.Fill(0);
@@ -2542,13 +2513,6 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>
     std::cout << " No TV Field " << std::endl;  return intfield;
     }
   this->m_VelocityFieldInterpolator->SetInputImage(this->m_TimeVaryingVelocity);
-
-  typedef itk::ImageRegionIteratorWithIndex<DisplacementFieldType> FieldIterator;
-  typedef itk::ImageRegionIteratorWithIndex<tvt>                   TVFieldIterator;
-  typedef typename DisplacementFieldType::IndexType                DIndexType;
-  typedef typename DisplacementFieldType::PointType                DPointType;
-  typedef typename TimeVaryingVelocityFieldType::IndexType         VIndexType;
-  typedef typename TimeVaryingVelocityFieldType::PointType         VPointType;
 
   if( starttimein < 0 )
     {
@@ -2609,10 +2573,7 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>
 {
   typedef Point<TReal, itkGetStaticConstMacro(ImageDimension + 1)> xPointType;
   this->m_Debug = false;
-//  std::cout <<"Enter IP "<< std::endl;
-  typedef typename VelocityFieldInterpolatorType::OutputType InterpPointType;
 
-  typedef TimeVaryingVelocityFieldType tvt;
 
   VectorType zero;
   zero.Fill(0);
@@ -2621,12 +2582,7 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>
     return zero;
     }
 
-  typedef itk::ImageRegionIteratorWithIndex<DisplacementFieldType> FieldIterator;
-  typedef itk::ImageRegionIteratorWithIndex<tvt>                   TVFieldIterator;
-  typedef typename DisplacementFieldType::IndexType                DIndexType;
-  typedef typename DisplacementFieldType::PointType                DPointType;
   typedef typename TimeVaryingVelocityFieldType::IndexType         VIndexType;
-  typedef typename TimeVaryingVelocityFieldType::PointType         VPointType;
 
   this->m_VelocityFieldInterpolator->SetInputImage(this->m_TimeVaryingVelocity);
 

--- a/ImageRegistration/itkANTSImageRegistrationOptimizer.h
+++ b/ImageRegistration/itkANTSImageRegistrationOptimizer.h
@@ -1768,8 +1768,6 @@ public:
   {
     typedef WarpImageFilter<ImageType, ImageType, DisplacementFieldType> WarperType;
     typename WarperType::Pointer  warper = WarperType::New();
-    typedef NearestNeighborInterpolateImageFunction<ImageType, TReal>
-      InterpolatorType;
     warper->SetInput(image);
     warper->SetDisplacementField( field );
     warper->SetEdgePaddingValue( 0);
@@ -1823,7 +1821,6 @@ public:
 
     typedef typename DisplacementFieldType::PixelType           DispVectorType;
     typedef typename DisplacementFieldType::IndexType           DispIndexType;
-    typedef typename DispVectorType::ValueType                  ScalarType;
     typedef ImageRegionIteratorWithIndex<DisplacementFieldType> Iterator;
 
     DisplacementFieldPointer lagrangianInitCond =
@@ -2025,7 +2022,6 @@ protected:
     typedef typename DisplacementFieldType::PixelType           DispVectorType;
     typedef typename DisplacementFieldType::IndexType           DispIndexType;
     typedef typename DisplacementFieldType::SizeType            SizeType;
-    typedef typename DispVectorType::ValueType                  ScalarType;
     typedef ImageRegionIteratorWithIndex<DisplacementFieldType> Iterator;
     // all we have to do here is add the local field to the global field.
     Iterator      vfIter( field,  field->GetLargestPossibleRegion() );

--- a/ImageRegistration/itkAvantsMutualInformationRegistrationFunction.cxx
+++ b/ImageRegistration/itkAvantsMutualInformationRegistrationFunction.cxx
@@ -140,7 +140,6 @@ AvantsMutualInformationRegistrationFunction<TFixedImage, TMovingImage, TDisplace
 
 //  this->ComputeMetricImage();
 
-  typedef ImageRegionIteratorWithIndex<TFixedImage> ittype;
   /*
   bool makenewimage=false;
   if (!this->m_MetricImage ) makenewimage=true;

--- a/ImageRegistration/itkAvantsPDEDeformableRegistrationFunction.h
+++ b/ImageRegistration/itkAvantsPDEDeformableRegistrationFunction.h
@@ -159,7 +159,6 @@ public:
   {
     bool makenewimage = false;
 
-    typedef ImageRegionIteratorWithIndex<MetricImageType> ittype;
     FixedImageType* img = const_cast<FixedImageType *>(this->m_FixedImage.GetPointer() );
     typename FixedImageType::SizeType imagesize = img->GetLargestPossibleRegion().GetSize();
 

--- a/ImageRegistration/itkCrossCorrelationRegistrationFunction.cxx
+++ b/ImageRegistration/itkCrossCorrelationRegistrationFunction.cxx
@@ -107,7 +107,6 @@ void
 CrossCorrelationRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>
 ::InitializeIteration()
 {
-  typedef ImageRegionIteratorWithIndex<MetricImageType> ittype;
   if( !Superclass::m_MovingImage || !Superclass::m_FixedImage || !m_MovingImageInterpolator )
     {
     itkExceptionMacro( << "MovingImage, FixedImage and/or Interpolator not set" );
@@ -127,11 +126,6 @@ CrossCorrelationRegistrationFunction<TFixedImage, TMovingImage, TDisplacementFie
 
   m_MetricTotal = 0.0;
   this->m_Energy = 0.0;
-
-  typedef itk::DiscreteGaussianImageFilter<BinaryImageType, BinaryImageType> dgf1;
-//  typedef itk::DiscreteGaussianImageFilter<BinaryImageType, BinaryImageType> dgf;
-  typedef itk::MeanImageFilter<BinaryImageType, BinaryImageType>   dgf;
-  typedef itk::MedianImageFilter<BinaryImageType, BinaryImageType> dgf2;
 
   // compute the normalizer
   m_Normalizer      = 0.0;

--- a/ImageRegistration/itkCrossCorrelationRegistrationFunction.h
+++ b/ImageRegistration/itkCrossCorrelationRegistrationFunction.h
@@ -327,8 +327,6 @@ public:
   float  m_TEMP;
   MetricImagePointer MakeImage()
   {
-    typedef ImageRegionIteratorWithIndex<MetricImageType> ittype;
-    typedef ImageRegionIteratorWithIndex<BinaryImageType> ittype2;
     FixedImageType* img = const_cast<FixedImageType *>(Superclass::m_FixedImage.GetPointer() );
 
     this->m_MetricImage = AllocImage<MetricImageType>(img, 0);

--- a/ImageRegistration/itkExpectationBasedPointSetRegistrationFunction.hxx
+++ b/ImageRegistration/itkExpectationBasedPointSetRegistrationFunction.hxx
@@ -113,7 +113,6 @@ void
 ExpectationBasedPointSetRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField, TPointSet>
 ::ExpectationLandmarkField(float weight, bool whichdirection)
 {
-  typedef ImageRegionIteratorWithIndex<DisplacementFieldType> Iterator;
 
   SpacingType   spacing = this->GetFixedImage()->GetSpacing();
   unsigned long sz1 = this->m_FixedPointSet->GetNumberOfPoints();
@@ -631,7 +630,6 @@ ExpectationBasedPointSetRegistrationFunction<TFixedImage, TMovingImage, TDisplac
   m_MeshResolution.Fill(1);
   unsigned int PointDimension = ImageDimension;
 
-  typedef ImageRegionIteratorWithIndex<DisplacementFieldType> Iterator;
   SpacingType spacing = this->GetFixedImage()->GetSpacing();
 
   typename TreeGeneratorType::Pointer fkdtree;

--- a/ImageRegistration/itkProbabilisticRegistrationFunction.cxx
+++ b/ImageRegistration/itkProbabilisticRegistrationFunction.cxx
@@ -104,7 +104,6 @@ void
 ProbabilisticRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>
 ::InitializeIteration()
 {
-  typedef ImageRegionIteratorWithIndex<MetricImageType> ittype;
   if( !Superclass::m_MovingImage || !Superclass::m_FixedImage || !m_MovingImageInterpolator )
     {
     itkExceptionMacro( << "MovingImage, FixedImage and/or Interpolator not set" );
@@ -124,11 +123,6 @@ ProbabilisticRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>
 
   m_MetricTotal = 0.0;
   this->m_Energy = 0.0;
-
-  typedef itk::DiscreteGaussianImageFilter<BinaryImageType, BinaryImageType> dgf1;
-//  typedef itk::DiscreteGaussianImageFilter<BinaryImageType, BinaryImageType> dgf;
-  typedef itk::MeanImageFilter<BinaryImageType, BinaryImageType>   dgf;
-  typedef itk::MedianImageFilter<BinaryImageType, BinaryImageType> dgf2;
 
   // compute the normalizer
   m_Normalizer      = 0.0;
@@ -584,7 +578,6 @@ void
 ProbabilisticRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>
 ::InitializeIterationOld()
 {
-  typedef ImageRegionIteratorWithIndex<MetricImageType> ittype;
   if( !Superclass::m_MovingImage || !Superclass::m_FixedImage || !m_MovingImageInterpolator )
     {
     itkExceptionMacro( << "MovingImage, FixedImage and/or Interpolator not set" );
@@ -604,11 +597,6 @@ ProbabilisticRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>
 
   m_MetricTotal = 0.0;
   this->m_Energy = 0.0;
-
-  typedef itk::DiscreteGaussianImageFilter<BinaryImageType, BinaryImageType> dgf1;
-//  typedef itk::DiscreteGaussianImageFilter<BinaryImageType, BinaryImageType> dgf;
-  typedef itk::MeanImageFilter<BinaryImageType, BinaryImageType>   dgf;
-  typedef itk::MedianImageFilter<BinaryImageType, BinaryImageType> dgf2;
 
   // compute the normalizer
   m_Normalizer      = 0.0;

--- a/ImageRegistration/itkProbabilisticRegistrationFunction.h
+++ b/ImageRegistration/itkProbabilisticRegistrationFunction.h
@@ -340,8 +340,6 @@ protected:
 
   MetricImagePointer MakeImage()
   {
-    typedef ImageRegionIteratorWithIndex<MetricImageType> ittype;
-    typedef ImageRegionIteratorWithIndex<BinaryImageType> ittype2;
     FixedImageType* img = const_cast<FixedImageType *>(Superclass::m_FixedImage.GetPointer() );
 
     this->m_MetricImage = AllocImage<MetricImageType>(img->GetLargestPossibleRegion(), 0);

--- a/ImageRegistration/itkSpatialMutualInformationRegistrationFunction.cxx
+++ b/ImageRegistration/itkSpatialMutualInformationRegistrationFunction.cxx
@@ -146,7 +146,6 @@ SpatialMutualInformationRegistrationFunction<TFixedImage, TMovingImage, TDisplac
 //  this->ComputeMetricImage();
 //  std::cout << " A " << std::endl;
 //    bool makenewimage=false;
-  typedef ImageRegionIteratorWithIndex<TFixedImage> ittype;
 //  std::cout << " B " << std::endl;
 
   /*

--- a/Temporary/antsFastMarchingImageFilter.hxx
+++ b/Temporary/antsFastMarchingImageFilter.hxx
@@ -614,7 +614,6 @@ FMarchingImageFilter<TLevelSet, TSpeedImage>
   bb = 0.0;
   if( speedImage )
     {
-    typedef typename SpeedImageType::PixelType SpeedPixelType;
     cc = (double) speedImage->GetPixel( index ) / this->m_NormalizationFactor;
     cc = -1.0 * vnl_math_sqr( 1.0 / cc );
     }

--- a/Tensor/TensorFunctions.h
+++ b/Tensor/TensorFunctions.h
@@ -433,8 +433,6 @@ float  GetMetricTensorCost(  TVectorType dpath,  TTensorType dtv, unsigned int m
 template <class TVectorType, class TTensorType>
 TVectorType ChangeTensorByVector(  TVectorType dpath,  TTensorType dtv, float epsilon)
 {
-  typedef TVectorType VectorType;
-
   typedef vnl_matrix<double> MatrixType;
   MatrixType DT(3, 3);
   DT.fill(0);
@@ -537,28 +535,6 @@ float  GetTensorADC( TTensorType dtv,  unsigned int opt = 0)
     {
     return 0;
     }
-
-  //  typedef itk::Vector<float, 6> TensorTypeIn;
-  typedef itk::Vector<float, 6> TensorType;
-  typedef itk::Vector<float, 6> TensorTypeOut;
-  typedef itk::Vector<float, 6> TensorTypeIn;
-  const unsigned int ImageDimension = 3;
-  typedef itk::Image<TensorTypeIn, ImageDimension>  InTensorImageType;
-  typedef itk::Image<TensorTypeOut, ImageDimension> OutTensorImageType;
-  typedef itk::Image<TensorTypeOut, ImageDimension> TensorImageType;
-  typedef     InTensorImageType::Pointer            TensorImagePointer;
-  typedef float                                     PixelType;
-  typedef itk::Vector<float, ImageDimension>        VectorType1;
-  typedef itk::Image<VectorType1, ImageDimension>   FieldType;
-  typedef itk::Image<PixelType, ImageDimension>     ImageType;
-  typedef itk::ImageFileReader<InTensorImageType>   readertype;
-  typedef itk::ImageFileWriter<OutTensorImageType>  writertype;
-  typedef ImageType::IndexType                      IndexType;
-  typedef ImageType::SizeType                       SizeType;
-  typedef ImageType::SpacingType                    SpacingType;
-//   typedef itk::AffineTransform<double,ImageDimension>   AffineTransformType;
-//   typedef itk::LinearInterpolateImageFunction<ImageType,double>  InterpolatorType1;
-//   typedef itk::NearestNeighborInterpolateImageFunction<ImageType,double>  InterpolatorType2;
 
   itk::Vector<float, 6> dtv2;
   typedef vnl_matrix<double> MatrixType;
@@ -683,28 +659,6 @@ itk::RGBPixel<float>   GetTensorPrincipalEigenvector( TTensorType dtv )
     return zero;
     }
 
-  //  typedef itk::Vector<float, 6> TensorTypeIn;
-  typedef itk::Vector<float, 6> TensorType;
-  typedef itk::Vector<float, 6> TensorTypeOut;
-  typedef itk::Vector<float, 6> TensorTypeIn;
-  const unsigned int ImageDimension = 3;
-  typedef itk::Image<TensorTypeIn, ImageDimension>  InTensorImageType;
-  typedef itk::Image<TensorTypeOut, ImageDimension> OutTensorImageType;
-  typedef itk::Image<TensorTypeOut, ImageDimension> TensorImageType;
-  typedef     InTensorImageType::Pointer            TensorImagePointer;
-  typedef float                                     PixelType;
-  typedef itk::Vector<float, ImageDimension>        VectorType1;
-  typedef itk::Image<VectorType1, ImageDimension>   FieldType;
-  typedef itk::Image<PixelType, ImageDimension>     ImageType;
-  typedef itk::ImageFileReader<InTensorImageType>   readertype;
-  typedef itk::ImageFileWriter<OutTensorImageType>  writertype;
-  typedef ImageType::IndexType                      IndexType;
-  typedef ImageType::SizeType                       SizeType;
-  typedef ImageType::SpacingType                    SpacingType;
-//   typedef itk::AffineTransform<double,ImageDimension>   AffineTransformType;
-//   typedef itk::LinearInterpolateImageFunction<ImageType,double>  InterpolatorType1;
-//   typedef itk::NearestNeighborInterpolateImageFunction<ImageType,double>  InterpolatorType2;
-
   itk::Vector<float, 6> dtv2;
   typedef vnl_matrix<double> MatrixType;
   MatrixType DT(3, 3);
@@ -785,28 +739,6 @@ itk::Vector<float>   GetTensorPrincipalEigenvector( TTensorType dtv, unsigned in
     {
     return zero;
     }
-
-  //  typedef itk::Vector<float, 6> TensorTypeIn;
-  typedef itk::Vector<float, 6> TensorType;
-  typedef itk::Vector<float, 6> TensorTypeOut;
-  typedef itk::Vector<float, 6> TensorTypeIn;
-  const unsigned int ImageDimension = 3;
-  typedef itk::Image<TensorTypeIn, ImageDimension>  InTensorImageType;
-  typedef itk::Image<TensorTypeOut, ImageDimension> OutTensorImageType;
-  typedef itk::Image<TensorTypeOut, ImageDimension> TensorImageType;
-  typedef     InTensorImageType::Pointer            TensorImagePointer;
-  typedef float                                     PixelType;
-  typedef itk::Vector<float, ImageDimension>        VectorType1;
-  typedef itk::Image<VectorType1, ImageDimension>   FieldType;
-  typedef itk::Image<PixelType, ImageDimension>     ImageType;
-  typedef itk::ImageFileReader<InTensorImageType>   readertype;
-  typedef itk::ImageFileWriter<OutTensorImageType>  writertype;
-  typedef ImageType::IndexType                      IndexType;
-  typedef ImageType::SizeType                       SizeType;
-  typedef ImageType::SpacingType                    SpacingType;
-//   typedef itk::AffineTransform<double,ImageDimension>   AffineTransformType;
-//   typedef itk::LinearInterpolateImageFunction<ImageType,double>  InterpolatorType1;
-//   typedef itk::NearestNeighborInterpolateImageFunction<ImageType,double>  InterpolatorType2;
 
   itk::Vector<float, 6> dtv2;
   typedef vnl_matrix<double> MatrixType;

--- a/Utilities/ReadWriteData.h
+++ b/Utilities/ReadWriteData.h
@@ -153,7 +153,6 @@ void ReadTensorImage(itk::SmartPointer<TImageType> & target, const char *file, b
 
   typedef TImageType                      ImageType;
   typedef itk::ImageFileReader<ImageType> FileSourceType;
-  typedef typename ImageType::PixelType   PixType;
 
   typedef itk::LogTensorImageFilter<ImageType, ImageType> LogFilterType;
   typename FileSourceType::Pointer reffilter = NULL;
@@ -211,7 +210,6 @@ template <class TImageType>
 // void ReadImage(typename TImageType::Pointer target, const char *file)
 bool ReadImage(itk::SmartPointer<TImageType> & target, const char *file)
 {
-  typedef typename TImageType::PixelType PixelType;
   enum { ImageDimension = TImageType::ImageDimension };
   if( std::string(file).length() < 3 )
     {
@@ -246,8 +244,7 @@ bool ReadImage(itk::SmartPointer<TImageType> & target, const char *file)
       }
     typedef TImageType                      ImageType;
     typedef itk::ImageFileReader<ImageType> FileSourceType;
-    typedef typename ImageType::PixelType   PixType;
-    //    const unsigned int ImageDimension=ImageType::ImageDimension;
+
     typename FileSourceType::Pointer reffilter = FileSourceType::New();
     reffilter->SetFileName( file );
     try
@@ -278,8 +275,7 @@ typename ImageType::Pointer ReadImage(char* fn )
 {
   // Read the image files begin
   typedef itk::ImageFileReader<ImageType> FileSourceType;
-  typedef typename ImageType::PixelType   PixType;
-//   const unsigned int ImageDimension=ImageType::ImageDimension;
+
   typename FileSourceType::Pointer reffilter = FileSourceType::New();
   reffilter->SetFileName( fn );
   try
@@ -309,9 +305,8 @@ typename ImageType::Pointer ReadTensorImage(char* fn, bool takelog = true )
 {
   // Read the image files begin
   typedef itk::ImageFileReader<ImageType>                 FileSourceType;
-  typedef typename ImageType::PixelType                   PixType;
   typedef itk::LogTensorImageFilter<ImageType, ImageType> LogFilterType;
-//   const unsigned int ImageDimension=ImageType::ImageDimension;
+
   typename FileSourceType::Pointer reffilter = FileSourceType::New();
   reffilter->SetFileName( fn );
   try
@@ -345,7 +340,6 @@ template <class TPointSet>
 bool ReadPointSet( itk::SmartPointer<TPointSet> & target, const char *file,
   bool boundaryPointsOnly = false, float samplingPercentage = 1.0 )
 {
-  typedef typename TPointSet::PixelType PixelType;
   if( std::string( file ).length() < 3 )
     {
     std::cerr << " bad file name " << std::string(file) << std::endl;
@@ -473,7 +467,6 @@ bool WriteImage(itk::SmartPointer<TImageType> image, const char *file)
 template <class TImageType>
 void WriteTensorImage(itk::SmartPointer<TImageType> image, const char *file, bool takeexp = true)
 {
-  typedef typename TImageType::PixelType                    PixType;
   typedef itk::ExpTensorImageFilter<TImageType, TImageType> ExpFilterType;
   typename itk::ImageFileWriter<TImageType>::Pointer writer =
     itk::ImageFileWriter<TImageType>::New();
@@ -597,7 +590,6 @@ void
 WriteDisplacementField(TField* field, std::string filename)
 {
   typedef TField                        FieldType;
-  typedef typename FieldType::PixelType VectorType;
   enum { ImageDimension = FieldType::ImageDimension };
 
   typedef itk::Image<float, ImageDimension> RealImageType;
@@ -632,7 +624,6 @@ void
 WriteDisplacementField2(TField* field, std::string filename, std::string app)
 {
   typedef TField                        FieldType;
-  typedef typename FieldType::PixelType VectorType;
   enum { ImageDimension = FieldType::ImageDimension };
 
   typedef itk::Image<float, ImageDimension> RealImageType;

--- a/Utilities/antsSCCANObject.hxx
+++ b/Utilities/antsSCCANObject.hxx
@@ -328,7 +328,6 @@ antsSCCANObject<TInputImage, TRealType>
   if ( ImageDimension == 4 ) return this->ClusterThresholdVariate4D( w_p, mask,  minclust );
   typedef unsigned long                                                    ULPixelType;
   typedef itk::Image<ULPixelType, ImageDimension>                          labelimagetype;
-  typedef TInputImage                                                      InternalImageType;
   typedef itk::ImageRegionIteratorWithIndex<ImageType>                     fIterator;
   typedef itk::ImageRegionIteratorWithIndex<labelimagetype>                Iterator;
   typedef itk::ConnectedComponentImageFilter<TInputImage, labelimagetype>  FilterType;
@@ -439,7 +438,6 @@ antsSCCANObject<TInputImage, TRealType>
     }
   typedef unsigned long                                                    ULPixelType;
   typedef itk::Image<ULPixelType, ImageDimension>                          labelimagetype;
-  typedef TInputImage                                                      InternalImageType;
   typedef itk::ImageRegionIteratorWithIndex<labelimagetype>                Iterator;
   typedef itk::ConnectedComponentImageFilter<TInputImage, labelimagetype>  FilterType;
   typedef itk::RelabelComponentImageFilter<labelimagetype, labelimagetype> RelabelType;
@@ -5492,7 +5490,6 @@ TRealType antsSCCANObject<TInputImage, TRealType>
   unsigned int       maxloop = this->m_MaximumNumberOfIterations;
   unsigned int       innerloop = 1;
   unsigned int       loop = 0;
-  bool               energyincreases = true;
   RealType           energy = 0;
   RealType           lastenergy = 0;
   VectorType gradsteps( n_vecs , basegradstep );
@@ -5519,12 +5516,7 @@ TRealType antsSCCANObject<TInputImage, TRealType>
     energy = this->m_CanonicalCorrelations.one_norm() / ( float ) n_vecs_in;
     if( this->m_GradStep < 1.e-12 ) // || ( vnl_math_abs( energy - lastenergy ) < this->m_Epsilon  && !changedgrad ) )
       {
-      energyincreases = false;
       std::cout << " this->m_GradStep : " << this->m_GradStep << " energy : " << energy << " changedgrad : " << changedgrad << std::endl;
-      }
-    else
-      {
-      energyincreases = true;
       }
     gradsteps[ k ] = this->m_GradStep;
     loop++;


### PR DESCRIPTION
GCC complains about unused typedefs. Removing them gets rid
of a ton of boilerplate block-copied code, and makes the code more
readable.
