### PR TITLE
Denoise once only, also change the winsorization and intensity...

### DIFF
--- a/Scripts/antsAtroposN4.sh
+++ b/Scripts/antsAtroposN4.sh
@@ -453,7 +453,8 @@ for (( i = 0; i < ${N4_ATROPOS_NUMBER_OF_ITERATIONS}; i++ ))
         if [[ $j == 0 ]];
           then
             # BA edit - forcing the image to copy physical space due to ITK bug images do not occupy same space
-            logCmd ${ANTSPATH}/ImageMath ${DIMENSION} ${SEGMENTATION_N4_IMAGES[$j]} TruncateImageIntensity ${ANATOMICAL_IMAGES[$j]} 0.025 0.995 256 ${ATROPOS_SEGMENTATION_MASK} 1
+	    # Truncate on the whole image, not just within the brain - avoids losing brain contrast
+            logCmd ${ANTSPATH}/ImageMath ${DIMENSION} ${SEGMENTATION_N4_IMAGES[$j]} TruncateImageIntensity ${ANATOMICAL_IMAGES[$j]} 0 0.995 256
             if [[ ${DENOISE_ANATOMICAL_IMAGES} -ne 0 ]];
               then
                 logCmd ${ANTSPATH}/DenoiseImage -d ${DIMENSION} -i ${SEGMENTATION_N4_IMAGES[$j]} -o ${SEGMENTATION_N4_IMAGES[$j]} --verbose 1


### PR DESCRIPTION
truncation to be less aggressive.

I was finding that T1 images lost gray / white contrast in places, and I think this is due to intensity truncation that happens within the brain mask. For many images, the outlier intensities are outside the brain mask and the values inside the mask are all quite reasonable.

This happens twice because antsAtroposN4.sh is called twice.

The same problem happens with denoising. The first time the original image is de-noised, and the second time the truncated and de-noised image is truncated and de-noised again, which I found was smoothing out real tissue contrast. So I turned off de-noising for the second call.

Also, by truncating intensities over the whole head, it solves the problem of the skull in the BrainSegmentation0N4.nii.gz being all white (intensity 1000). The downside is that the contrast might not be optimally balanced for display of the brain, but you probably want to use ExtractedBrain0N4 for that anyway. It looked OK for me on non fat-suppressed T1 where the skull is fairly bright.
