### PR TITLE
COMP: Future proof code for null pointer robustness

### DIFF
--- a/Examples/ANTS.cxx
+++ b/Examples/ANTS.cxx
@@ -107,7 +107,7 @@ int ANTSex(int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ANTS( std::vector<std::string> args, std::ostream* /*out_stream = NULL*/ )
+int ANTS( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR*/ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;
@@ -279,7 +279,7 @@ private:
       pos = delimPos + 1;
       }
 
-    char * *     my_argv = NULL;
+    char * *     my_argv = ITK_NULLPTR;
     if( my_argc > 0 )
       {
       unsigned int arg_count = 0;

--- a/Examples/ANTSConformalMapping.cxx
+++ b/Examples/ANTSConformalMapping.cxx
@@ -206,9 +206,9 @@ int ANTSConformalMapping( itk::ants::CommandLineParser *parser )
   // we define the options in the InitializeCommandLineOptions function
   // and then use them here ...
   typedef vtkPolyData MeshType;
-  vtkSmartPointer<MeshType> labelmesh = NULL;
-  vtkSmartPointer<MeshType> featuremesh = NULL;
-  vtkSmartPointer<MeshType> inflatedmesh = NULL;
+  vtkSmartPointer<MeshType> labelmesh = ITK_NULLPTR;
+  vtkSmartPointer<MeshType> featuremesh = ITK_NULLPTR;
+  vtkSmartPointer<MeshType> inflatedmesh = ITK_NULLPTR;
   typedef itk::FEMDiscConformalMap<MeshType, ImageType> ParamType;
   typename ParamType::Pointer flattener = ParamType::New();
   flattener->SetDebug(false);
@@ -403,7 +403,7 @@ int ANTSConformalMapping( itk::ants::CommandLineParser *parser )
     }
 
   // do stuff -- but not implemented yet
-  //   flattener->SetDiscBoundaryList(NULL);
+  //   flattener->SetDiscBoundaryList(ITK_NULLPTR);
 
   std::cout << " you will flatten " << labeltoflatten << ".  param while searching? " << paramws << std::endl;
   flattener->SetSigma(1);
@@ -470,7 +470,7 @@ int ANTSConformalMapping( itk::ants::CommandLineParser *parser )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ANTSConformalMapping( std::vector<std::string> args, std::ostream* out_stream = NULL )
+int ANTSConformalMapping( std::vector<std::string> args, std::ostream* out_stream = ITK_NULLPTR )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ANTSIntegrateVectorField.cxx
+++ b/Examples/ANTSIntegrateVectorField.cxx
@@ -397,7 +397,7 @@ int IntegrateVectorField(int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ANTSIntegrateVectorField( std::vector<std::string> args, std::ostream* /*out_stream = NULL*/ )
+int ANTSIntegrateVectorField( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR*/ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ANTSIntegrateVelocityField.cxx
+++ b/Examples/ANTSIntegrateVelocityField.cxx
@@ -112,7 +112,7 @@ int IntegrateVelocityField(int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ANTSIntegrateVelocityField( std::vector<std::string> args, std::ostream* /*out_stream = NULL */)
+int ANTSIntegrateVelocityField( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */)
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ANTSJacobian.cxx
+++ b/Examples/ANTSJacobian.cxx
@@ -534,7 +534,7 @@ int Jacobian(int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ANTSJacobian( std::vector<std::string> args, std::ostream* /*out_stream = NULL */)
+int ANTSJacobian( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */)
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ANTSUseDeformationFieldToGetAffineTransform.cxx
+++ b/Examples/ANTSUseDeformationFieldToGetAffineTransform.cxx
@@ -415,7 +415,7 @@ typedef itk::Rigid2DTransform< double > TransformType;
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ANTSUseDeformationFieldToGetAffineTransform( std::vector<std::string> args, std::ostream* /*out_stream = NULL */)
+int ANTSUseDeformationFieldToGetAffineTransform( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */)
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ANTSUseLandmarkImagesToGetAffineTransform.cxx
+++ b/Examples/ANTSUseLandmarkImagesToGetAffineTransform.cxx
@@ -367,7 +367,7 @@ int LandmarkBasedTransformInitializerBA(int, char * argv[])
   return EXIT_SUCCESS;
 }
 
-int ANTSUseLandmarkImagesToGetAffineTransform( std::vector<std::string> args, std::ostream* /*out_stream = NULL */)
+int ANTSUseLandmarkImagesToGetAffineTransform( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */)
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ANTSUseLandmarkImagesToGetBSplineDisplacementField.cxx
+++ b/Examples/ANTSUseLandmarkImagesToGetBSplineDisplacementField.cxx
@@ -468,7 +468,7 @@ int LandmarkBasedDisplacementFieldTransformInitializer( int argc, char *argv[] )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ANTSUseLandmarkImagesToGetBSplineDisplacementField( std::vector<std::string> args, std::ostream* /*out_stream = NULL */)
+int ANTSUseLandmarkImagesToGetBSplineDisplacementField( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */)
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/Atropos.cxx
+++ b/Examples/Atropos.cxx
@@ -1658,7 +1658,7 @@ void AtroposInitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int Atropos( std::vector<std::string> args, std::ostream* /*out_stream = NULL */)
+int Atropos( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */)
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/AverageAffineTransform.cxx
+++ b/Examples/AverageAffineTransform.cxx
@@ -96,7 +96,7 @@ static bool AverageAffineTransform_ParseInput(int argc, char * *argv, char *& ou
     ind++;
     }
 
-//    if (reference_image_filename == NULL) {
+//    if (reference_image_filename == ITK_NULLPTR) {
 //        std::cout << "the reference image file (-R) must be given!!!"
 //        << std::endl;
 //        return false;
@@ -226,7 +226,7 @@ void AverageAffineTransform(char *output_affine_txt, char *reference_affine_txt,
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int AverageAffineTransform( std::vector<std::string> args, std::ostream* /*out_stream = NULL */)
+int AverageAffineTransform( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */)
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/AverageAffineTransformNoRigid.cxx
+++ b/Examples/AverageAffineTransformNoRigid.cxx
@@ -96,7 +96,7 @@ static bool AverageAffineTransformNoRigid_ParseInput(int argc, char * *argv, cha
     ind++;
     }
 
-//    if (reference_image_filename == NULL) {
+//    if (reference_image_filename == ITK_NULLPTR) {
 //        std::cout << "the reference image file (-R) must be given!!!"
 //        << std::endl;
 //        return false;
@@ -225,7 +225,7 @@ void AverageAffineTransformNoRigid(char *output_affine_txt, char *reference_affi
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int AverageAffineTransformNoRigid( std::vector<std::string> args, std::ostream* /*out_stream = NULL */)
+int AverageAffineTransformNoRigid( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */)
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/AverageImages.cxx
+++ b/Examples/AverageImages.cxx
@@ -258,7 +258,7 @@ int AverageImages(unsigned int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int AverageImages( std::vector<std::string> args, std::ostream* /*out_stream = NULL */)
+int AverageImages( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */)
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/AverageTensorImages.cxx
+++ b/Examples/AverageTensorImages.cxx
@@ -87,7 +87,7 @@ int AverageTensorImages(unsigned int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int AverageTensorImages( std::vector<std::string> args, std::ostream* /*out_stream = NULL */)
+int AverageTensorImages( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */)
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ClusterImageStatistics.cxx
+++ b/Examples/ClusterImageStatistics.cxx
@@ -282,7 +282,7 @@ int  ClusterStatistics(unsigned int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ClusterImageStatistics( std::vector<std::string> args, std::ostream* /*out_stream = NULL */)
+int ClusterImageStatistics( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */)
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ComposeMultiTransform.cxx
+++ b/Examples/ComposeMultiTransform.cxx
@@ -66,7 +66,7 @@ static bool ComposeMultiTransform_ParseInput(int argc, char * *argv, char *& out
     ind++;
     }
 
-//    if (reference_image_filename == NULL) {
+//    if (reference_image_filename == ITK_NULLPTR) {
 //        std::cout << "the reference image file (-R) must be given!!!"
 //        << std::endl;
 //        return false;
@@ -284,7 +284,7 @@ void ComposeMultiAffine(char *output_affine_txt,
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ComposeMultiTransform( std::vector<std::string> args, std::ostream* /*out_stream = NULL */)
+int ComposeMultiTransform( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */)
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;
@@ -361,7 +361,7 @@ private:
     }
 
   TRAN_OPT_QUEUE opt_queue;
-  //    char *moving_image_filename = NULL;
+  //    char *moving_image_filename = ITK_NULLPTR;
   char *output_image_filename = ITK_NULLPTR;
   char *reference_image_filename = ITK_NULLPTR;
 

--- a/Examples/CompositeTransformUtil.cxx
+++ b/Examples/CompositeTransformUtil.cxx
@@ -167,7 +167,7 @@ static int Assemble(const std::string & CompositeName,
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int CompositeTransformUtil( std::vector<std::string> args, std::ostream* /*out_stream = NULL */)
+int CompositeTransformUtil( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */)
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ComputeSimilarityMetric.cxx
+++ b/Examples/ComputeSimilarityMetric.cxx
@@ -59,9 +59,9 @@ int ComputeSimilarityMetric(int argc, char *argv[])
     }
   argct++;
 
-  typename ImageType::Pointer image1 = NULL;
+  typename ImageType::Pointer image1 = ITK_NULLPTR;
   ReadImage<ImageType>(image1, fn1.c_str() );
-  typename ImageType::Pointer image2 = NULL;
+  typename ImageType::Pointer image2 = ITK_NULLPTR;
   ReadImage<ImageType>(image2, fn2.c_str() );
 
 /*
@@ -209,7 +209,7 @@ int ComputeSimilarityMetric(int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ComputeSimilarityMetric( std::vector<std::string> args, std::ostream* out_stream = NULL )
+int ComputeSimilarityMetric( std::vector<std::string> args, std::ostream* out_stream = ITK_NULLPTR )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ConformalMapping.cxx
+++ b/Examples/ConformalMapping.cxx
@@ -864,7 +864,7 @@ vtkwriter->Write();
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ConformalMapping( std::vector<std::string> args, std::ostream* out_stream = NULL )
+int ConformalMapping( std::vector<std::string> args, std::ostream* out_stream = ITK_NULLPTR )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ConvertImage.cxx
+++ b/Examples/ConvertImage.cxx
@@ -171,7 +171,7 @@ int ConvertImage( int argc, char *argv[] )
     bool isRescaleType = false;
     for( unsigned int i = 0; i < rescaleFileTypes.size(); i++ )
       {
-      if( strstr( argv[3], rescaleFileTypes[i].c_str() ) != NULL )
+      if( strstr( argv[3], rescaleFileTypes[i].c_str() ) != ITK_NULLPTR )
         {
         isRescaleType = true;
         break;
@@ -203,7 +203,7 @@ int ConvertImage( int argc, char *argv[] )
   return EXIT_SUCCESS;
 }
 
-int ConvertImage( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int ConvertImage( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ConvertImagePixelType.cxx
+++ b/Examples/ConvertImagePixelType.cxx
@@ -90,7 +90,7 @@ int ConvertType(int argc, char *argv[], double MINVAL, double MAXVAL)
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ConvertImagePixelType( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int ConvertImagePixelType( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ConvertInputImagePixelTypeToFloat.cxx
+++ b/Examples/ConvertInputImagePixelTypeToFloat.cxx
@@ -74,7 +74,7 @@ int ConvertTypeToFloat( int argc, char *argv[] )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ConvertInputImagePixelTypeToFloat( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int ConvertInputImagePixelTypeToFloat( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ConvertScalarImageToRGB.cxx
+++ b/Examples/ConvertScalarImageToRGB.cxx
@@ -326,7 +326,7 @@ int ConvertScalarImageToRGB( int argc, char *argv[] )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ConvertScalarImageToRGB( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int ConvertScalarImageToRGB( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ConvertToJpg.cxx
+++ b/Examples/ConvertToJpg.cxx
@@ -88,7 +88,7 @@ int ConvertType(int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ConvertToJpg( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int ConvertToJpg( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   try
     {

--- a/Examples/ConvertTransformFile.cxx
+++ b/Examples/ConvertTransformFile.cxx
@@ -447,7 +447,7 @@ int ConvertTransformFile(int argc, char* argv[])
 /*
  *
  */
-int ConvertTransformFile( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int ConvertTransformFile( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ConvertVectorFieldToVTK.cxx
+++ b/Examples/ConvertVectorFieldToVTK.cxx
@@ -29,7 +29,7 @@ namespace ants
 {
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ConvertVectorFieldToVTK( std::vector<std::string> args, std::ostream* out_stream = NULL )
+int ConvertVectorFieldToVTK( std::vector<std::string> args, std::ostream* out_stream = ITK_NULLPTR )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/CopyImageHeaderInformation.cxx
+++ b/Examples/CopyImageHeaderInformation.cxx
@@ -122,7 +122,7 @@ int CopyImageHeaderInformation(int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int CopyImageHeaderInformation( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int CopyImageHeaderInformation( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/CreateDTICohort.cxx
+++ b/Examples/CreateDTICohort.cxx
@@ -1065,7 +1065,7 @@ void InitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int CreateDTICohort( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int CreateDTICohort( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/CreateDisplacementField.cxx
+++ b/Examples/CreateDisplacementField.cxx
@@ -134,7 +134,7 @@ void CreateDisplacementField( int argc, char *argv[] )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int CreateDisplacementField( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int CreateDisplacementField( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/CreateImage.cxx
+++ b/Examples/CreateImage.cxx
@@ -245,7 +245,7 @@ int CreateZeroImage( int argc, char *argv[] )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int CreateImage( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int CreateImage( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/CreateTiledMosaic.cxx
+++ b/Examples/CreateTiledMosaic.cxx
@@ -1199,7 +1199,7 @@ void InitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int CreateTiledMosaic( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int CreateTiledMosaic( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/CreateWarpedGridImage.cxx
+++ b/Examples/CreateWarpedGridImage.cxx
@@ -134,7 +134,7 @@ int CreateWarpedGridImage( int argc, char *argv[] )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int CreateWarpedGridImage( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int CreateWarpedGridImage( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/DeNrrd.cxx
+++ b/Examples/DeNrrd.cxx
@@ -43,7 +43,7 @@ namespace ants
 {
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int DeNrrd( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int DeNrrd( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/DenoiseImage.cxx
+++ b/Examples/DenoiseImage.cxx
@@ -523,7 +523,7 @@ void InitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int DenoiseImage( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int DenoiseImage( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ExtractRegionFromImage.cxx
+++ b/Examples/ExtractRegionFromImage.cxx
@@ -148,7 +148,7 @@ int ExtractRegionFromImage( int argc, char *argv[] )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ExtractRegionFromImage( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int ExtractRegionFromImage( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ExtractRegionFromImageByMask.cxx
+++ b/Examples/ExtractRegionFromImageByMask.cxx
@@ -109,7 +109,7 @@ int ExtractRegionFromImageByMask(int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ExtractRegionFromImageByMask( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int ExtractRegionFromImageByMask( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ExtractSliceFromImage.cxx
+++ b/Examples/ExtractSliceFromImage.cxx
@@ -33,7 +33,7 @@ int ExtractSliceFromImage( int itkNotUsed( argc ), char *argv[] )
     {
     extracter->SetDirectionCollapseToIdentity();
     }
-  else 
+  else
     {
     extracter->SetDirectionCollapseToSubmatrix();
     }
@@ -47,7 +47,7 @@ int ExtractSliceFromImage( int itkNotUsed( argc ), char *argv[] )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ExtractSliceFromImage( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int ExtractSliceFromImage( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/FitBSplineToPoints.cxx
+++ b/Examples/FitBSplineToPoints.cxx
@@ -340,7 +340,7 @@ int FitBSplineCurveToPoints( unsigned int argc, char *argv[] )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int FitBSplineToPoints( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int FitBSplineToPoints( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/GetConnectedComponentsFeatureImages.cxx
+++ b/Examples/GetConnectedComponentsFeatureImages.cxx
@@ -144,7 +144,7 @@ int GetConnectedComponentsFeatureImages(int itkNotUsed( argc ), char* argv[] )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int GetConnectedComponentsFeatureImages( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int GetConnectedComponentsFeatureImages( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ImageCompare.cxx
+++ b/Examples/ImageCompare.cxx
@@ -22,7 +22,7 @@ int RegressionTestImage(const char *, const char *, int, bool);
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ImageCompare( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int ImageCompare( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ImageMath_Templates.hxx
+++ b/Examples/ImageMath_Templates.hxx
@@ -1836,12 +1836,12 @@ int PadImage(int argc, char *argv[])
   int               argct = 2;
   const std::string outname = std::string(argv[argct]);
   argct += 2;
-  std::string fn1 = std::string(argv[argct]);   
+  std::string fn1 = std::string(argv[argct]);
   argct++;
   const float padvalue = atof(argv[argct]);
   argct++;
 
-  PixelType padVoxelValue = itk::NumericTraits<PixelType>::Zero; 
+  PixelType padVoxelValue = itk::NumericTraits<PixelType>::Zero;
   if( argc > 6 )
     {
     padVoxelValue = static_cast<PixelType>( atof( argv[argct] ) );
@@ -3199,7 +3199,7 @@ int PCASLQuantifyCBF(int argc, char *  /*NOT USED argv*/[])
     }
 
 
-  typename TimeImageType::Pointer diff = NULL;
+  typename TimeImageType::Pointer diff = ITK_NULLPTR;
   if( fn1.length() > 3 )
     {
     ReadImage<TimeImageType>(diff, fn1.c_str() );
@@ -3209,7 +3209,7 @@ int PCASLQuantifyCBF(int argc, char *  /*NOT USED argv*/[])
     return 1;
     }
 
-  typename ImageType::Pointer m0 = NULL;
+  typename ImageType::Pointer m0 = ITK_NULLPTR;
   if( m0name.length() > 3 )
     {
     ReadImage<ImageType>(m0, m0name.c_str() );
@@ -5010,11 +5010,11 @@ int FitSphere(int argc, char *argv[])
   float MaxRad=5;
   if (argc > argct) MaxRad = atof(argv[argct]);   argct++;
 
-  typename ImageType::Pointer image1 = NULL;
-  typename ImageType::Pointer radimage = NULL;
-  typename ImageType::Pointer radimage2 = NULL;
-  typename ImageType::Pointer priorimage = NULL;
-  typename ImageType::Pointer wmimage = NULL;
+  typename ImageType::Pointer image1 = ITK_NULLPTR;
+  typename ImageType::Pointer radimage = ITK_NULLPTR;
+  typename ImageType::Pointer radimage2 = ITK_NULLPTR;
+  typename ImageType::Pointer priorimage = ITK_NULLPTR;
+  typename ImageType::Pointer wmimage = ITK_NULLPTR;
   if (fn2.length() > 3)   ReadImage<ImageType>(wmimage, fn2.c_str());
   // std::cout <<"  read " << fn1 << " MXR " << MaxRad << std::endl;
   ReadImage<ImageType>(image1, fn1.c_str());
@@ -5035,7 +5035,7 @@ int FitSphere(int argc, char *argv[])
   typename ScalarInterpolatorType::ContinuousIndexType  Y2;
   typename ScalarInterpolatorType::ContinuousIndexType  GMx;
   typename ScalarInterpolatorType::ContinuousIndexType  WMx;
-  typename ScalarInterpolatorType::Pointer winterp=NULL;
+  typename ScalarInterpolatorType::Pointer winterp= ITK_NULLPTR;
   if (wmimage)
     {
       winterp=ScalarInterpolatorType::New();
@@ -6719,7 +6719,7 @@ int CompareHeadersAndImages(int argc, char *argv[])
 //
 //   typedef itk::ImageFileReader< InputImageType >  ReaderType;
 //   typename ReaderType::Pointer reader =  ReaderType::New();
-//   typename InputImageType::Pointer priors=NULL;
+//   typename InputImageType::Pointer priors= ITK_NULLPTR;
 //
 //   if (priorfn.length()  > 3 )
 //     {
@@ -11042,7 +11042,7 @@ int RandomlySampleImageSetToCSV(unsigned int argc, char *argv[])
   argct += 2;
   unsigned int n_samples = atoi(argv[argct]);   argct++;
   /* std::string maskfn=std::string(argv[argct]); argct++;
-  typename ImageType::Pointer mask = NULL;
+  typename ImageType::Pointer mask = ITK_NULLPTR;
   ReadImage<ImageType>(mask,maskfn.c_str());
   Iterator mIter( mask,mask->GetLargestPossibleRegion() );
   for(  mIter.GoToBegin(); !mIter.IsAtEnd(); ++mIter )
@@ -12782,8 +12782,8 @@ int InPaint2(int argc, char *argv[])
     {
     sigma = atof(argv[argct]); argct++;
     }
-  typename ImageType::Pointer image1 = NULL;
-  typename ImageType::Pointer varimage = NULL;
+  typename ImageType::Pointer image1 = ITK_NULLPTR;
+  typename ImageType::Pointer varimage = ITK_NULLPTR;
   ReadImage<ImageType>(image1, fn1.c_str() );
   PixelType     spacingsize = 0;
   PixelType     minsp = image1->GetSpacing()[0];

--- a/Examples/ImageSetStatistics.cxx
+++ b/Examples/ImageSetStatistics.cxx
@@ -744,7 +744,7 @@ int ImageSetStatistics(int argc, char *argv[])
   typename ImageType::Pointer meanimage;
   std::vector<typename ImageType::Pointer> imagestack;
   imagestack.resize(filecount1);
-  //  imagestack.fill(NULL);
+  //  imagestack.fill(ITK_NULLPTR);
   std::vector<std::string> filenames(filecount1);
   typename ImageType::Pointer StatImage;
   unsigned int  ct = 0;
@@ -959,7 +959,7 @@ int ImageSetStatistics(int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ImageSetStatistics( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int ImageSetStatistics( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/KellyKapowski.cxx
+++ b/Examples/KellyKapowski.cxx
@@ -631,7 +631,7 @@ void KellyKapowskiInitializeCommandLineOptions( itk::ants::CommandLineParser *pa
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int KellyKapowski( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int KellyKapowski( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/KellySlater.cxx
+++ b/Examples/KellySlater.cxx
@@ -714,7 +714,7 @@ int LaplacianThicknessExpDiff2(int argc, char *argv[])
 
     while( ttiter < numtimepoints )    // N time integration points
       {
-      //      m_MFR->Compose(incrinvfield,invfield,NULL);
+      //      m_MFR->Compose(incrinvfield,invfield,ITK_NULLPTR);
       m_MFR->ComposeDiffs(invfield, incrinvfield, invfield, 1);
 
       if( debug )
@@ -1035,7 +1035,7 @@ int LaplacianThicknessExpDiff2(int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int KellySlater( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int KellySlater( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/LabelClustersUniquely.cxx
+++ b/Examples/LabelClustersUniquely.cxx
@@ -113,7 +113,7 @@ int  LabelUniquely(int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int LabelClustersUniquely( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int LabelClustersUniquely( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/LabelOverlapMeasures.cxx
+++ b/Examples/LabelOverlapMeasures.cxx
@@ -181,7 +181,7 @@ int LabelOverlapMeasures( int argc, char * argv[] )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int LabelOverlapMeasures( std::vector<std::string> args, std::ostream * /*out_stream = NULL */ )
+int LabelOverlapMeasures( std::vector<std::string> args, std::ostream * /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/LaplacianThickness.cxx
+++ b/Examples/LaplacianThickness.cxx
@@ -942,7 +942,7 @@ int LaplacianThickness(int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int LaplacianThickness( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int LaplacianThickness( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/LesionFilling.cxx
+++ b/Examples/LesionFilling.cxx
@@ -57,7 +57,7 @@ namespace ants
       return 0;
       }
     typename T1ImageReaderType::Pointer T1Reader = T1ImageReaderType::New();
-    T1Reader->SetFileName( T1FileName); 
+    T1Reader->SetFileName( T1FileName);
     try
       {
       T1Reader->Update();
@@ -67,7 +67,7 @@ namespace ants
       std::cout << "no T1 image that can be read" << std::endl;
       return 0;
       }
-    typename T1ImageType::Pointer outImage = NULL ;
+    typename T1ImageType::Pointer outImage = ITK_NULLPTR ;
     outImage = T1Reader->GetOutput() ;
     typedef itk::ImageRegionIterator< T1ImageType> IteratorType;
     typedef itk::BinaryThresholdImageFilter <T1ImageType, T1ImageType>
@@ -106,7 +106,7 @@ namespace ants
        //first finding the edges of lesions
        //by subtracting dilated lesion map from lesion map itself
        typename DilateFilterType::Pointer binaryDilate = DilateFilterType::New();
-  
+
        StructuringElementType structuringElement;
        structuringElement.SetRadius( 1 );  // 3x3 structuring element
        structuringElement.CreateStructuringElement();
@@ -129,9 +129,9 @@ namespace ants
        maskFilter->SetInput( outImage ) ;
        maskFilter->SetMaskImage( subtractFilter->GetOutput() );
        maskFilter->Update() ;
-       typename T1ImageType::Pointer LesionEdge= NULL ;
+       typename T1ImageType::Pointer LesionEdge= ITK_NULLPTR ;
        LesionEdge = maskFilter->GetOutput() ;
-       
+
        //calculating mean lesion intesity
        //Note: lesions should not be filled with values
        //less than their originial values, this is a
@@ -158,8 +158,8 @@ namespace ants
            ++it;
          }
        meanInsideLesion /= (double) counter;
-       
-       //check that all outer voxels are more than the mean 
+
+       //check that all outer voxels are more than the mean
        //intensity of the lesion, i.e. not including CSF voxels
        IteratorType itNoCSF( maskFilter->GetOutput(),
                          maskFilter->GetOutput()->GetLargestPossibleRegion() );
@@ -176,7 +176,7 @@ namespace ants
       //walk through original T1
       //and change inside the lesion with a random pick from
       //collected normal appearing WM voxels (outerWMVoxels)
-      IteratorType it4( outImage, 
+      IteratorType it4( outImage,
                         outImage->GetLargestPossibleRegion() );
       IteratorType itL( thresholdFilter->GetOutput(),
                         thresholdFilter->GetOutput()->GetLargestPossibleRegion() );
@@ -208,10 +208,10 @@ namespace ants
     std::cerr << "ExceptionObject caught !" << std::endl;
     std::cerr << err << std::endl;
     return EXIT_FAILURE;
-    } 
+    }
   return EXIT_SUCCESS;
   }//main int
-  
+
   int LesionFilling( std::vector<std::string> args, std::ostream* itkNotUsed( out_stream ) )
   {
     // put the arguments coming in as 'args' into standard (argc,argv) format;
@@ -219,7 +219,7 @@ namespace ants
     // 'args' may have adjacent arguments concatenated into one argument,
     // which the parser should handle
     args.insert( args.begin(), "LesionFilling" );
-  
+
     int     argc = args.size();
     char* * argv = new char *[args.size() + 1];
     for( unsigned int i = 0; i < args.size(); ++i )
@@ -238,7 +238,7 @@ namespace ants
       Cleanup_argv( char* * argv_, int argc_plus_one_ ) : argv( argv_ ), argc_plus_one( argc_plus_one_ )
       {
       }
-  
+
       ~Cleanup_argv()
       {
         for( unsigned int i = 0; i < argc_plus_one; ++i )
@@ -247,20 +247,20 @@ namespace ants
           }
         delete[] argv;
       }
-  
+
   private:
       char* *      argv;
       unsigned int argc_plus_one;
     };
     Cleanup_argv cleanup_argv( argv, argc + 1 );
-  
+
     // antscout->set_stream( out_stream );
-  
+
     //LesionFilling dimension t1.nii.gz lesionmask output.nii.gz
     if( argc < 3 )
       {
       std::cout << "Example usage: " << argv[0] << " imageDimension T1_image.nii.gz lesion_mask.nii.gz output_lesion_filled.nii.gz" << std::endl;
-  
+
       if( argc >= 2 &&
           ( std::string( argv[1] ) == std::string("--help") || std::string( argv[1] ) == std::string("-h") ) )
         {
@@ -268,7 +268,7 @@ namespace ants
         }
       return EXIT_FAILURE;
       }
-  
+
       switch( atoi( argv[1] ) )
         {
         case 2:
@@ -285,6 +285,6 @@ namespace ants
           std::cout << "Unsupported dimension" << std::endl;
           return EXIT_FAILURE;
         }
-     return EXIT_SUCCESS;    
+     return EXIT_SUCCESS;
   }//int LesionFilling std::vector
 }//namespace ants

--- a/Examples/MeasureImageSimilarity.cxx
+++ b/Examples/MeasureImageSimilarity.cxx
@@ -21,7 +21,7 @@ int MeasureImageSimilarity( itk::ants::CommandLineParser *parser )
   typedef typename RegistrationHelperType::DisplacementFieldType          DisplacementFieldType;
   typedef typename DisplacementFieldType::PixelType                       DisplacementVectorType;
   typedef typename RegistrationHelperType::DisplacementFieldTransformType DisplacementFieldTransformType;
-  
+
   typedef itk::ImageToImageMetricv4<ImageType, ImageType, ImageType, TComputeType>  ImageMetricType;
   typedef itk::ImageMaskSpatialObject<ImageDimension>                               ImageMaskSpatialObjectType;
   typedef typename ImageMaskSpatialObjectType::ImageType                            MaskImageType;
@@ -393,12 +393,12 @@ int MeasureImageSimilarity( itk::ants::CommandLineParser *parser )
     }
 
   std::cout << imageMetric->GetValue() << std::endl;
-  
+
   itk::ants::CommandLineParser::OptionType::Pointer outputOption = parser->GetOption( "output" );
   if( outputOption && outputOption->GetNumberOfFunctions() )
     {
     const DisplacementVectorType zeroVector( 0.0 );
-    
+
     typename DisplacementFieldType::Pointer identityField = DisplacementFieldType::New();
     identityField->CopyInformation( fixedImage );
     identityField->SetRegions( fixedImage->GetLargestPossibleRegion() );
@@ -413,9 +413,9 @@ int MeasureImageSimilarity( itk::ants::CommandLineParser *parser )
     imageMetric->SetMovingTransform( identityDisplacementFieldTransform );
 
     imageMetric->Initialize();
-    
+
     typedef typename ImageMetricType::DerivativeType MetricDerivativeType;
-    const typename MetricDerivativeType::SizeValueType metricDerivativeSize = 
+    const typename MetricDerivativeType::SizeValueType metricDerivativeSize =
       fixedImage->GetLargestPossibleRegion().GetNumberOfPixels() * ImageDimension;
     MetricDerivativeType metricDerivative( metricDerivativeSize );
 
@@ -427,9 +427,9 @@ int MeasureImageSimilarity( itk::ants::CommandLineParser *parser )
     gradientField->CopyInformation( fixedImage );
     gradientField->SetRegions( fixedImage->GetLargestPossibleRegion() );
     gradientField->Allocate();
-  
+
     itk::ImageRegionIterator<DisplacementFieldType> ItG( gradientField, gradientField->GetRequestedRegion() );
-  
+
     itk::SizeValueType count = 0;
     for( ItG.GoToBegin(); !ItG.IsAtEnd(); ++ItG )
       {
@@ -532,7 +532,7 @@ void InitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
   option->SetDescription( description );
   parser->AddOption( option );
   }
-  
+
   {
   std::string description = std::string( "Print the help menu (short version)." );
 
@@ -552,7 +552,7 @@ void InitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
   }
 }
 
-int MeasureImageSimilarity( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int MeasureImageSimilarity( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
 
   // put the arguments coming in as 'args' into standard (argc,argv) format;

--- a/Examples/MeasureMinMaxMean.cxx
+++ b/Examples/MeasureMinMaxMean.cxx
@@ -129,7 +129,7 @@ int MeasureMinMaxMean(int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int MeasureMinMaxMean( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int MeasureMinMaxMean( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;
@@ -193,7 +193,7 @@ private:
   unsigned int ncomponents = imageIO->GetNumberOfComponents();
 
   int returnValue = EXIT_FAILURE;
-  
+
   // Get the image dimension
   switch( atoi(argv[1]) )
     {
@@ -288,6 +288,6 @@ private:
       return EXIT_FAILURE;
     }
   return returnValue;
- 
+
 }
 } // namespace ants

--- a/Examples/MemoryTest.cxx
+++ b/Examples/MemoryTest.cxx
@@ -116,7 +116,7 @@ int MemoryTest(unsigned int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int MemoryTest( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int MemoryTest( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/MultiplyImages.cxx
+++ b/Examples/MultiplyImages.cxx
@@ -125,7 +125,7 @@ int MultiplyImages(int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int MultiplyImages( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int MultiplyImages( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;
@@ -191,7 +191,7 @@ private:
   unsigned int ncomponents = imageIO->GetNumberOfComponents();
 
   int returnValue = EXIT_FAILURE;
-  
+
   // Get the image dimension
   switch( atoi(argv[1]) )
     {

--- a/Examples/N3BiasFieldCorrection.cxx
+++ b/Examples/N3BiasFieldCorrection.cxx
@@ -199,7 +199,7 @@ int N3BiasFieldCorrection( int argc, char *argv[] )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int N3BiasFieldCorrection( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int N3BiasFieldCorrection( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/N4BiasFieldCorrection.cxx
+++ b/Examples/N4BiasFieldCorrection.cxx
@@ -782,7 +782,7 @@ void N4InitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int N4BiasFieldCorrection( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int N4BiasFieldCorrection( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/NonLocalSuperResolution.cxx
+++ b/Examples/NonLocalSuperResolution.cxx
@@ -579,7 +579,7 @@ void InitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int NonLocalSuperResolution( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int NonLocalSuperResolution( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/PasteImageIntoImage.cxx
+++ b/Examples/PasteImageIntoImage.cxx
@@ -89,7 +89,7 @@ int PasteImageIntoImage( unsigned int argc, char *argv[] )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int PasteImageIntoImage( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int PasteImageIntoImage( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/PermuteFlipImageOrientationAxes.cxx
+++ b/Examples/PermuteFlipImageOrientationAxes.cxx
@@ -132,7 +132,7 @@ int PermuteFlipImageOrientationAxes( int argc, char * argv[] )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int PermuteFlipImageOrientationAxes( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int PermuteFlipImageOrientationAxes( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/PrintHeader.cxx
+++ b/Examples/PrintHeader.cxx
@@ -388,7 +388,7 @@ bool FileExists(string strFilename)
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int PrintHeader( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int PrintHeader( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/RebaseTensorImage.cxx
+++ b/Examples/RebaseTensorImage.cxx
@@ -25,7 +25,7 @@ namespace ants
 {
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int RebaseTensorImage( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int RebaseTensorImage( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ReorientTensorImage.cxx
+++ b/Examples/ReorientTensorImage.cxx
@@ -150,7 +150,7 @@ void ReorientTensorImage(char *moving_image_filename, char *output_image_filenam
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ReorientTensorImage( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int ReorientTensorImage( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ResampleImage.cxx
+++ b/Examples/ResampleImage.cxx
@@ -260,7 +260,7 @@ typename ImageType::IndexType newStartIndex;
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ResampleImage( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int ResampleImage( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ResampleImageBySpacing.cxx
+++ b/Examples/ResampleImageBySpacing.cxx
@@ -27,7 +27,7 @@ namespace ants
 {
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ResampleImageBySpacing( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int ResampleImageBySpacing( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   args.insert( args.begin(), "ResampleImageBySpacing" );
   int     argc = args.size();

--- a/Examples/ResetDirection.cxx
+++ b/Examples/ResetDirection.cxx
@@ -77,7 +77,7 @@ int ResetDirection(int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ResetDirection( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int ResetDirection( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/SetDirectionByMatrix.cxx
+++ b/Examples/SetDirectionByMatrix.cxx
@@ -96,7 +96,7 @@ int ResetDirection(int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int SetDirectionByMatrix( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int SetDirectionByMatrix( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/SetOrigin.cxx
+++ b/Examples/SetOrigin.cxx
@@ -85,7 +85,7 @@ int SetOrigin(int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int SetOrigin( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int SetOrigin( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/SetSpacing.cxx
+++ b/Examples/SetSpacing.cxx
@@ -87,7 +87,7 @@ int SetSpacing(int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int SetSpacing( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int SetSpacing( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/SmoothDisplacementField.cxx
+++ b/Examples/SmoothDisplacementField.cxx
@@ -225,7 +225,7 @@ int SmoothDisplacementField( int argc, char *argv[] )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int SmoothDisplacementField( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int SmoothDisplacementField( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/SmoothImage.cxx
+++ b/Examples/SmoothImage.cxx
@@ -120,7 +120,7 @@ int SmoothImage(int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int SmoothImage( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int SmoothImage( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/StackSlices.cxx
+++ b/Examples/StackSlices.cxx
@@ -35,7 +35,7 @@ namespace ants
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int StackSlices( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int StackSlices( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/StudentsTestOnImages.cxx
+++ b/Examples/StudentsTestOnImages.cxx
@@ -106,7 +106,7 @@ void generatePermGroup(int * groupID, int lengthGroupA, int lengthGroupB,
 
   if( !first )
     {
-    first = 1; srand(time(NULL) );
+    first = 1; srand(time(ITK_NULLPTR) );
     // cout << "generatePermGroup called" << endl;
     }
   int * newPerm = new int[numSubjects];
@@ -123,7 +123,7 @@ void generatePerm(int length, int * genPerm)
 {
   if( !first )
     {
-    first = 1; srand(time(NULL) );
+    first = 1; srand(time(ITK_NULLPTR) );
     // cout << "generatePerm called" << endl;
     }
   PermElement * newPerm = new PermElement[length];
@@ -169,7 +169,7 @@ double computeQuantile(int numObs, double * stat, double quantile)
   if( !first )
     {
     first = 1;
-    srand(time(NULL) );
+    srand(time(ITK_NULLPTR) );
     }
 
   StatElement * sortStat = new StatElement[numObs];
@@ -212,7 +212,7 @@ void computePermStatPval(int numFeatures, int numPerms,
   if( !first )
     {
     first = 1;
-    srand(time(NULL) );
+    srand(time(ITK_NULLPTR) );
     }
 
   int feat;
@@ -427,7 +427,7 @@ int StudentsTestOnImages(int argc, char *argv[])
   typedef float                                 PixelType;
   typedef itk::Image<PixelType, ImageDimension> ImageType;
 
-  typename ImageType::Pointer mask = NULL;
+  typename ImageType::Pointer mask = ITK_NULLPTR;
 //  ReadImage<ImageType>(mask, argv[1], false);
 
   unsigned int numSubjectsA = atoi(argv[3]);
@@ -561,7 +561,7 @@ int StudentsTestOnImages(int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int StudentsTestOnImages( std::vector<std::string> args, std::ostream* out_stream = NULL )
+int StudentsTestOnImages( std::vector<std::string> args, std::ostream* out_stream = ITK_NULLPTR )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/SuperResolution.cxx
+++ b/Examples/SuperResolution.cxx
@@ -278,7 +278,7 @@ int SuperResolution( unsigned int argc, char *argv[] )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int SuperResolution( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int SuperResolution( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/SurfaceBasedSmoothing.cxx
+++ b/Examples/SurfaceBasedSmoothing.cxx
@@ -10,7 +10,7 @@ namespace ants
 {
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int SurfaceBasedSmoothing( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int SurfaceBasedSmoothing( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/SurfaceCurvature.cxx
+++ b/Examples/SurfaceCurvature.cxx
@@ -43,7 +43,7 @@ typedef itk::SurfaceCurvatureBase<ImageType>  ParamType;
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int SurfaceCurvature( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int SurfaceCurvature( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/TensorDerivedImage.cxx
+++ b/Examples/TensorDerivedImage.cxx
@@ -30,7 +30,7 @@ namespace ants
 {
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int TensorDerivedImage( std::vector<std::string> args, std::ostream* out_stream = NULL )
+int TensorDerivedImage( std::vector<std::string> args, std::ostream* out_stream = ITK_NULLPTR )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/TextureCooccurrenceFeatures.cxx
+++ b/Examples/TextureCooccurrenceFeatures.cxx
@@ -46,7 +46,7 @@ int TextureCooccurrenceFeatures( int argc, char *argv[] )
   typename TextureFilterType::Pointer textureFilter = TextureFilterType::New();
   textureFilter->SetInput( rescaler->GetOutput() );
 
-  typename ImageType::Pointer mask = NULL;
+  typename ImageType::Pointer mask = ITK_NULLPTR;
   PixelType label = itk::NumericTraits<PixelType>::OneValue();
   if ( argc > 4 )
     {
@@ -154,7 +154,7 @@ int TextureCooccurrenceFeatures( int argc, char *argv[] )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int TextureCooccurrenceFeatures( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int TextureCooccurrenceFeatures( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/TextureRunLengthFeatures.cxx
+++ b/Examples/TextureRunLengthFeatures.cxx
@@ -34,7 +34,7 @@ int TextureRunLengthFeatures( int argc, char *argv[] )
   typename RunLengthFilterType::Pointer runLengthFilter = RunLengthFilterType::New();
   runLengthFilter->SetInput( inputImage );
 
-  typename ImageType::Pointer mask = NULL;
+  typename ImageType::Pointer mask = ITK_NULLPTR;
   PixelType label = itk::NumericTraits<PixelType>::OneValue();
   if ( argc > 4 )
     {
@@ -125,7 +125,7 @@ int TextureRunLengthFeatures( int argc, char *argv[] )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int TextureRunLengthFeatures( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int TextureRunLengthFeatures( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/ThresholdImage.cxx
+++ b/Examples/ThresholdImage.cxx
@@ -483,7 +483,7 @@ int ThresholdImage( int argc, char * argv[] )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int ThresholdImage( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int ThresholdImage( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/TileImages.cxx
+++ b/Examples/TileImages.cxx
@@ -148,7 +148,7 @@ int CreateMosaic( unsigned int argc, char *argv[] )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int TileImages( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int TileImages( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/TimeSCCAN.cxx
+++ b/Examples/TimeSCCAN.cxx
@@ -770,7 +770,7 @@ void InitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int TimeSCCAN( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int TimeSCCAN( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/WarpImageMultiTransform.cxx
+++ b/Examples/WarpImageMultiTransform.cxx
@@ -349,7 +349,7 @@ void WarpImageMultiTransform(char *moving_image_filename, char *output_image_fil
     img_ref = reader_img_ref->GetOutput();
     }
   // else
-  //    img_ref = NULL;
+  //    img_ref = ITK_NULLPTR;
 
   typename WarperType::Pointer  warper = WarperType::New();
   warper->SetInput(img_mov);
@@ -627,7 +627,7 @@ void WarpImageMultiTransform(char *moving_image_filename, char *output_image_fil
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int WarpImageMultiTransform( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int WarpImageMultiTransform( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/WarpTensorImageMultiTransform.cxx
+++ b/Examples/WarpTensorImageMultiTransform.cxx
@@ -481,7 +481,7 @@ static void WarpImageMultiTransform(char *moving_image_filename, char *output_im
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int WarpTensorImageMultiTransform( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int WarpTensorImageMultiTransform( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/WarpTimeSeriesImageMultiTransform.cxx
+++ b/Examples/WarpTimeSeriesImageMultiTransform.cxx
@@ -640,7 +640,7 @@ void WarpImageMultiTransform(char *moving_image_filename, char *output_image_fil
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int WarpTimeSeriesImageMultiTransform( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int WarpTimeSeriesImageMultiTransform( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/WarpVTKPolyDataMultiTransform.cxx
+++ b/Examples/WarpVTKPolyDataMultiTransform.cxx
@@ -81,7 +81,7 @@ static bool WarpVTKPolyDataMultiTransform_ParseInput(int argc, char * *argv, cha
   input_vtk_filename = argv[0];
   output_vtk_filename = argv[1];
 
-  reference_image_filename = NULL;
+  reference_image_filename = ITK_NULLPTR;
 
   int ind = 2;
   while( ind < argc )
@@ -126,7 +126,7 @@ static bool WarpVTKPolyDataMultiTransform_ParseInput(int argc, char * *argv, cha
     ind++;
     }
 
-//    if (reference_image_filename == NULL) {
+//    if (reference_image_filename == ITK_NULLPTR) {
 //        std::cout << "the reference image file (-R) must be given!!!"
 //        << std::endl;
 //        return false;
@@ -540,10 +540,10 @@ private:
     }
 
   TRAN_OPT_QUEUE opt_queue;
-  //    char *moving_image_filename = NULL;
-  char *input_vtk_filename = NULL;
-  char *output_vtk_filename = NULL;
-  char *reference_image_filename = NULL;
+  //    char *moving_image_filename = ITK_NULLPTR;
+  char *input_vtk_filename = ITK_NULLPTR;
+  char *output_vtk_filename = ITK_NULLPTR;
+  char *reference_image_filename = ITK_NULLPTR;
 
   int  kImageDim = atoi(argv[1]);
 
@@ -556,7 +556,7 @@ private:
       {
       case DEFORMATION_FILE:
         {
-        if( reference_image_filename == NULL )
+        if( reference_image_filename == ITK_NULLPTR )
           {
           std::cout << "the reference image file (-R) must be given!!!"
                    << std::endl;

--- a/Examples/antsAI.cxx
+++ b/Examples/antsAI.cxx
@@ -1559,7 +1559,7 @@ void InitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
   }
 }
 
-int antsAI( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int antsAI( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
 
   // put the arguments coming in as 'args' into standard (argc,argv) format;

--- a/Examples/antsAffineInitializer.cxx
+++ b/Examples/antsAffineInitializer.cxx
@@ -520,7 +520,7 @@ int antsAffineInitializerImp(int argc, char *argv[])
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int antsAffineInitializer( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int antsAffineInitializer( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/antsAlignOrigin.cxx
+++ b/Examples/antsAlignOrigin.cxx
@@ -216,7 +216,7 @@ static void InitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int antsAlignOrigin( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int antsAlignOrigin( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/antsApplyTransforms.cxx
+++ b/Examples/antsApplyTransforms.cxx
@@ -901,7 +901,7 @@ static void antsApplyTransformsInitializeCommandLineOptions( itk::ants::CommandL
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int antsApplyTransforms( std::vector<std::string> args, std::ostream * /*out_stream = NULL */ )
+int antsApplyTransforms( std::vector<std::string> args, std::ostream * /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/antsApplyTransformsToPoints.cxx
+++ b/Examples/antsApplyTransformsToPoints.cxx
@@ -380,7 +380,7 @@ static void antsApplyTransformsToPointsInitializeCommandLineOptions( itk::ants::
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int antsApplyTransformsToPoints( std::vector<std::string> args, std::ostream * /*out_stream = NULL */ )
+int antsApplyTransformsToPoints( std::vector<std::string> args, std::ostream * /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/antsJointFusion.cxx
+++ b/Examples/antsJointFusion.cxx
@@ -870,7 +870,7 @@ void InitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int antsJointFusion( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int antsJointFusion( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/antsJointTensorFusion.cxx
+++ b/Examples/antsJointTensorFusion.cxx
@@ -842,7 +842,7 @@ void InitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int antsJointTensorFusion( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int antsJointTensorFusion( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/antsLandmarkBasedTransformInitializer.cxx
+++ b/Examples/antsLandmarkBasedTransformInitializer.cxx
@@ -510,7 +510,7 @@ int InitializeBSplineTransform( int argc, char *argv[] )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int antsLandmarkBasedTransformInitializer( std::vector<std::string> args, std::ostream* /*out_stream = NULL */)
+int antsLandmarkBasedTransformInitializer( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */)
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/antsMotionCorr.cxx
+++ b/Examples/antsMotionCorr.cxx
@@ -167,7 +167,7 @@ typename ImageType::Pointer PreprocessImage( ImageType * inputImage,
                                              typename ImageType::PixelType lowerScaleFunction,
                                              typename ImageType::PixelType upperScaleFunction,
                                              float winsorizeLowerQuantile, float winsorizeUpperQuantile,
-                                             ImageType *histogramMatchSourceImage = NULL )
+                                             ImageType *histogramMatchSourceImage = ITK_NULLPTR )
 {
   bool verbose = false;
   typedef itk::Statistics::ImageToHistogramFilter<ImageType>   HistogramFilterType;
@@ -1824,7 +1824,7 @@ void antsMotionCorrInitializeCommandLineOptions( itk::ants::CommandLineParser *p
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int antsMotionCorr( std::vector<std::string> args, std::ostream * /*out_stream = NULL */ )
+int antsMotionCorr( std::vector<std::string> args, std::ostream * /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/antsMotionCorrDiffusionDirection.cxx
+++ b/Examples/antsMotionCorrDiffusionDirection.cxx
@@ -254,7 +254,7 @@ int ants_motion_directions( itk::ants::CommandLineParser *parser )
             directionArray(i-2,j) = schemeMatrix(i-2,j);
           }
       }
-    
+
     }
 
   bool transposeArray = true;
@@ -330,7 +330,7 @@ int ants_motion_directions( itk::ants::CommandLineParser *parser )
      std::cout << "Can't read reference image " << physicalName << std::endl;
      return EXIT_FAILURE;
    }
- if (imageIO->GetNumberOfDimensions() != ImageDimension) 
+ if (imageIO->GetNumberOfDimensions() != ImageDimension)
    {
      std::cout << "Reference image must be 3D " << std::endl;
      return EXIT_FAILURE;
@@ -382,7 +382,7 @@ int ants_motion_directions( itk::ants::CommandLineParser *parser )
     AffineTransformType::Pointer directionTransform = AffineTransformType::New();
     AffineTransformType::ParametersType params;
 
-    if (nTransformParams == 6) { 
+    if (nTransformParams == 6) {
       RigidTransformType::Pointer rigid = RigidTransformType::New();
       RigidTransformType::ParametersType rParams;
 
@@ -395,7 +395,7 @@ int ants_motion_directions( itk::ants::CommandLineParser *parser )
       affineTransform->SetMatrix( rigid->GetMatrix() );
       affineTransform->SetTranslation( rigid->GetTranslation() );
     }
-    else if (nTransformParams == 12) { 
+    else if (nTransformParams == 12) {
       params.SetSize( nTransformParams );
       for ( unsigned int t=0; t<nTransformParams; t++ )
         {
@@ -571,7 +571,7 @@ void antsMotionCorrDiffusionDirectionInitializeCommandLineOptions( itk::ants::Co
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int antsMotionCorrDiffusionDirection( std::vector<std::string> args, std::ostream * /*out_stream = NULL */ )
+int antsMotionCorrDiffusionDirection( std::vector<std::string> args, std::ostream * /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/antsMotionCorrStats.cxx
+++ b/Examples/antsMotionCorrStats.cxx
@@ -44,12 +44,12 @@ int ants_motion_stats( itk::ants::CommandLineParser *parser )
   typedef itk::Image<RealType, ImageDimension>      ImageType;
   typedef vnl_matrix<RealType>                      vMatrix;
   vMatrix param_values;
-  typedef itk::Image<RealType, 4>                   TimeSeriesImageType; 
-  typedef TimeSeriesImageType::RegionType           TimeSeriesRegionType; 
+  typedef itk::Image<RealType, 4>                   TimeSeriesImageType;
+  typedef TimeSeriesImageType::RegionType           TimeSeriesRegionType;
   typedef TimeSeriesImageType::IndexType            TimeSeriesIndexType;
-  typedef TimeSeriesImageType::SizeType             TimeSeriesSizeType; 
+  typedef TimeSeriesImageType::SizeType             TimeSeriesSizeType;
   typedef itk::ImageRegionIterator< TimeSeriesImageType > TimeSeriesIteratorType;
- 
+
   typedef itk::ImageRegionIteratorWithIndex<ImageType>      IteratorType;
   typedef itk::AffineTransform<RealType, ImageDimension>    AffineTransformType;
   typedef itk::Euler3DTransform<RealType>                   RigidTransformType;
@@ -69,11 +69,11 @@ int ants_motion_stats( itk::ants::CommandLineParser *parser )
   std::string outputName = "";
   std::string mocoName = "";
   std::string spatialName = "";
-  std::string timeseriesDisplacementName = ""; 
+  std::string timeseriesDisplacementName = "";
   unsigned long transformIndex = 0;
   bool writeMap = false;
   bool writeTransform = false;
-  bool timeseriesDisplacement = false; 
+  bool timeseriesDisplacement = false;
 
   OptionType::Pointer outputOption = parser->GetOption( "output" );
   if( outputOption && outputOption->GetNumberOfFunctions() )
@@ -95,13 +95,13 @@ int ants_motion_stats( itk::ants::CommandLineParser *parser )
     writeMap = true;
     }
 
-  OptionType::Pointer timeseriesDisplacementOption = 
-    parser->GetOption("timeseries-displacement"); 
+  OptionType::Pointer timeseriesDisplacementOption =
+    parser->GetOption("timeseries-displacement");
   if(timeseriesDisplacementOption && timeseriesDisplacementOption->GetNumberOfFunctions())
   {
-    timeseriesDisplacementName = timeseriesDisplacementOption->GetFunction(0)->GetName(); 
-    std::cout << "Time-series displacement map input 4d image: " << timeseriesDisplacementName << std::endl; 
-    timeseriesDisplacement = true; 
+    timeseriesDisplacementName = timeseriesDisplacementOption->GetFunction(0)->GetName();
+    std::cout << "Time-series displacement map input 4d image: " << timeseriesDisplacementName << std::endl;
+    timeseriesDisplacement = true;
   }
   OptionType::Pointer transformOption = parser->GetOption( "transform" );
   if( transformOption && transformOption->GetNumberOfFunctions() )
@@ -152,7 +152,7 @@ int ants_motion_stats( itk::ants::CommandLineParser *parser )
     }
 
 
-  TimeSeriesImageType::Pointer timeseriesImage = TimeSeriesImageType::New(); 
+  TimeSeriesImageType::Pointer timeseriesImage = TimeSeriesImageType::New();
   TimeSeriesImageType::Pointer timeseriesDisplacementImage = TimeSeriesImageType::New();
   if ( timeseriesDisplacement )
     {
@@ -165,7 +165,7 @@ int ants_motion_stats( itk::ants::CommandLineParser *parser )
 	  timeseriesDisplacementImage->SetDirection(timeseriesImage->GetDirection());
     }
 
-  
+
   bool doFramewise = 0;
   doFramewise = parser->Convert<bool>( parser->GetOption( "framewise" )->GetFunction()->GetName() );
   std::cout << "Framewise = " << doFramewise << std::endl;
@@ -274,22 +274,22 @@ int ants_motion_stats( itk::ants::CommandLineParser *parser )
     double meanDisplacement = 0.0;
     double maxDisplacement = 0.0;
     double count = 0;
-    
+
     // we iterate over the time-series one time volume at a time
-    TimeSeriesRegionType timeSeriesRegion; 
-    TimeSeriesIndexType timeSeriesIndex; 
-    TimeSeriesSizeType timeSeriesSize; 
+    TimeSeriesRegionType timeSeriesRegion;
+    TimeSeriesIndexType timeSeriesIndex;
+    TimeSeriesSizeType timeSeriesSize;
     if(timeseriesDisplacement){
       for(int jj=0; jj<3; jj++){
-        timeSeriesIndex[jj] = mask->GetLargestPossibleRegion().GetIndex()[jj]; 
-        timeSeriesSize[jj] = mask->GetLargestPossibleRegion().GetSize()[jj]; 
+        timeSeriesIndex[jj] = mask->GetLargestPossibleRegion().GetIndex()[jj];
+        timeSeriesSize[jj] = mask->GetLargestPossibleRegion().GetSize()[jj];
       }
-      timeSeriesIndex[3] = i; 
+      timeSeriesIndex[3] = i;
       timeSeriesSize[3] = 1;
-      timeSeriesRegion.SetIndex(timeSeriesIndex); 
+      timeSeriesRegion.SetIndex(timeSeriesIndex);
       timeSeriesRegion.SetSize(timeSeriesSize);
-    }  
-    TimeSeriesIteratorType timeseriesIterator(timeseriesDisplacementImage, timeSeriesRegion); 
+    }
+    TimeSeriesIteratorType timeseriesIterator(timeseriesDisplacementImage, timeSeriesRegion);
     IteratorType it( mask, mask->GetLargestPossibleRegion() );
     while( !it.IsAtEnd() )
       {
@@ -337,11 +337,11 @@ int ants_motion_stats( itk::ants::CommandLineParser *parser )
         ++count;
         if(timeseriesDisplacement) {
           timeseriesIterator.Set(dist);
-        } 
+        }
         }
       ++it;
       if(timeseriesDisplacement) {
-        ++timeseriesIterator; 
+        ++timeseriesIterator;
       }
       }
 
@@ -364,7 +364,7 @@ int ants_motion_stats( itk::ants::CommandLineParser *parser )
     {
     WriteImage<ImageType>( map, spatialOption->GetFunction(0)->GetName().c_str()  );
     }
-  
+
   if(timeseriesDisplacement){
 	std::string tsOutImageName = outputName;
     std::size_t lastdot = outputName.find_last_of(".");
@@ -445,14 +445,14 @@ void antsMotionCorrStatsInitializeCommandLineOptions( itk::ants::CommandLinePars
     parser->AddOption( option );
     }
 
-    { 
-    std::string description = 
+    {
+    std::string description =
       std::string("output 4d time-series image of displacement magnitude");
-    OptionType::Pointer option = OptionType::New(); 
-    option->SetLongName("timeseries-displacement"); 
+    OptionType::Pointer option = OptionType::New();
+    option->SetLongName("timeseries-displacement");
     option->SetShortName('d');
-    option->SetDescription(description); 
-    parser->AddOption(option);  
+    option->SetDescription(description);
+    parser->AddOption(option);
     }
     {
     std::string description = std::string( "Print the help menu (short version)." );
@@ -478,7 +478,7 @@ void antsMotionCorrStatsInitializeCommandLineOptions( itk::ants::CommandLinePars
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int antsMotionCorrStats( std::vector<std::string> args, std::ostream * /*out_stream = NULL */ )
+int antsMotionCorrStats( std::vector<std::string> args, std::ostream * /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/antsRegistration.cxx
+++ b/Examples/antsRegistration.cxx
@@ -521,7 +521,7 @@ static void antsRegistrationInitializeCommandLineOptions( itk::ants::CommandLine
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
 
-int antsRegistration( std::vector<std::string> args, std::ostream * /*out_stream = NULL */ )
+int antsRegistration( std::vector<std::string> args, std::ostream * /*out_stream = ITK_NULLPTR */ )
 {
   try
     {

--- a/Examples/antsSliceRegularizedRegistration.cxx
+++ b/Examples/antsSliceRegularizedRegistration.cxx
@@ -168,7 +168,7 @@ typename ImageType::Pointer sliceRegularizedPreprocessImage( ImageType * inputIm
                                              typename ImageType::PixelType lowerScaleFunction,
                                              typename ImageType::PixelType upperScaleFunction,
                                              float winsorizeLowerQuantile, float winsorizeUpperQuantile,
-                                             ImageType *histogramMatchSourceImage = NULL )
+                                             ImageType *histogramMatchSourceImage = ITK_NULLPTR )
 {
   typedef itk::Statistics::ImageToHistogramFilter<ImageType>   HistogramFilterType;
   typedef typename HistogramFilterType::InputBooleanObjectType InputBooleanObjectType;
@@ -1243,7 +1243,7 @@ void antsSliceRegularizedRegistrationInitializeCommandLineOptions( itk::ants::Co
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int antsSliceRegularizedRegistration( std::vector<std::string> args, std::ostream * /*out_stream = NULL */ )
+int antsSliceRegularizedRegistration( std::vector<std::string> args, std::ostream * /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/antsSurf.cxx
+++ b/Examples/antsSurf.cxx
@@ -79,7 +79,7 @@ void Display( vtkPolyData *vtkMesh,
               const std::vector<float> backgroundColor,
               const std::string screenCaptureFileName,
               const bool renderScalarBar = false,
-              vtkLookupTable *scalarBarLookupTable = NULL,
+              vtkLookupTable *scalarBarLookupTable = ITK_NULLPTR,
               const std::string scalarBarTitle = std::string( "" ),
               unsigned int scalarBarNumberOfLabels = 5,
               unsigned int scalarBarWidthInPixels = 0,
@@ -204,7 +204,7 @@ int antsImageToSurface( itk::ants::CommandLineParser *parser )
 
   // Read in input surface image
 
-  ImageType::Pointer inputImage = NULL;
+  ImageType::Pointer inputImage = ITK_NULLPTR;
 
   RealType defaultColorRed = 255.0;
   RealType defaultColorGreen = 255.0;
@@ -1000,7 +1000,7 @@ void InitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int antsSurf( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int antsSurf( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/antsTransformInfo.cxx
+++ b/Examples/antsTransformInfo.cxx
@@ -28,7 +28,7 @@ namespace ants
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int antsTransformInfo( std::vector<std::string> args, std::ostream * /*out_stream = NULL */ )
+int antsTransformInfo( std::vector<std::string> args, std::ostream * /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;
@@ -71,7 +71,7 @@ private:
   Cleanup_argv cleanup_argv( argv, argc + 1 );
 
   for (int i=1; i<argc; i++) {
-  
+
     std::cout << "Transform file: " << argv[i] << std::endl;
 
     itk::TransformFileReader::Pointer reader = itk::TransformFileReader::New();

--- a/Examples/antsVol.cxx
+++ b/Examples/antsVol.cxx
@@ -470,7 +470,7 @@ void InitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int antsVol( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int antsVol( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/compareTwoTransforms.cxx
+++ b/Examples/compareTwoTransforms.cxx
@@ -154,7 +154,7 @@ int compareTransforms( const typename itk::Transform<double, VImageDimension, VI
   return EXIT_SUCCESS;
 }
 
-int compareTwoTransforms( std::vector<std::string> args, std::ostream* /* out_stream = NULL */ )
+int compareTwoTransforms( std::vector<std::string> args, std::ostream* /* out_stream = ITK_NULLPTR */ )
 {
   // the arguments coming in as 'args' is a replacement for the standard (argc,argv) format
   // Just notice that the argv[i] equals to args[i-1]

--- a/Examples/iMath.cxx
+++ b/Examples/iMath.cxx
@@ -166,8 +166,8 @@ iMathHelperAll(int argc, char **argv)
   if( operation == "BlobDetector" )
     {
     typedef itk::Image<float,DIM> ImageType;
-    typename ImageType::Pointer input = NULL;
-    typename ImageType::Pointer output = NULL;
+    typename ImageType::Pointer input = ITK_NULLPTR;
+    typename ImageType::Pointer output = ITK_NULLPTR;
 
     if ( argc < 6 )
     {
@@ -200,8 +200,8 @@ iMathHelperAll(int argc, char **argv)
   else if( operation == "Canny" )
     {
     typedef itk::Image<float,DIM> ImageType;
-    typename ImageType::Pointer input = NULL;
-    typename ImageType::Pointer output = NULL;
+    typename ImageType::Pointer input = ITK_NULLPTR;
+    typename ImageType::Pointer output = ITK_NULLPTR;
 
     if ( argc < 8 )
     {
@@ -237,8 +237,8 @@ iMathHelperAll(int argc, char **argv)
     {
 
     typedef itk::Image<float,DIM> ImageType;
-    typename ImageType::Pointer input = NULL;
-    typename ImageType::Pointer output = NULL;
+    typename ImageType::Pointer input = ITK_NULLPTR;
+    typename ImageType::Pointer output = ITK_NULLPTR;
 
     bool useSpacing = iMathDistanceMapUseSpacing;
 
@@ -271,8 +271,8 @@ iMathHelperAll(int argc, char **argv)
     {
 
     typedef itk::Image<float,DIM> ImageType;
-    typename ImageType::Pointer input = NULL;
-    typename ImageType::Pointer output = NULL;
+    typename ImageType::Pointer input = ITK_NULLPTR;
+    typename ImageType::Pointer output = ITK_NULLPTR;
 
     double holeType = iMathFillHolesHoleParam;
 
@@ -311,8 +311,8 @@ iMathHelperAll(int argc, char **argv)
       }
 
     typedef itk::Image<float,DIM> ImageType;
-    typename ImageType::Pointer input = NULL;
-    typename ImageType::Pointer output = NULL;
+    typename ImageType::Pointer input = ITK_NULLPTR;
+    typename ImageType::Pointer output = ITK_NULLPTR;
 
     ReadImage<ImageType>( input, inName.c_str() );
     if ( input.IsNull() )
@@ -344,8 +344,8 @@ iMathHelperAll(int argc, char **argv)
       }
 
     typedef itk::Image<float,DIM> ImageType;
-    typename ImageType::Pointer input = NULL;
-    typename ImageType::Pointer output = NULL;
+    typename ImageType::Pointer input = ITK_NULLPTR;
+    typename ImageType::Pointer output = ITK_NULLPTR;
 
     ReadImage<ImageType>( input, inName.c_str() );
     if ( input.IsNull() )
@@ -377,8 +377,8 @@ iMathHelperAll(int argc, char **argv)
       }
 
     typedef itk::Image<float,DIM> ImageType;
-    typename ImageType::Pointer input = NULL;
-    typename ImageType::Pointer output = NULL;
+    typename ImageType::Pointer input = ITK_NULLPTR;
+    typename ImageType::Pointer output = ITK_NULLPTR;
 
     ReadImage<ImageType>( input, inName.c_str() );
     if ( input.IsNull() )
@@ -410,8 +410,8 @@ iMathHelperAll(int argc, char **argv)
       }
 
     typedef itk::Image<float,DIM> ImageType;
-    typename ImageType::Pointer input = NULL;
-    typename ImageType::Pointer output = NULL;
+    typename ImageType::Pointer input = ITK_NULLPTR;
+    typename ImageType::Pointer output = ITK_NULLPTR;
 
     ReadImage<ImageType>( input, inName.c_str() );
     if ( input.IsNull() )
@@ -442,8 +442,8 @@ iMathHelperAll(int argc, char **argv)
     }
 
     typedef itk::Image<float,DIM> ImageType;
-    typename ImageType::Pointer input = NULL;
-    typename ImageType::Pointer output = NULL;
+    typename ImageType::Pointer input = ITK_NULLPTR;
+    typename ImageType::Pointer output = ITK_NULLPTR;
 
     ReadImage<ImageType>( input, inName.c_str() );
     if ( input.IsNull() )
@@ -480,8 +480,8 @@ iMathHelperAll(int argc, char **argv)
       }
 
     typedef itk::Image<float,DIM> ImageType;
-    typename ImageType::Pointer input = NULL;
-    typename ImageType::Pointer output = NULL;
+    typename ImageType::Pointer input = ITK_NULLPTR;
+    typename ImageType::Pointer output = ITK_NULLPTR;
 
     ReadImage<ImageType>( input, inName.c_str() );
     if ( input.IsNull() )
@@ -506,8 +506,8 @@ iMathHelperAll(int argc, char **argv)
   else if( operation == "HistogramEqualization" )
     {
     typedef itk::Image<float,DIM> ImageType;
-    typename ImageType::Pointer input = NULL;
-    typename ImageType::Pointer output = NULL;
+    typename ImageType::Pointer input = ITK_NULLPTR;
+    typename ImageType::Pointer output = ITK_NULLPTR;
     float alpha = 0;
     float beta  = 1;
     if ( argc >= 6 )
@@ -555,8 +555,8 @@ iMathHelperAll(int argc, char **argv)
       }
 
     typedef itk::Image<float,DIM> ImageType;
-    typename ImageType::Pointer input = NULL;
-    typename ImageType::Pointer output = NULL;
+    typename ImageType::Pointer input = ITK_NULLPTR;
+    typename ImageType::Pointer output = ITK_NULLPTR;
 
     ReadImage<ImageType>( input, inName.c_str() );
     if ( input.IsNull() )
@@ -623,8 +623,8 @@ iMathHelperAll(int argc, char **argv)
       }
 
     typedef itk::Image<float,DIM> ImageType;
-    typename ImageType::Pointer input = NULL;
-    typename ImageType::Pointer output = NULL;
+    typename ImageType::Pointer input = ITK_NULLPTR;
+    typename ImageType::Pointer output = ITK_NULLPTR;
 
     ReadImage<ImageType>( input, inName.c_str() );
     if ( input.IsNull() )
@@ -691,8 +691,8 @@ iMathHelperAll(int argc, char **argv)
       }
 
     typedef itk::Image<float,DIM> ImageType;
-    typename ImageType::Pointer input = NULL;
-    typename ImageType::Pointer output = NULL;
+    typename ImageType::Pointer input = ITK_NULLPTR;
+    typename ImageType::Pointer output = ITK_NULLPTR;
 
     ReadImage<ImageType>( input, inName.c_str() );
     if ( input.IsNull() )
@@ -758,8 +758,8 @@ iMathHelperAll(int argc, char **argv)
       }
 
     typedef itk::Image<float,DIM> ImageType;
-    typename ImageType::Pointer input = NULL;
-    typename ImageType::Pointer output = NULL;
+    typename ImageType::Pointer input = ITK_NULLPTR;
+    typename ImageType::Pointer output = ITK_NULLPTR;
 
     ReadImage<ImageType>( input, inName.c_str() );
     if ( input.IsNull() )
@@ -825,8 +825,8 @@ iMathHelperAll(int argc, char **argv)
       }
 
     typedef itk::Image<float,DIM> ImageType;
-    typename ImageType::Pointer input = NULL;
-    typename ImageType::Pointer output = NULL;
+    typename ImageType::Pointer input = ITK_NULLPTR;
+    typename ImageType::Pointer output = ITK_NULLPTR;
 
     ReadImage<ImageType>( input, inName.c_str() );
     if ( input.IsNull() )
@@ -859,8 +859,8 @@ iMathHelperAll(int argc, char **argv)
       }
 
     typedef itk::Image<float,DIM> ImageType;
-    typename ImageType::Pointer input = NULL;
-    typename ImageType::Pointer output = NULL;
+    typename ImageType::Pointer input = ITK_NULLPTR;
+    typename ImageType::Pointer output = ITK_NULLPTR;
 
     ReadImage<ImageType>( input, inName.c_str() );
     if ( input.IsNull() )
@@ -885,8 +885,8 @@ iMathHelperAll(int argc, char **argv)
   else if( operation == "Normalize" )
     {
     typedef itk::Image<float,DIM> ImageType;
-    typename ImageType::Pointer input = NULL;
-    typename ImageType::Pointer output = NULL;
+    typename ImageType::Pointer input = ITK_NULLPTR;
+    typename ImageType::Pointer output = ITK_NULLPTR;
 
     ReadImage<ImageType>( input, inName.c_str() );
     if ( input.IsNull() )
@@ -914,8 +914,8 @@ iMathHelperAll(int argc, char **argv)
     int padding = atoi(argv[5]);
 
     typedef itk::Image<float,DIM> ImageType;
-    typename ImageType::Pointer input = NULL;
-    typename ImageType::Pointer output = NULL;
+    typename ImageType::Pointer input = ITK_NULLPTR;
+    typename ImageType::Pointer output = ITK_NULLPTR;
 
     ReadImage<ImageType>( input, inName.c_str() );
     if ( input.IsNull() )
@@ -952,8 +952,8 @@ iMathHelperAll(int argc, char **argv)
       }
 
     typedef itk::Image<float,DIM> ImageType;
-    typename ImageType::Pointer input = NULL;
-    typename ImageType::Pointer output = NULL;
+    typename ImageType::Pointer input = ITK_NULLPTR;
+    typename ImageType::Pointer output = ITK_NULLPTR;
 
     ReadImage<ImageType>( input, inName.c_str() );
     if ( input.IsNull() )
@@ -978,8 +978,8 @@ iMathHelperAll(int argc, char **argv)
   else if( operation == "Sharpen" )
     {
     typedef itk::Image<float,DIM> ImageType;
-    typename ImageType::Pointer input = NULL;
-    typename ImageType::Pointer output = NULL;
+    typename ImageType::Pointer input = ITK_NULLPTR;
+    typename ImageType::Pointer output = ITK_NULLPTR;
 
     ReadImage<ImageType>( input, inName.c_str() );
     if ( input.IsNull() )
@@ -1010,8 +1010,8 @@ iMathHelperAll(int argc, char **argv)
       return EXIT_FAILURE;
     }
 
-    typename ImageType::Pointer mask = NULL;
-    typename ImageType::Pointer labels = NULL;
+    typename ImageType::Pointer mask = ITK_NULLPTR;
+    typename ImageType::Pointer labels = ITK_NULLPTR;
 
     ReadImage<ImageType>( mask, inName.c_str() );
     ReadImage<ImageType>( labels, argv[5] );
@@ -1063,15 +1063,15 @@ iMathHelperAll(int argc, char **argv)
       nBins= atoi(argv[7]);
       }
 
-    typename MaskType::Pointer mask = NULL;
+    typename MaskType::Pointer mask = ITK_NULLPTR;
     if ( argc >= 9 )
       {
       ReadImage<MaskType>( mask, argv[8] );
       }
 
     typedef itk::Image<float,DIM> ImageType;
-    typename ImageType::Pointer input = NULL;
-    typename ImageType::Pointer output = NULL;
+    typename ImageType::Pointer input = ITK_NULLPTR;
+    typename ImageType::Pointer output = ITK_NULLPTR;
 
     ReadImage<ImageType>( input, inName.c_str() );
     if ( input.IsNull() )

--- a/Examples/itkCommandLineParserTest.cxx
+++ b/Examples/itkCommandLineParserTest.cxx
@@ -9,7 +9,7 @@ namespace ants
 {
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int itkCommandLineParserTest( std::vector<std::string> args, std::ostream* out_stream = NULL )
+int itkCommandLineParserTest( std::vector<std::string> args, std::ostream* out_stream = ITK_NULLPTR )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/itkantsRegistrationHelper.hxx
+++ b/Examples/itkantsRegistrationHelper.hxx
@@ -78,7 +78,7 @@ typename ImageType::Pointer PreprocessImage( typename ImageType::ConstPointer  i
                                              typename ImageType::PixelType lowerScaleValue,
                                              typename ImageType::PixelType upperScaleValue,
                                              float winsorizeLowerQuantile, float winsorizeUpperQuantile,
-                                             typename ImageType::ConstPointer histogramMatchSourceImage = NULL )
+                                             typename ImageType::ConstPointer histogramMatchSourceImage = ITK_NULLPTR )
 {
   typedef itk::Statistics::ImageToHistogramFilter<ImageType>   HistogramFilterType;
   typedef typename HistogramFilterType::InputBooleanObjectType InputBooleanObjectType;

--- a/Examples/sccan.cxx
+++ b/Examples/sccan.cxx
@@ -427,7 +427,7 @@ int matrixOperation( itk::ants::CommandLineParser::OptionType *option,
   std::string funcName = std::string("matrixOperation");
 
   typedef itk::Image<PixelType, ImageDimension> ImageType;
-  typename ImageType::Pointer outputImage = NULL;
+  typename ImageType::Pointer outputImage = ITK_NULLPTR;
 
   //   option->SetUsageOption( 2, "multires_matrix_invert[list.txt,maskhighres.nii.gz,masklowres.nii.gz,matrix.mhd]" );
 
@@ -2463,7 +2463,7 @@ int sccan( itk::ants::CommandLineParser *sccanparser )
 
 // entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
 // 'main()'
-int sccan( std::vector<std::string> args, std::ostream * /*out_stream = NULL */ )
+int sccan( std::vector<std::string> args, std::ostream * /*out_stream = ITK_NULLPTR */ )
 {
   // put the arguments coming in as 'args' into standard (argc,argv) format;
   // 'args' doesn't have the command name as first, argument, so add it manually;

--- a/Examples/simpleSynRegistration.cxx
+++ b/Examples/simpleSynRegistration.cxx
@@ -95,7 +95,7 @@ simpleSynReg( ImageType::Pointer & fixedImage, ImageType::Pointer & movingImage,
   return invalidTransform;      // Return an empty registration type.
 }
 
-int simpleSynRegistration( std::vector<std::string> args, std::ostream* /*out_stream = NULL */ )
+int simpleSynRegistration( std::vector<std::string> args, std::ostream* /*out_stream = ITK_NULLPTR */ )
 {
   // the arguments coming in as 'args' is a replacement for the standard (argc,argv) format
   // Just notice that the argv[i] equals to args[i-1]

--- a/ImageRegistration/ANTS_affine_registration.h
+++ b/ImageRegistration/ANTS_affine_registration.h
@@ -208,10 +208,10 @@ void compute_single_affine_transform_3d(ImagePointerType I_fixed, ImagePointerTy
   int          number_of_iteration = 10000;
   int          MI_bins = 32;
   int          MI_samples = 6000;
-  unsigned int time_seed = (unsigned int) time(NULL);
+  unsigned int time_seed = (unsigned int) time(ITK_NULLPTR);
   srand(time_seed);
   // TODO: need to fix here
-  bool b_use_mask = 0;   // (mask_fixed == NULL);
+  bool b_use_mask = 0;   // (mask_fixed == ITK_NULLPTR);
 
   std::cout << "number_of_seeds: " << number_of_seeds << std::endl;
   std::cout << "rand_time_seed: " << time_seed << std::endl;
@@ -999,10 +999,10 @@ void compute_single_affine_transform_2d(ImagePointerType I_fixed, ImagePointerTy
   int          number_of_iteration = 500;
   int          MI_bins = 32;
   int          MI_samples = 6000;
-  unsigned int time_seed = (unsigned int) time(NULL);
+  unsigned int time_seed = (unsigned int) time(ITK_NULLPTR);
   srand(time_seed);
   // TODO: need to fix here
-  bool b_use_mask = 0;   // (mask_fixed == NULL);
+  bool b_use_mask = 0;   // (mask_fixed == ITK_NULLPTR);
 
   std::cout << "number_of_seeds: " << number_of_seeds << std::endl;
   std::cout << "rand_time_seed: " << time_seed << std::endl;

--- a/ImageRegistration/itkANTSImageRegistrationOptimizer.cxx
+++ b/ImageRegistration/itkANTSImageRegistrationOptimizer.cxx
@@ -470,7 +470,7 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>
   typedef itk::VectorLinearInterpolateImageFunction<DisplacementFieldType, TReal>   DefaultInterpolatorType;
   typename DefaultInterpolatorType::Pointer vinterp =  DefaultInterpolatorType::New();
   vinterp->SetInputImage(field);
-  //    vinterp->SetParameters(NULL,1);
+  //    vinterp->SetParameters(ITK_NULLPTR,1);
 
   VPointType pointIn1;
   VPointType pointIn2;
@@ -1068,17 +1068,17 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>
                                    DisplacementFieldPointer totalUpdateInvField,
                                    bool updateenergy)
 {
-  ImagePointer mask = NULL;
+  ImagePointer mask = ITK_NULLPTR;
 
   if( movingwarp && this->m_MaskImage )
     {
-    mask = this->WarpMultiTransform( this->m_ReferenceSpaceImage, this->m_MaskImage, NULL, movingwarp, false,
+    mask = this->WarpMultiTransform( this->m_ReferenceSpaceImage, this->m_MaskImage, ITK_NULLPTR, movingwarp, false,
                                      this->m_FixedImageAffineTransform );
     }
   else if( this->m_MaskImage )
     {
     mask = this->SubsampleImage( this->m_MaskImage, this->m_ScaleFactor,
-                                 this->m_MaskImage->GetOrigin(), this->m_MaskImage->GetDirection(),  NULL);
+                                 this->m_MaskImage->GetOrigin(), this->m_MaskImage->GetDirection(),  ITK_NULLPTR);
     }
 
   if( !fixedwarp )
@@ -1146,7 +1146,7 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>
 /** FIXME really should pass an image list and then warp each one in
       turn  then expand the update field to fit size of total
       deformation */
-    ImagePointer wmimage = NULL;
+    ImagePointer wmimage = ITK_NULLPTR;
     if( fixedwarp )
       {
       wmimage =
@@ -1159,15 +1159,15 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>
       {
       wmimage = this->SubsampleImage( this->m_SmoothMovingImages[metricCount], this->m_ScaleFactor,
                                       this->m_SmoothMovingImages[metricCount]->GetOrigin(),
-                                      this->m_SmoothMovingImages[metricCount]->GetDirection(),  NULL);
+                                      this->m_SmoothMovingImages[metricCount]->GetDirection(),  ITK_NULLPTR);
       }
 
 //    std::cout << " C " << std::endl;
-    ImagePointer wfimage = NULL;
+    ImagePointer wfimage = ITK_NULLPTR;
     if( movingwarp )
       {
       wfimage =
-        this->WarpMultiTransform( this->m_ReferenceSpaceImage, this->m_SmoothFixedImages[metricCount], NULL, movingwarp,
+        this->WarpMultiTransform( this->m_ReferenceSpaceImage, this->m_SmoothFixedImages[metricCount], ITK_NULLPTR, movingwarp,
                                   false,
                                   this->m_FixedImageAffineTransform );
       }
@@ -1175,7 +1175,7 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>
       {
       wfimage = this->SubsampleImage( this->m_SmoothFixedImages[metricCount], this->m_ScaleFactor,
                                       this->m_SmoothFixedImages[metricCount]->GetOrigin(),
-                                      this->m_SmoothFixedImages[metricCount]->GetDirection(),  NULL);
+                                      this->m_SmoothFixedImages[metricCount]->GetDirection(),  ITK_NULLPTR);
       }
 
 //    std::cout << " D " << std::endl;
@@ -1773,9 +1773,9 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>
     }
 
   ImagePointer           wfimage, wmimage;
-  PointSetPointer        wfpoints = NULL, wmpoints = NULL;
+  PointSetPointer        wfpoints = ITK_NULLPTR, wmpoints = ITK_NULLPTR;
   AffineTransformPointer aff = this->m_AffineTransform;
-  AffineTransformPointer affinverse = NULL;
+  AffineTransformPointer affinverse = ITK_NULLPTR;
 
 // here, SyNF holds the moving velocity field, SyNM holds the fixed
 // velocity field and we integrate both to generate the inv/fwd fields
@@ -1799,7 +1799,7 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>
     }
   if( fpoints )
     {  // need full inverse map
-    wfpoints = this->WarpMultiTransform(this->m_ReferenceSpaceImage, fixedImage, fpoints,  NULL, this->m_SyNF, false,
+    wfpoints = this->WarpMultiTransform(this->m_ReferenceSpaceImage, fixedImage, fpoints,  ITK_NULLPTR, this->m_SyNF, false,
                                         this->m_FixedImageAffineTransform );
     }
 

--- a/ImageRegistration/itkANTSImageRegistrationOptimizer.h
+++ b/ImageRegistration/itkANTSImageRegistrationOptimizer.h
@@ -329,7 +329,7 @@ public:
       }
   }
 
-  void SmoothDisplacementFieldGauss(DisplacementFieldPointer field = NULL, TReal sig = 0.0, bool useparamimage = false,
+  void SmoothDisplacementFieldGauss(DisplacementFieldPointer field = ITK_NULLPTR, TReal sig = 0.0, bool useparamimage = false,
                                     unsigned int lodim = ImageDimension);
 
 //  TReal = smoothingparam, int = maxdim to smooth
@@ -340,13 +340,13 @@ public:
 
   DisplacementFieldPointer ComputeUpdateFieldAlternatingMin(DisplacementFieldPointer fixedwarp,
                                                             DisplacementFieldPointer movingwarp,
-                                                            PointSetPointer  fpoints = NULL,  PointSetPointer wpoints =
-                                                              NULL, DisplacementFieldPointer updateFieldInv = NULL,
+                                                            PointSetPointer  fpoints = ITK_NULLPTR,  PointSetPointer wpoints =
+                                                              ITK_NULLPTR, DisplacementFieldPointer updateFieldInv = ITK_NULLPTR,
                                                             bool updateenergy = true);
 
   DisplacementFieldPointer ComputeUpdateField(DisplacementFieldPointer fixedwarp, DisplacementFieldPointer movingwarp,
-                                              PointSetPointer  fpoints = NULL,  PointSetPointer wpoints = NULL,
-                                              DisplacementFieldPointer updateFieldInv = NULL, bool updateenergy = true);
+                                              PointSetPointer  fpoints = ITK_NULLPTR,  PointSetPointer wpoints = ITK_NULLPTR,
+                                              DisplacementFieldPointer updateFieldInv = ITK_NULLPTR, bool updateenergy = true);
 
   TimeVaryingVelocityFieldPointer ExpandVelocity()
   {
@@ -437,7 +437,7 @@ public:
 
   ImagePointer SubsampleImage( ImagePointer, RealType, typename ImageType::PointType outputOrigin,
                                typename ImageType::DirectionType outputDirection,
-                               AffineTransformPointer aff = NULL);
+                               AffineTransformPointer aff = ITK_NULLPTR);
 
   DisplacementFieldPointer SubsampleField( DisplacementFieldPointer field, typename ImageType::SizeType
                                            targetSize, typename ImageType::SpacingType targetSpacing )
@@ -769,8 +769,8 @@ public:
 
   /** Base optimization functions */
   // AffineTransformPointer AffineOptimization(AffineTransformPointer &aff_init, OptAffine &affine_opt); // {return
-  // NULL;}
-  AffineTransformPointer AffineOptimization(OptAffineType & affine_opt);  // {return NULL;}
+  // ITK_NULLPTR;}
+  AffineTransformPointer AffineOptimization(OptAffineType & affine_opt);  // {return ITK_NULLPTR;}
 
   std::string GetTransformationModel()
   {
@@ -1704,22 +1704,22 @@ public:
   }
 
   void DiffeomorphicExpRegistrationUpdate(ImagePointer fixedImage, ImagePointer movingImage, PointSetPointer fpoints =
-                                            NULL, PointSetPointer mpoints = NULL);
+                                            ITK_NULLPTR, PointSetPointer mpoints = ITK_NULLPTR);
 
-  void GreedyExpRegistrationUpdate(ImagePointer fixedImage, ImagePointer movingImage, PointSetPointer fpoints = NULL,
-                                   PointSetPointer mpoints = NULL);
+  void GreedyExpRegistrationUpdate(ImagePointer fixedImage, ImagePointer movingImage, PointSetPointer fpoints = ITK_NULLPTR,
+                                   PointSetPointer mpoints = ITK_NULLPTR);
 
-  void SyNRegistrationUpdate(ImagePointer fixedImage, ImagePointer movingImage, PointSetPointer fpoints = NULL,
-                             PointSetPointer mpoints = NULL);
+  void SyNRegistrationUpdate(ImagePointer fixedImage, ImagePointer movingImage, PointSetPointer fpoints = ITK_NULLPTR,
+                             PointSetPointer mpoints = ITK_NULLPTR);
 
-  void SyNExpRegistrationUpdate(ImagePointer fixedImage, ImagePointer movingImage, PointSetPointer fpoints = NULL,
-                                PointSetPointer mpoints = NULL);
+  void SyNExpRegistrationUpdate(ImagePointer fixedImage, ImagePointer movingImage, PointSetPointer fpoints = ITK_NULLPTR,
+                                PointSetPointer mpoints = ITK_NULLPTR);
 
-  void SyNTVRegistrationUpdate(ImagePointer fixedImage, ImagePointer movingImage, PointSetPointer fpoints = NULL,
-                               PointSetPointer mpoints = NULL);
+  void SyNTVRegistrationUpdate(ImagePointer fixedImage, ImagePointer movingImage, PointSetPointer fpoints = ITK_NULLPTR,
+                               PointSetPointer mpoints = ITK_NULLPTR);
 
-  void DiReCTUpdate(ImagePointer fixedImage, ImagePointer movingImage, PointSetPointer fpoints = NULL,
-                    PointSetPointer mpoints = NULL);
+  void DiReCTUpdate(ImagePointer fixedImage, ImagePointer movingImage, PointSetPointer fpoints = ITK_NULLPTR,
+                    PointSetPointer mpoints = ITK_NULLPTR);
 
   /** allows one to copy or add a field to a time index within the velocity
 * field

--- a/ImageRegistration/itkJensenTsallisBSplineRegistrationFunction.hxx
+++ b/ImageRegistration/itkJensenTsallisBSplineRegistrationFunction.hxx
@@ -52,11 +52,11 @@ JensenTsallisBSplineRegistrationFunction<TFixedImage,
 
   this->m_Alpha = 2.0;
 
-//  this->m_FixedControlPointLattice = NULL;
-//  this->m_MovingControlPointLattice = NULL;
+//  this->m_FixedControlPointLattice = ITK_NULLPTR;
+//  this->m_MovingControlPointLattice = ITK_NULLPTR;
 
-  this->m_DerivativeFixedField = NULL;
-  this->m_DerivativeMovingField = NULL;
+  this->m_DerivativeFixedField = ITK_NULLPTR;
+  this->m_DerivativeMovingField = ITK_NULLPTR;
   this->m_IsPointSetMetric = true;
 
   this->m_SplineOrder = 3;

--- a/ImageRegistration/itkLabelImageGenericInterpolateImageFunction.h
+++ b/ImageRegistration/itkLabelImageGenericInterpolateImageFunction.h
@@ -66,7 +66,7 @@ public:
   virtual OutputType EvaluateAtContinuousIndex(
     const ContinuousIndexType & cindex ) const ITK_OVERRIDE
     {
-    return this->EvaluateAtContinuousIndex( cindex, NULL );
+    return this->EvaluateAtContinuousIndex( cindex, ITK_NULLPTR );
     }
 
   virtual void SetInputImage( const TInputImage *image ) ITK_OVERRIDE;

--- a/ImageSegmentation/antsAtroposSegmentationImageFilter.h
+++ b/ImageSegmentation/antsAtroposSegmentationImageFilter.h
@@ -608,7 +608,7 @@ public:
   /**
    * Set the outlier handling filter.  This takes the intensity samples from the
    * input images and modifies the sample such that the outlier effects of the
-   * sample points are removed.  Default = NULL.
+   * sample points are removed.  Default = ITK_NULLPTR.
    */
   itkSetObjectMacro( OutlierHandlingFilter, OutlierHandlingFilterType );
 

--- a/Temporary/itkDijkstrasAlgorithm.cxx
+++ b/Temporary/itkDijkstrasAlgorithm.cxx
@@ -40,7 +40,7 @@ void DijkstrasAlgorithm<TGraphSearchNode>::InitializeGraph()
   NodeLocationType loc;
   while(  !GraphIterator.IsAtEnd()  )
     {
-    typename GraphSearchNode<PixelType, CoordRep, GraphDimension>::Pointer G = NULL;
+    typename GraphSearchNode<PixelType, CoordRep, GraphDimension>::Pointer G = ITK_NULLPTR;
     GraphIterator.Set(G);
     ++GraphIterator;
     /*
@@ -52,9 +52,9 @@ void DijkstrasAlgorithm<TGraphSearchNode>::InitializeGraph()
     G->SetTotalCost(m_MaxCost);
     for (int i=0; i<GraphDimension; i++) loc[i]=m_GraphIndex[i];
     G->SetLocation(loc);
-    G->SetPredecessor(NULL);
+    G->SetPredecessor(ITK_NULLPTR);
     m_Graph->SetPixel(m_GraphIndex,G);*/
-    m_Graph->SetPixel( GraphIterator.GetIndex(), NULL);  // USE IF POINTER IMAGE defines visited
+    m_Graph->SetPixel( GraphIterator.GetIndex(), ITK_NULLPTR);  // USE IF POINTER IMAGE defines visited
     }
 
   m_SearchFinished = false;
@@ -86,7 +86,7 @@ void DijkstrasAlgorithm<TGraphSearchNode>::InitializeQueue()
   for( int i = 0; i < m_QS->m_SinkNodes.size(); i++ )
     {
     typename GraphSearchNode<PixelType, CoordRep, GraphDimension>::Pointer G = m_QS->m_SinkNodes[i];
-    G->SetPredecessor(NULL);
+    G->SetPredecessor(ITK_NULLPTR);
     loc = G->GetLocation();
     for( int d = 0; d < GraphDimension; d++ )
       {

--- a/Temporary/itkDijkstrasAlgorithm.h
+++ b/Temporary/itkDijkstrasAlgorithm.h
@@ -318,8 +318,8 @@ protected:
     m_Value2 = 0.0;
     m_Value3 = 0.0;
     m_Value4 = 0.0;
-    m_PredecessorAddress = NULL;
-    m_AncestorAddress = NULL;
+    m_PredecessorAddress = ITK_NULLPTR;
+    m_AncestorAddress = ITK_NULLPTR;
     m_State = UnVisitedState;
     m_NumberOfNeighbors = 0;
     m_Identity = 0;

--- a/Temporary/itkFEMConformalMap.cxx
+++ b/Temporary/itkFEMConformalMap.cxx
@@ -60,14 +60,14 @@ FEMConformalMap<TSurface, TImage, TDimension>
   m_NorthPole = 0;
   m_SouthPole = 1;
 
-  m_VtkSurfaceMesh = NULL;
+  m_VtkSurfaceMesh = ITK_NULLPTR;
   m_Pi = 3.14159265358979323846;
   m_ReadFromFile = true;
   m_Debug = false;
   m_FindingRealSolution = true;
-  m_SurfaceMesh = NULL;
-  m_Image = NULL;
-  m_SphereImage = NULL;
+  m_SurfaceMesh = ITK_NULLPTR;
+  m_Image = ITK_NULLPTR;
+  m_SphereImage = ITK_NULLPTR;
   for( int i = 0; i < 7; i++ )
     {
     m_PoleElementsGN[i] = 0;
@@ -1196,7 +1196,7 @@ void  FEMConformalMap<TSurface, TImage, TDimension>
   ::std::cout << " start pts ";
   int idx = 0;
 
-  vtkDataArray* scs = NULL;
+  vtkDataArray* scs = ITK_NULLPTR;
   if( m_VtkSurfaceMesh )
     {
     vtkPointData *pd = m_VtkSurfaceMesh->GetPointData();

--- a/Temporary/itkFEMDiscConformalMap.cxx
+++ b/Temporary/itkFEMDiscConformalMap.cxx
@@ -50,7 +50,7 @@ FEMDiscConformalMap<TSurface, TImage, TDimension>
   m_ReadFromFile = false;
   m_Debug = false;
   m_FindingRealSolution = true;
-  this->m_SurfaceMesh = NULL;
+  this->m_SurfaceMesh = ITK_NULLPTR;
   for( int i = 0; i < 7; i++ )
     {
     m_PoleElementsGN[i] = 0;
@@ -60,7 +60,7 @@ FEMDiscConformalMap<TSurface, TImage, TDimension>
   this->m_ParamWhileSearching = true;
   m_Smooth = 2.0;
   this->m_Label_to_Flatten = 0;
-  this->m_FlatImage  = NULL;
+  this->m_FlatImage  = ITK_NULLPTR;
 
   manifoldIntegrator = ManifoldIntegratorType::New();
 }
@@ -151,7 +151,7 @@ void  FEMDiscConformalMap<TSurface, TImage, TDimension>
   unsigned long ct = 0;
 
   vtkDataArray* labels = this->m_SurfaceMesh->GetPointData()->GetArray("Label");
-  vtkDataArray* features = NULL;
+  vtkDataArray* features = ITK_NULLPTR;
 
   if( this->m_SurfaceFeatureMesh )
     {
@@ -388,13 +388,13 @@ unsigned int FEMDiscConformalMap<TSurface, TImage, TDimension>
   unsigned int           newnodeid = 0;
   unsigned int           nodeparam = 0;        // the position in the curve parameter
   float                  newedgelength = 1.e9; // minimize this
-  GraphSearchNodePointer G1, G2, G3, BestG = NULL;
+  GraphSearchNodePointer G1, G2, G3, BestG = ITK_NULLPTR;
   for( unsigned int i = 0; i < this->m_DiscBoundaryList.size(); i++ )
     {
     unsigned int nxt = ( ( i + 1 ) % this->m_DiscBoundaryList.size() );
     G1 = this->m_DiscBoundaryList[i];
     G2 = this->m_DiscBoundaryList[nxt];
-    G3 = NULL;
+    G3 = ITK_NULLPTR;
     /** 3 conditions : (1) HelpFindLoop == 0  (2) am neighbor of curnode (3) am neighbor of next node (4) minlength */
     for( unsigned int n = 0; n < G1->m_NumberOfNeighbors; n++ )
       {
@@ -540,7 +540,7 @@ unsigned int  FEMDiscConformalMap<TSurface, TImage, TDimension>
 ::FindLoopAroundNode( unsigned int j_in )
 {
   vtkDataArray* labels = this->m_SurfaceMesh->GetPointData()->GetArray("Label");
-  vtkDataArray* features = NULL;
+  vtkDataArray* features = ITK_NULLPTR;
 
   if( this->m_SurfaceFeatureMesh )
     {
@@ -567,7 +567,7 @@ unsigned int  FEMDiscConformalMap<TSurface, TImage, TDimension>
     manifoldIntegrator->GetGraphNode(i)->SetValue(0.0, 2);
     float labval = labels->GetTuple1(i);
     manifoldIntegrator->GetGraphNode(i)->SetValue(labval, 3);
-    manifoldIntegrator->GetGraphNode(i)->SetPredecessor(NULL);
+    manifoldIntegrator->GetGraphNode(i)->SetPredecessor(ITK_NULLPTR);
     }
   manifoldIntegrator->EmptyQ();
   manifoldIntegrator->SetSearchFinished( false );
@@ -590,7 +590,7 @@ unsigned int  FEMDiscConformalMap<TSurface, TImage, TDimension>
   this->m_HelpFindLoop[j_in] = -1;
   unsigned int           furthestnode = 0;
   float                  maxdist = 0;
-  GraphSearchNodePointer farnode1 = NULL;
+  GraphSearchNodePointer farnode1 = ITK_NULLPTR;
   for( unsigned int j = 0; j < this->m_DiscBoundaryList.size(); j++ )
     {
     if( this->m_DiscBoundaryList[j]->GetTotalCost() > maxdist )
@@ -621,7 +621,7 @@ unsigned int  FEMDiscConformalMap<TSurface, TImage, TDimension>
       }
     discParameterizer->GetGraphNode(i)->SetValue(0.0, 1);
     discParameterizer->GetGraphNode(i)->SetValue(0.0, 2);
-    discParameterizer->GetGraphNode(i)->SetPredecessor(NULL);
+    discParameterizer->GetGraphNode(i)->SetPredecessor(ITK_NULLPTR);
     }
   discParameterizer->EmptyQ();
   discParameterizer->SetSearchFinished( false );
@@ -630,7 +630,7 @@ unsigned int  FEMDiscConformalMap<TSurface, TImage, TDimension>
   discParameterizer->SetWeights(1.e9, 1, 0);
   discParameterizer->FindPath();
   float                  temp = 0;
-  GraphSearchNodePointer farnode2 = NULL;
+  GraphSearchNodePointer farnode2 = ITK_NULLPTR;
   unsigned int           vct = 0;
   for( int i = 0; i < discParameterizer->GetGraphSize(); i++ )
     {
@@ -663,7 +663,7 @@ unsigned int  FEMDiscConformalMap<TSurface, TImage, TDimension>
       }
     lastlooper->GetGraphNode(i)->SetValue(0.0, 1);
     lastlooper->GetGraphNode(i)->SetValue(0.0, 2);
-    lastlooper->GetGraphNode(i)->SetPredecessor(NULL);
+    lastlooper->GetGraphNode(i)->SetPredecessor(ITK_NULLPTR);
     }
   lastlooper->EmptyQ();
   lastlooper->SetSearchFinished( false );
@@ -675,7 +675,7 @@ unsigned int  FEMDiscConformalMap<TSurface, TImage, TDimension>
   lastlooper->InitializeQueue();
   lastlooper->SetWeights(1.e9, 1, 0);
   lastlooper->FindPath();
-  GraphSearchNodePointer farnode3 = NULL;
+  GraphSearchNodePointer farnode3 = ITK_NULLPTR;
   vct = 0;
   temp = 0;
   for( int i = 0; i < lastlooper->GetGraphSize(); i++ )
@@ -704,7 +704,7 @@ unsigned int  FEMDiscConformalMap<TSurface, TImage, TDimension>
       }
     lastlooper->GetGraphNode(i)->SetValue(0.0, 1);
     lastlooper->GetGraphNode(i)->SetValue(0.0, 2);
-    lastlooper->GetGraphNode(i)->SetPredecessor(NULL);
+    lastlooper->GetGraphNode(i)->SetPredecessor(ITK_NULLPTR);
     }
   lastlooper->EmptyQ();
   lastlooper->SetSearchFinished( false );
@@ -1259,7 +1259,7 @@ void  FEMDiscConformalMap<TSurface, TImage, TDimension>::BuildOutputMeshes(float
   int numPoints = m_Solver.node.size();
 
   vtkDataArray* labels = this->m_SurfaceMesh->GetPointData()->GetArray("Label");
-  vtkDataArray* features = NULL;
+  vtkDataArray* features = ITK_NULLPTR;
   if( this->m_SurfaceFeatureMesh )
     {
     if( this->m_SurfaceFeatureMesh->GetPointData()->GetArray("Feature") )
@@ -1518,7 +1518,7 @@ void  FEMDiscConformalMap<TSurface, TImage, TDimension>
     manifoldIntegrator->GetGraphNode(i)->SetUnVisited();
     manifoldIntegrator->GetGraphNode(i)->SetValue(0.0, 1);
     manifoldIntegrator->GetGraphNode(i)->SetValue(0.0, 2);
-    manifoldIntegrator->GetGraphNode(i)->SetPredecessor(NULL);
+    manifoldIntegrator->GetGraphNode(i)->SetPredecessor(ITK_NULLPTR);
     }
   manifoldIntegrator->SetSource(manifoldIntegrator->GetGraphNode(this->m_SourceNodeNumber) );
   manifoldIntegrator->InitializeQueue();

--- a/Temporary/itkManifoldIntegrationAlgorithm.cxx
+++ b/Temporary/itkManifoldIntegrationAlgorithm.cxx
@@ -19,7 +19,7 @@ namespace itk
 template <class TGraphSearchNode>
 ManifoldIntegrationAlgorithm<TGraphSearchNode>::ManifoldIntegrationAlgorithm()
 {
-  m_SurfaceMesh = NULL;
+  m_SurfaceMesh = ITK_NULLPTR;
   m_QS = DijkstrasAlgorithmQueue<TGraphSearchNode>::New();
   m_MaxCost = vnl_huge_val(m_MaxCost);
   m_PureDist = false;
@@ -110,7 +110,7 @@ void ManifoldIntegrationAlgorithm<TGraphSearchNode>::InitializeGraph3()
       loc[j] = pt[j];
       }
     G->SetLocation(loc);
-    G->SetPredecessor(NULL);
+    G->SetPredecessor(ITK_NULLPTR);
     G->m_NumberOfNeighbors = 0;
     G->SetIdentity(i);
     m_GraphX[i] = G;
@@ -250,14 +250,14 @@ void ManifoldIntegrationAlgorithm<TGraphSearchNode>::InitializeGraph2()
       loc[j] = pt[j];
       }
     G->SetLocation(loc);
-    G->SetPredecessor(NULL);
+    G->SetPredecessor(ITK_NULLPTR);
     G->m_NumberOfNeighbors = 0;
     m_GraphX[i] = G;
     }
 
   std::cout << " allocation of graph done ";
 
-  vtkIdType nPoints = 0; vtkIdType *xPoints = NULL;
+  vtkIdType nPoints = 0; vtkIdType *xPoints = ITK_NULLPTR;
   for( unsigned int i = 0; i < nEdges; i++ )
     {
     // Get the next edge
@@ -337,7 +337,7 @@ void ManifoldIntegrationAlgorithm<TGraphSearchNode>::InitializeGraph()
       loc[j] = pt[j];
       }
     G->SetLocation(loc);
-    G->SetPredecessor(NULL);
+    G->SetPredecessor(ITK_NULLPTR);
     G->m_NumberOfNeighbors = 0;
     m_GraphX[i] = G;
     }
@@ -345,7 +345,7 @@ void ManifoldIntegrationAlgorithm<TGraphSearchNode>::InitializeGraph()
 
   std::cout << " begin edg iter ";
   vtkIdType  nPoints = 0;
-  vtkIdType *xPoints = NULL;
+  vtkIdType *xPoints = ITK_NULLPTR;
   for( unsigned int i = 0; i < nedg; i++ )
     {
     // Get the next edge
@@ -407,7 +407,7 @@ void ManifoldIntegrationAlgorithm<TGraphSearchNode>::InitializeQueue()
   for( unsigned int i = 0; i < m_QS->m_SinkNodes.size(); i++ )
     {
     typename GraphSearchNode<PixelType, CoordRep, GraphDimension>::Pointer G = m_QS->m_SinkNodes[i];
-    G->SetPredecessor(NULL);
+    G->SetPredecessor(ITK_NULLPTR);
     loc = G->GetLocation();
 //      for (int d=0;d<GraphDimension;d++) m_GraphIndex[d]=(long)loc[d];
 //        m_Graph->SetPixel(m_GraphIndex,G);
@@ -425,7 +425,7 @@ bool ManifoldIntegrationAlgorithm<TGraphSearchNode>
 {
   std::vector<SearchNodePointer> neighborlist;
   bool                           I_Am_A_Neighbor = false;
-  SearchNodePointer              neighbor = NULL;
+  SearchNodePointer              neighbor = ITK_NULLPTR;
   SearchNodePointer              curNode = rootNode;
   //  unsigned int rootnn=rootNode>m_NumberOfNeighbors;
   unsigned int ct = 0;

--- a/Temporary/topological_numbers.h
+++ b/Temporary/topological_numbers.h
@@ -218,7 +218,7 @@ NBH * N_6_2(NBH* nbh_src, NBH* nbh_dst)
   int  i, j, k;
   NBH* nbh;
 
-  nbh = N_6_1(nbh_src, NULL);
+  nbh = N_6_1(nbh_src, ITK_NULLPTR);
   for( i = 0; i < 3; i = i + 2 )
     {
     if( (*nbh)[i][1][1] )
@@ -310,7 +310,7 @@ NBH * N_6_3(NBH* nbh_src, NBH* nbh_dst)
   int  i, j, k;
   NBH* nbh;
 
-  nbh = N_6_2(nbh_src, NULL);
+  nbh = N_6_2(nbh_src, ITK_NULLPTR);
 
   i = 0; j = 0; k = 0;
   if( (*nbh_src)[i][j][k] )
@@ -448,7 +448,7 @@ NBH * N_18_2(NBH* nbh_src, NBH* nbh_dst)
   int  i, j, k;
   NBH* nbh;
 
-  nbh = N_18_1(nbh_src, NULL);
+  nbh = N_18_1(nbh_src, ITK_NULLPTR);
 
   i = 0; j = 0; k = 0;
   if( (*nbh_src)[i][j][k] )

--- a/Tensor/itkWarpTensorImageMultiTransformFilter.hxx
+++ b/Tensor/itkWarpTensorImageMultiTransformFilter.hxx
@@ -250,7 +250,7 @@ WarpTensorImageMultiTransformFilter<TInputImage, TOutputImage, TDisplacementFiel
 ::AfterThreadedGenerateData()
 {
   // Disconnect input image from interpolator
-  m_Interpolator->SetInputImage( NULL );
+  m_Interpolator->SetInputImage( ITK_NULLPTR );
 }
 
 template <class TInputImage, class TOutputImage, class TDisplacementField, class TTransform>

--- a/Utilities/ReadWriteData.h
+++ b/Utilities/ReadWriteData.h
@@ -286,7 +286,7 @@ typename ImageType::Pointer ReadImage(char* fn )
     {
     std::cerr << "Exception caught during image reference file reading " << std::endl;
     std::cerr << e << std::endl;
-    return NULL;
+    return ITK_NULLPTR;
     }
 
   //typename ImageType::DirectionType dir;
@@ -587,7 +587,7 @@ ReadWarpFromFile( std::string warpfn, std::string ext)
   typename RealImageType::Pointer yvec = ReadImage<ImageType>( (char *)fn.c_str() );
   // std::cout << " done reading " << fn << std::endl;
   fn = warpfn + "z" + ext;
-  typename RealImageType::Pointer zvec = NULL;
+  typename RealImageType::Pointer zvec = ITK_NULLPTR;
   // std::cout << " done reading " << fn << std::endl;
   if( ImageDimension == 3 )
     {

--- a/Utilities/antsMatrixUtilities.h
+++ b/Utilities/antsMatrixUtilities.h
@@ -75,8 +75,8 @@ public:
 
   MatrixType VNLPseudoInverse( MatrixType,  bool take_sqrt = false );
 
-  VectorType Orthogonalize(VectorType Mvec, VectorType V, MatrixType* projecterM = NULL,  MatrixType* projecterV =
-                             NULL )
+  VectorType Orthogonalize(VectorType Mvec, VectorType V, MatrixType* projecterM = ITK_NULLPTR,  MatrixType* projecterV =
+                             ITK_NULLPTR )
   {
     if( !projecterM && !projecterV )
       {

--- a/Utilities/antsSCCANObject.h
+++ b/Utilities/antsSCCANObject.h
@@ -155,8 +155,8 @@ public:
 
   RealType ReconstructionError( MatrixType, MatrixType );
 
-  VectorType Orthogonalize(VectorType Mvec, VectorType V, MatrixType* projecterM = NULL,  MatrixType* projecterV =
-                             NULL )
+  VectorType Orthogonalize(VectorType Mvec, VectorType V, MatrixType* projecterM = ITK_NULLPTR,  MatrixType* projecterV =
+                             ITK_NULLPTR )
   {
     if( ( !projecterM ) &&  ( !projecterV ) )
       {

--- a/Utilities/antsSCCANObject.hxx
+++ b/Utilities/antsSCCANObject.hxx
@@ -5030,7 +5030,7 @@ template <class TInputImage, class TRealType>
 bool antsSCCANObject<TInputImage, TRealType>
 ::CCAUpdate( unsigned int n_vecs, bool allowchange  , bool normbycov , unsigned int k )
 {
-  // srand (time(NULL));
+  // srand (time(ITK_NULLPTR));
   RealType gsteP = this->m_GradStepP;
   RealType gsteQ = this->m_GradStepQ;
   this->m_FractionNonZeroP = this->m_SparsenessP( k );

--- a/Utilities/itkGeneralToBSplineDisplacementFieldFilter.hxx
+++ b/Utilities/itkGeneralToBSplineDisplacementFieldFilter.hxx
@@ -17,7 +17,7 @@ GeneralToBSplineDisplacementFieldFilter<TInputImage, TOutputImage>
   this->m_SplineOrder = 3;
   this->m_NumberOfControlPoints.Fill( this->m_SplineOrder + 1 );
 
-//  this->m_ConfidenceImage = NULL;
+//  this->m_ConfidenceImage = ITK_NULLPTR;
 }
 
 template <class TInputImage, class TOutputImage>

--- a/Utilities/itkManifoldParzenWindowsPointSetFunction.hxx
+++ b/Utilities/itkManifoldParzenWindowsPointSetFunction.hxx
@@ -30,8 +30,8 @@ ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordRep>
 
   this->m_EvaluationKNeighborhood = 50;
 
-  this->m_SamplePoints = NULL;
-  this->m_KdTreeGenerator = NULL;
+  this->m_SamplePoints = ITK_NULLPTR;
+  this->m_KdTreeGenerator = ITK_NULLPTR;
 
   this->m_RegularizationSigma = 1.0;
   this->m_KernelSigma = 1.0;

--- a/Utilities/itkPointSetFunction.hxx
+++ b/Utilities/itkPointSetFunction.hxx
@@ -25,7 +25,7 @@ template <class TInputPointSet, class TOutput, class TCoordRep>
 PointSetFunction<TInputPointSet, TOutput, TCoordRep>
 ::PointSetFunction()
 {
-  m_PointSet = NULL;
+  m_PointSet = ITK_NULLPTR;
 }
 
 /**

--- a/Utilities/itkVectorGaussianInterpolateImageFunction.h
+++ b/Utilities/itkVectorGaussianInterpolateImageFunction.h
@@ -73,7 +73,7 @@ public:
   {
     const TInputImage *img = this->GetInputImage();
 
-    if( img == NULL )
+    if( img == ITK_NULLPTR )
       {
       return;
       }
@@ -128,7 +128,7 @@ public:
   virtual OutputType EvaluateAtContinuousIndex(
     const ContinuousIndexType & index ) const
   {
-    return EvaluateAtContinuousIndex(index, NULL);
+    return EvaluateAtContinuousIndex(index, ITK_NULLPTR);
   }
 
   virtual OutputType EvaluateAtContinuousIndex(

--- a/Utilities/itkWarpImageWAffineFilter.hxx
+++ b/Utilities/itkWarpImageWAffineFilter.hxx
@@ -162,7 +162,7 @@ WarpImageWAffineFilter<TInputImage, TOutputImage, TDisplacementField, TTransform
 ::AfterThreadedGenerateData()
 {
   // Disconnect input image from interpolator
-  m_Interpolator->SetInputImage( NULL );
+  m_Interpolator->SetInputImage( ITK_NULLPTR );
 }
 
 // /**

--- a/Utilities/itkWarpTensorImageMultiTransformFilter.hxx
+++ b/Utilities/itkWarpTensorImageMultiTransformFilter.hxx
@@ -174,7 +174,7 @@ WarpTensorImageMultiTransformFilter<TInputImage, TOutputImage, TDisplacementFiel
 ::AfterThreadedGenerateData()
 {
   // Disconnect input image from interpolator
-  m_Interpolator->SetInputImage( NULL );
+  m_Interpolator->SetInputImage( ITK_NULLPTR );
 }
 
 template <class TInputImage, class TOutputImage, class TDisplacementField, class TTransform>


### PR DESCRIPTION
Prior to C++11 the NULL macro expanded to different
integer types on different compilers (sometimes size_t 0, usually
unsigned long 0).  C++11 provides a keyword nullptr to more robustly
identify a null pointer.  This robust null pointer (i.e. NOT an integer)
allows for more comprehensive type checking that is utilized in ITKv5.

As a consequence, implicit type conversion from integers (a.k.a NULL)
for smart pointers can cause compiler ambiguities in ITKv5 with C++11
enhanced pointer checking.

Using ITK_NULLPTR allows both ITKv4 and ITKv5 to compile and behave
as expected.

When building:
ITKv4 & CXX_STANDARD=98, ITK_NULLPTR -> NULL    (smartpointers can be initialized with integers like NULL)
ITKv4 & CXX_STANDARD=11, ITK_NULLPTR -> nullptr (prefer initializing smartpointers with nullptr, but NULL also works)
ITKv5 & CXX_STANDARD=11, ITK_NULLPTR -> nullptr (nullptr required for initializing smartpointers)