### PR TITLE
BUG: fix a bug in ImageSegmentation/antsAtroposSegmentationImageFilter.h

### DIFF
--- a/ImageSegmentation/antsAtroposSegmentationImageFilter.h
+++ b/ImageSegmentation/antsAtroposSegmentationImageFilter.h
@@ -518,7 +518,7 @@ public:
   /**
    * Get the prior label parameters.
    */
-  void GetPriorLabelParameterMap()
+  LabelParameterMapType GetPriorLabelParameterMap()
   {
     return this->m_PriorLabelParameterMap;
   }


### PR DESCRIPTION
Hello! The return type of that getter method was wrong, breaking compilation on gcc 8.1.0.