### PR TITLE
Fix for --write-interval-volumes filename padding

### DIFF
--- a/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
+++ b/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
@@ -451,19 +451,24 @@ public:
      To prevent: "Iter1 Iter10 Iter2 Iter20" we use the following style.
      Then the order is: "Iter1 Iter2 ... Iters10 ... Itert20"
     */
-    if( curIter > 9 )
+	if( curIter < 10 )
       {
-      currentFileName << "_Iters" << curIter << ".nii.gz";
+      currentFileName << "_Iter000" << curIter << ".nii.gz";
       }
-    else if( curIter > 19 )
+    else if( curIter < 100 )
       {
-      currentFileName << "_Itert" << curIter << ".nii.gz";
+      currentFileName << "_Iter00" << curIter << ".nii.gz";
+      }
+    else if( curIter < 1000 )
+      {
+      currentFileName << "_Iter0" << curIter << ".nii.gz";
       }
     else
       {
       currentFileName << "_Iter" << curIter << ".nii.gz";
       }
     std::cout << "*"; // The star befor each DIAGNOSTIC shows that its output is writtent out.
+    std::cout << currentFileName.str() << std::endl; // The star befor each DIAGNOSTIC shows that its output is writtent out.
 
     typedef itk::ImageFileWriter<MovingImageType> WarpedImageWriterType;
     typename WarpedImageWriterType::Pointer writer = WarpedImageWriterType::New();

--- a/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
+++ b/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
@@ -391,19 +391,24 @@ public:
 
     const unsigned int curIter = this->m_Optimizer->GetCurrentIteration() + 1;
 
-    if( curIter > 9 )
+    if( curIter < 10 )
       {
-      currentFileName << "_Iters" << curIter << ".nii.gz";
+      currentFileName << "_Iter000" << curIter << ".nii.gz";
       }
-    else if( curIter > 19 )
+    else if( curIter < 100 )
       {
-      currentFileName << "_Itert" << curIter << ".nii.gz";
+      currentFileName << "_Iter00" << curIter << ".nii.gz";
+      }
+    else if( curIter < 1000 )
+      {
+      currentFileName << "_Iter0" << curIter << ".nii.gz";
       }
     else
       {
       currentFileName << "_Iter" << curIter << ".nii.gz";
       }
     std::cout << "*"; // The star befor each DIAGNOSTIC shows that its output is writtent out.
+    std::cout << currentFileName.str() << std::endl; // The star befor each DIAGNOSTIC shows that its output is writtent out.
 
     typedef itk::ImageFileWriter<ImageType> WarpedImageWriterType;
     typename WarpedImageWriterType::Pointer writer = WarpedImageWriterType::New();


### PR DESCRIPTION
Having more than 100 iterations in one level causes naming for interval volumes to be sorted incorrectly. This fixes this.