### PR TITLE
ENH: Allow compressing transform files

### DIFF
--- a/Examples/ANTSUseDeformationFieldToGetAffineTransform.cxx
+++ b/Examples/ANTSUseDeformationFieldToGetAffineTransform.cxx
@@ -31,6 +31,9 @@ void WriteAffineTransformFile(typename TransformType::Pointer & transform,
   transform_writer = itk::TransformFileWriter::New();
   transform_writer->SetFileName(filename);
   transform_writer->SetInput(transform);
+#if ITK_VERSION_MAJOR >= 5
+  transform_writer->SetUseCompression(true);
+#endif
 
   try
     {

--- a/Examples/ANTSUseLandmarkImagesToGetAffineTransform.cxx
+++ b/Examples/ANTSUseLandmarkImagesToGetAffineTransform.cxx
@@ -28,6 +28,9 @@ void WriteAffineTransformFile(typename TransformType::Pointer & transform,
   transform_writer = itk::TransformFileWriter::New();
   transform_writer->SetFileName(filename);
   transform_writer->SetInput(transform);
+#if ITK_VERSION_MAJOR >= 5
+  transform_writer->SetUseCompression(true);
+#endif
 
   try
     {

--- a/Examples/AverageAffineTransform.cxx
+++ b/Examples/AverageAffineTransform.cxx
@@ -219,6 +219,9 @@ void AverageAffineTransform(char *output_affine_txt, char *reference_affine_txt,
   typename TranWriterType::Pointer tran_writer = TranWriterType::New();
   tran_writer->SetFileName(output_affine_txt);
   tran_writer->SetInput(aff_output);
+#if ITK_VERSION_MAJOR >= 5
+  tran_writer->SetUseCompression(true);
+#endif
   tran_writer->Update();
 
   std::cout << "wrote file to : " << output_affine_txt << std::endl;

--- a/Examples/AverageAffineTransformNoRigid.cxx
+++ b/Examples/AverageAffineTransformNoRigid.cxx
@@ -218,6 +218,9 @@ void AverageAffineTransformNoRigid(char *output_affine_txt, char *reference_affi
   typename TranWriterType::Pointer tran_writer = TranWriterType::New();
   tran_writer->SetFileName(output_affine_txt);
   tran_writer->SetInput(aff_output);
+#if ITK_VERSION_MAJOR >= 5
+  tran_writer->SetUseCompression(true);
+#endif
   tran_writer->Update();
 
   std::cout << "wrote file to : " << output_affine_txt << std::endl;

--- a/Examples/ComposeMultiTransform.cxx
+++ b/Examples/ComposeMultiTransform.cxx
@@ -276,6 +276,9 @@ void ComposeMultiAffine(char *output_affine_txt,
       typename TranWriterType::Pointer tran_writer = TranWriterType::New();
       tran_writer->SetFileName(output_affine_txt);
       tran_writer->SetInput(aff_output);
+#if ITK_VERSION_MAJOR >= 5
+      tran_writer->SetUseCompression(true);
+#endif
       tran_writer->Update();
       }
     }

--- a/Examples/ImageMath_Templates.hxx
+++ b/Examples/ImageMath_Templates.hxx
@@ -321,6 +321,9 @@ void ReflectionMatrix(int argc, char *argv[])
   typename TransformWriterType::Pointer transformWriter = TransformWriterType::New();
   transformWriter->SetInput( aff );
   transformWriter->SetFileName( outname.c_str() );
+#if ITK_VERSION_MAJOR >= 5
+  transformWriter->SetUseCompression(true);
+#endif
   transformWriter->Update();
   return;
 }
@@ -345,6 +348,9 @@ void MakeAffineTransform(int argc, char *argv[])
     TransformWriterType::New();
   transformWriter->SetInput( aff );
   transformWriter->SetFileName( outname.c_str() );
+#if ITK_VERSION_MAJOR >= 5
+  transformWriter->SetUseCompression(true);
+#endif
   transformWriter->Update();
   return;
 }

--- a/Examples/WarpVTKPolyDataMultiTransform.cxx
+++ b/Examples/WarpVTKPolyDataMultiTransform.cxx
@@ -478,6 +478,9 @@ void ComposeMultiAffine(char * /*input_affine_txt*/, char *output_affine_txt,
   typename TranWriterType::Pointer tran_writer = TranWriterType::New();
   tran_writer->SetFileName(output_affine_txt);
   tran_writer->SetInput(aff_output);
+#if ITK_VERSION_MAJOR >= 5
+  tran_writer->SetUseCompression(true);
+#endif
   tran_writer->Update();
 
   std::cout << "wrote file to : " << output_affine_txt << std::endl;

--- a/Examples/antsAI.cxx
+++ b/Examples/antsAI.cxx
@@ -1026,6 +1026,9 @@ int antsAI( itk::ants::CommandLineParser *parser )
         }
 
       transformWriter->SetFileName( outputName.c_str() );
+#if ITK_VERSION_MAJOR >= 5
+      transformWriter->SetUseCompression(true);
+#endif
       transformWriter->Update();
       }
 

--- a/Examples/antsAffineInitializer.cxx
+++ b/Examples/antsAffineInitializer.cxx
@@ -332,6 +332,9 @@ int antsAffineInitializerImp(int argc, char *argv[])
     typename TransformWriterType::Pointer transformWriter = TransformWriterType::New();
     transformWriter->SetInput( affine1 );
     transformWriter->SetFileName( outname.c_str() );
+#if ITK_VERSION_MAJOR >= 5
+    transformWriter->SetUseCompression(true);
+#endif
     transformWriter->Update();
     }
   if( ImageDimension > 3  )
@@ -514,6 +517,9 @@ int antsAffineInitializerImp(int argc, char *argv[])
   typename TransformWriterType::Pointer transformWriter = TransformWriterType::New();
   transformWriter->SetInput( bestaffine );
   transformWriter->SetFileName( outname.c_str() );
+#if ITK_VERSION_MAJOR >= 5
+  transformWriter->SetUseCompression(true);
+#endif
   transformWriter->Update();
   return EXIT_SUCCESS;
 }

--- a/Examples/antsAlignOrigin.cxx
+++ b/Examples/antsAlignOrigin.cxx
@@ -128,6 +128,9 @@ int antsAlignOriginImplementation( itk::ants::CommandLineParser::Pointer & parse
   typename itk::TransformFileWriter::Pointer transform_writer = itk::TransformFileWriter::New();
   transform_writer->SetFileName( outputTransform );
   transform_writer->SetInput( transform );
+#if ITK_VERSION_MAJOR >= 5
+  transform_writer->SetUseCompression(true);
+#endif
   transform_writer->Update();
 
   return EXIT_SUCCESS;

--- a/Examples/antsApplyTransforms.cxx
+++ b/Examples/antsApplyTransforms.cxx
@@ -497,6 +497,9 @@ int antsApplyTransforms( itk::ants::CommandLineParser::Pointer & parser, unsigne
           {
           transformWriter->SetInput( transform );
           }
+#if ITK_VERSION_MAJOR >= 5
+        transformWriter->SetUseCompression(true);
+#endif
         transformWriter->Update();
         }
       }

--- a/Examples/antsLandmarkBasedTransformInitializer.cxx
+++ b/Examples/antsLandmarkBasedTransformInitializer.cxx
@@ -173,6 +173,9 @@ int InitializeLinearTransform( int itkNotUsed( argc ), char *argv[] )
   typename itk::TransformFileWriter::Pointer transformWriter = itk::TransformFileWriter::New();
   transformWriter->SetFileName( argv[5] );
   transformWriter->SetInput( transform );
+#if ITK_VERSION_MAJOR >= 5
+  transformWriter->SetUseCompression(true);
+#endif
 
   try
     {

--- a/Examples/antsMotionCorr.cxx
+++ b/Examples/antsMotionCorr.cxx
@@ -1102,6 +1102,9 @@ int ants_motion( itk::ants::CommandLineParser *parser )
         typename TransformWriterType::Pointer transformWriter = TransformWriterType::New();
         transformWriter->SetInput( affineRegistration->GetOutput()->Get() );
         transformWriter->SetFileName( filename.c_str() );
+#if ITK_VERSION_MAJOR >= 5
+        transformWriter->SetUseCompression(true);
+#endif
         //      transformWriter->Update();
         if( timedim == 0 )
           {
@@ -1173,6 +1176,9 @@ int ants_motion( itk::ants::CommandLineParser *parser )
         typename TransformWriterType::Pointer transformWriter = TransformWriterType::New();
         transformWriter->SetInput( rigidRegistration->GetOutput()->Get() );
         transformWriter->SetFileName( filename.c_str() );
+#if ITK_VERSION_MAJOR >= 5
+        transformWriter->SetUseCompression(true);
+#endif
         //      transformWriter->Update();
         if( timedim == 0 )
           {

--- a/Examples/antsMotionCorrStats.cxx
+++ b/Examples/antsMotionCorrStats.cxx
@@ -219,6 +219,9 @@ int ants_motion_stats( itk::ants::CommandLineParser *parser )
     TransformWriterType::Pointer transformWriter = TransformWriterType::New();
     transformWriter->SetInput( affineTransform1 );
     transformWriter->SetFileName( outputName.c_str() );
+#if ITK_VERSION_MAJOR >= 5
+    transformWriter->SetUseCompression(true);
+#endif
     transformWriter->Update();
 
     return EXIT_SUCCESS;

--- a/Examples/antsUtilitiesTesting.cxx
+++ b/Examples/antsUtilitiesTesting.cxx
@@ -326,6 +326,9 @@ private:
     TransformWriterType::Pointer transformWriter = TransformWriterType::New();
     transformWriter->SetInput( optimalTransform );
     transformWriter->SetFileName( argv[7] );
+#if ITK_VERSION_MAJOR >= 5
+    transformWriter->SetUseCompression(true);
+#endif
     transformWriter->Update();
     }
 

--- a/ImageRegistration/ANTS_affine_registration.h
+++ b/ImageRegistration/ANTS_affine_registration.h
@@ -80,6 +80,9 @@ void write_transform_file(TransformPointerType & transform, StringType filename)
   transform_writer = itk::TransformFileWriter::New();
   transform_writer->SetFileName(filename);
   transform_writer->SetInput(transform);
+#if ITK_VERSION_MAJOR >= 5
+  transform_writer->SetUseCompression(true);
+#endif
 
   try
     {

--- a/ImageRegistration/ANTS_affine_registration2.h
+++ b/ImageRegistration/ANTS_affine_registration2.h
@@ -160,6 +160,9 @@ void WriteAffineTransformFile(typename TransformType::Pointer & transform,
   transform_writer = itk::TransformFileWriter::New();
   transform_writer->SetFileName(filename);
   transform_writer->SetInput(transform);
+#if ITK_VERSION_MAJOR >= 5
+  transform_writer->SetUseCompression(true);
+#endif
 
   try
     {

--- a/Utilities/itkantsReadWriteTransform.h
+++ b/Utilities/itkantsReadWriteTransform.h
@@ -168,6 +168,9 @@ WriteTransform(typename itk::Transform<T, VImageDimension, VImageDimension>::Poi
         typename TransformWriterType::Pointer transformWriter = TransformWriterType::New();
         transformWriter->SetInput(tmp_xfrm);
         transformWriter->SetFileName(filename.c_str() );
+#if ITK_VERSION_MAJOR >= 5
+        transformWriter->SetUseCompression(true);
+#endif
         transformWriter->Update();
         }
       }
@@ -207,6 +210,9 @@ WriteTransform(typename itk::Transform<T, VImageDimension, VImageDimension>::Poi
         transformWriter->SetInput(xfrm);
         }
       transformWriter->SetFileName(filename.c_str() );
+#if ITK_VERSION_MAJOR >= 5
+      transformWriter->SetUseCompression(true);
+#endif
       transformWriter->Update();
       }
     }
@@ -251,6 +257,9 @@ WriteInverseTransform(typename itk::DisplacementFieldTransform<T, VImageDimensio
       typename TransformWriterType::Pointer transformWriter = TransformWriterType::New();
       transformWriter->SetInput(inv_xfrm);
       transformWriter->SetFileName(filename.c_str() );
+#if ITK_VERSION_MAJOR >= 5
+      transformWriter->SetUseCompression(true);
+#endif
       transformWriter->Update();
       }
     }


### PR DESCRIPTION
When writing transforms to hdf5 format it is possible to use lossless
compression in ITKv5 to provide about 10% disk space savings.  For large
studies with many registrations, this can lead to significant disk space
savings.