### PR TITLE
COMP: Fix inconsistency of SetSigma types and overrides

### DIFF
--- a/Utilities/itkSurfaceCurvatureBase.h
+++ b/Utilities/itkSurfaceCurvatureBase.h
@@ -159,8 +159,8 @@ public:
 
   itkGetMacro(Normal, FixedVectorType);
 
-  itkGetMacro(Sigma, RealType);
   itkGetMacro(MeanKappa, RealType);
+  itkGetMacro(Sigma, RealType);
   itkSetMacro(Sigma, RealType);
 
   itkGetMacro(UseGeodesicNeighborhood, bool);

--- a/Utilities/itkSurfaceCurvatureBase.hxx
+++ b/Utilities/itkSurfaceCurvatureBase.hxx
@@ -60,6 +60,7 @@ SurfaceCurvatureBase<TSurface, TDimension>
   m_UseGeodesicNeighborhood = false;
 
   m_TotalArea = 0.0;
+  m_Sigma = 1.0F;
 }
 
 template <typename TSurface, unsigned int TDimension>

--- a/Utilities/itkSurfaceImageCurvature.h
+++ b/Utilities/itkSurfaceImageCurvature.h
@@ -152,7 +152,6 @@ public:
   itkGetMacro(UseLabel, bool);
 
   itkSetMacro(kSign, float);
-  itkSetMacro(Sigma, float);
 
   itkSetMacro(Threshold, float);
 
@@ -260,7 +259,6 @@ private:
   NeighborhoodIteratorType m_ti2;
   bool                     m_UseLabel;
   float                    m_kSign;
-  float                    m_Sigma;
   float                    m_Threshold;
   float                    m_Area;
   RealType                 m_MinSpacing;

--- a/Utilities/itkSurfaceImageCurvature.hxx
+++ b/Utilities/itkSurfaceImageCurvature.hxx
@@ -86,7 +86,6 @@ SurfaceImageCurvature<TSurface>
   m_UseLabel = false;
   m_kSign = -1.0;
   m_FunctionImage = ITK_NULLPTR;
-  m_Sigma = 1.0;
   this->m_Vinterp = ITK_NULLPTR;
   this->m_MinSpacing = itk::NumericTraits<RealType>::max() ;
 }


### PR DESCRIPTION
Remove unnecessary redundancy for the SetSigma() between the base class
and the derived class.

ANTs/Examples/SurfaceBasedSmoothing.cxx:7:
ANTs/Utilities/itkSurfaceImageCurvature.h:155:3: warning: 'SetSigma' overrides a member function but is not marked 'override'
  itkSetMacro(Sigma, float);
  ^
ANTs/Examples/SurfaceBasedSmoothing.cxx:71:3: note: in instantiation of template class
      'itk::SurfaceImageCurvature<itk::Image<float, 3> >' requested here
  ParamType::Pointer Parameterizer = ParamType::New();
  ^
ANTs/Utilities/itkSurfaceCurvatureBase.h:164:3: note: overridden virtual function is here
  itkSetMacro(Sigma, RealType);
  ^