### PR TITLE
antsCommandLineParser only changes brackets at beginning/end of each argument

### DIFF
--- a/Utilities/antsCommandLineParser.cxx
+++ b/Utilities/antsCommandLineParser.cxx
@@ -237,14 +237,14 @@ CommandLineParser
     else
       {
       // replace left delimiters
-      std::replace( a.begin(), a.end(), '{', '[' );
-      std::replace( a.begin(), a.end(), '(', '[' );
-      std::replace( a.begin(), a.end(), '<', '[' );
+      std::replace( a.begin(),  a.begin()+1, '{', '[' );
+      std::replace( a.begin(), a.begin()+1, '(', '[' );
+      std::replace( a.begin(), a.begin()+1, '<', '[' );
 
       // replace right delimiters
-      std::replace( a.begin(), a.end(), '}', ']' );
-      std::replace( a.begin(), a.end(), ')', ']' );
-      std::replace( a.begin(), a.end(), '>', ']' );
+      std::replace( a.end()-1, a.end(), '}', ']' );
+      std::replace( a.end()-1, a.end(), ')', ']' );
+      std::replace( a.end()-1, a.end(), '>', ']' );
 
       if( isArgOpen )
         {


### PR DESCRIPTION
Had error with antsCommandLineParser changing my filenames which included brackets. Now only replaces open brackets at start of each argument and close brackets at end of each argument.
