### PR TITLE
template arguments of the Atropos filter could not be freely chosen

### DIFF
--- a/ImageSegmentation/antsAtroposSegmentationImageFilter.hxx
+++ b/ImageSegmentation/antsAtroposSegmentationImageFilter.hxx
@@ -543,7 +543,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
       {
       if( this->GetMaskImage() )
         {
-        typedef MaskImageFilter<ClassifiedImageType, ClassifiedImageType,
+        typedef MaskImageFilter<ClassifiedImageType, MaskImageType,
                                                      ClassifiedImageType> MaskerType;
         typename MaskerType::Pointer masker = MaskerType::New();
         masker->SetInput1( this->GetPriorLabelImage() );
@@ -718,7 +718,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
 
     sumPriorProbabilityImage = adder->GetOutput();
 
-    ImageRegionIteratorWithIndex<ImageType> ItP( priorProbabilityImage,
+    ImageRegionIteratorWithIndex<RealImageType> ItP( priorProbabilityImage,
                                                  priorProbabilityImage->GetRequestedRegion() );
     ImageRegionIterator<RealImageType> ItM( maxPriorProbabilityImage,
                                             maxPriorProbabilityImage->GetRequestedRegion() );
@@ -762,7 +762,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
     {
     RealImagePointer priorProbabilityImage = this->GetPriorProbabilityImage( n + 1 );
 
-    ImageRegionIteratorWithIndex<ImageType> ItP( priorProbabilityImage,
+    ImageRegionIteratorWithIndex<RealImageType> ItP( priorProbabilityImage,
                                                  priorProbabilityImage->GetRequestedRegion() );
     ImageRegionIterator<RealImageType> ItS( sumPriorProbabilityImage,
                                             sumPriorProbabilityImage->GetRequestedRegion() );
@@ -1077,7 +1077,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
     for( unsigned int i = 0; i < this->m_NumberOfIntensityImages; i++ )
       {
       typedef LabelStatisticsImageFilter<ImageType, ClassifiedImageType> ClassStatsType;
-      typename ClassStatsType::Pointer stats2 = StatsType::New();
+      typename ClassStatsType::Pointer stats2 = ClassStatsType::New();
       stats2->SetInput( this->GetIntensityImage( i ) );
       stats2->SetLabelInput( this->GetOutput() );
       stats2->UseHistogramsOff();


### PR DESCRIPTION
Following code can be used to test this. I did not see a good place to add the test to the repo though:

        using input_image_type = itk::Image<double,3>; // input != real type
        using mask_image_type = itk::Image<unsigned char,3>;
        using label_image_type = itk::Image<unsigned short,3>; // != mask type
        using atropos_filter = itk::ants::AtroposSegmentationImageFilter<input_image_type, mask_image_type, label_image_type>;

        auto instance = atropos_filter::New();
        instance->SetMaskImage(mask_image_type::New());
