### PR TITLE
Replace DiscreteGaussian with RecursiveGaussian

### DIFF
--- a/Examples/MeasureImageSimilarity.cxx
+++ b/Examples/MeasureImageSimilarity.cxx
@@ -233,7 +233,7 @@ int MeasureImageSimilarity( itk::ants::CommandLineParser *parser )
         mutualInformationMetric->SetNumberOfHistogramBins( binOption );
         mutualInformationMetric->SetUseMovingImageGradientFilter( gradientfilter );
         mutualInformationMetric->SetUseFixedImageGradientFilter( gradientfilter );
-        mutualInformationMetric->SetUseFixedSampledPointSet( false );
+        mutualInformationMetric->SetUseSampledPointSet( false );
 
         imageMetric = mutualInformationMetric;
         }
@@ -253,7 +253,7 @@ int MeasureImageSimilarity( itk::ants::CommandLineParser *parser )
         mutualInformationMetric->SetNumberOfHistogramBins( binOption );
         mutualInformationMetric->SetUseMovingImageGradientFilter( gradientfilter );
         mutualInformationMetric->SetUseFixedImageGradientFilter( gradientfilter );
-        mutualInformationMetric->SetUseFixedSampledPointSet( false );
+        mutualInformationMetric->SetUseSampledPointSet( false );
         mutualInformationMetric->SetVarianceForJointPDFSmoothing( 1.0 );
 
         imageMetric = mutualInformationMetric;
@@ -394,7 +394,7 @@ int MeasureImageSimilarity( itk::ants::CommandLineParser *parser )
           break;
         }
       imageMetric->SetFixedSampledPointSet( samplePointSet );
-      imageMetric->SetUseFixedSampledPointSet( true );
+      imageMetric->SetUseSampledPointSet( true );
       }
 
     imageMetric->Initialize();

--- a/Examples/antsAI.cxx
+++ b/Examples/antsAI.cxx
@@ -1204,7 +1204,7 @@ int antsAI( itk::ants::CommandLineParser *parser )
   imageMetric->SetMovingImage( movingImage );
   imageMetric->SetFixedImageMask( fixedMaskSpatialObject );
   imageMetric->SetMovingImageMask( movingMaskSpatialObject );
-  imageMetric->SetUseFixedSampledPointSet( false );
+  imageMetric->SetUseSampledPointSet( false );
 
   /** Sample the image domain **/
 
@@ -1303,7 +1303,7 @@ int antsAI( itk::ants::CommandLineParser *parser )
         break;
       }
     imageMetric->SetFixedSampledPointSet( samplePointSet );
-    imageMetric->SetUseFixedSampledPointSet( true );
+    imageMetric->SetUseSampledPointSet( true );
     }
 
   imageMetric->Initialize();

--- a/Examples/antsAffineInitializer.cxx
+++ b/Examples/antsAffineInitializer.cxx
@@ -424,9 +424,9 @@ int antsAffineInitializerImp(int argc, char *argv[])
         ct++;
       }
       mimetric->SetFixedSampledPointSet( pset );
-      mimetric->SetUseFixedSampledPointSet( true );
+      mimetric->SetUseSampledPointSet( true );
       gcmetric->SetFixedSampledPointSet( pset );
-      gcmetric->SetUseFixedSampledPointSet( true );
+      gcmetric->SetUseSampledPointSet( true );
     }
     if ( whichMetric.compare("MI") == 0  ) {
       mimetric->Initialize();

--- a/Examples/antsUtilitiesTesting.cxx
+++ b/Examples/antsUtilitiesTesting.cxx
@@ -196,7 +196,7 @@ private:
     count++;
     }
   imageMetric->SetFixedSampledPointSet( pointSet );
-  imageMetric->SetUseFixedSampledPointSet( true );
+  imageMetric->SetUseSampledPointSet( true );
 
   // Now go through the rotations + scalings to find the optimal pose.
 

--- a/Examples/itkantsRegistrationHelper.hxx
+++ b/Examples/itkantsRegistrationHelper.hxx
@@ -956,7 +956,7 @@ RegistrationHelper<TComputeType, VImageDimension>
           mutualInformationMetric->SetNumberOfHistogramBins( binOption );
           mutualInformationMetric->SetUseMovingImageGradientFilter( gradientfilter );
           mutualInformationMetric->SetUseFixedImageGradientFilter( gradientfilter );
-          mutualInformationMetric->SetUseFixedSampledPointSet( false );
+          mutualInformationMetric->SetUseSampledPointSet( false );
 
           imageMetric = mutualInformationMetric;
           }
@@ -974,7 +974,7 @@ RegistrationHelper<TComputeType, VImageDimension>
           mutualInformationMetric->SetNumberOfHistogramBins( binOption );
           mutualInformationMetric->SetUseMovingImageGradientFilter( gradientfilter );
           mutualInformationMetric->SetUseFixedImageGradientFilter( gradientfilter );
-          mutualInformationMetric->SetUseFixedSampledPointSet( false );
+          mutualInformationMetric->SetUseSampledPointSet( false );
           mutualInformationMetric->SetVarianceForJointPDFSmoothing( 1.0 );
 
           imageMetric = mutualInformationMetric;

--- a/SuperBuild/External_ITKv5.cmake
+++ b/SuperBuild/External_ITKv5.cmake
@@ -148,7 +148,7 @@ if(NOT DEFINED ${extProjName}_DIR AND NOT ${USE_SYSTEM_${extProjName}})
 
   ### --- End Project specific additions
   set(${proj}_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITK.git)
-  set(${proj}_GIT_TAG 732e53944f3fda761df83a11546f568237811915 ) ##
+  set(${proj}_GIT_TAG 05226185feb360139e954a1bf3b6eb86f11e5abc ) ##
   set(ITK_VERSION_ID ITK-5.0) ### NOTE: When updating GIT_TAG, also update ITK_VERSION_ID
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_ITKv5.cmake
+++ b/SuperBuild/External_ITKv5.cmake
@@ -148,7 +148,7 @@ if(NOT DEFINED ${extProjName}_DIR AND NOT ${USE_SYSTEM_${extProjName}})
 
   ### --- End Project specific additions
   set(${proj}_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITK.git)
-  set(${proj}_GIT_TAG d4294f8b8afed4656d724672d1ada6da2f059d13 ) ##
+  set(${proj}_GIT_TAG 732e53944f3fda761df83a11546f568237811915 ) ##
   set(ITK_VERSION_ID ITK-5.0) ### NOTE: When updating GIT_TAG, also update ITK_VERSION_ID
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_ITKv5.cmake
+++ b/SuperBuild/External_ITKv5.cmake
@@ -148,7 +148,7 @@ if(NOT DEFINED ${extProjName}_DIR AND NOT ${USE_SYSTEM_${extProjName}})
 
   ### --- End Project specific additions
   set(${proj}_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITK.git)
-  set(${proj}_GIT_TAG 05226185feb360139e954a1bf3b6eb86f11e5abc ) ##
+  set(${proj}_GIT_TAG e5520e9078ed0ca6085e1defccbd132d85ed49f7 ) ##
   set(ITK_VERSION_ID ITK-5.0) ### NOTE: When updating GIT_TAG, also update ITK_VERSION_ID
 
   ExternalProject_Add(${proj}

--- a/SuperBuild/External_ITKv5.cmake
+++ b/SuperBuild/External_ITKv5.cmake
@@ -148,7 +148,7 @@ if(NOT DEFINED ${extProjName}_DIR AND NOT ${USE_SYSTEM_${extProjName}})
 
   ### --- End Project specific additions
   set(${proj}_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITK.git)
-  set(${proj}_GIT_TAG 34c54c7929154df3bd40d5188b859731c54b8627) ##
+  set(${proj}_GIT_TAG d4294f8b8afed4656d724672d1ada6da2f059d13 ) ##
   set(ITK_VERSION_ID ITK-5.0) ### NOTE: When updating GIT_TAG, also update ITK_VERSION_ID
 
   ExternalProject_Add(${proj}


### PR DESCRIPTION
Following the merge here: https://github.com/InsightSoftwareConsortium/ITK/commit/569a4701b740d849a1efe20c9fd76a928c645fbb

I've updated the ITK tag to match.

I also rewrote SmoothImage to use RecursiveGaussian instead of DiscreteGaussian, this fixes #538 

This ITK version ID has a bug with HDF5 implementation (breaks MINCIO) so hold on merge until I get get that fixed and I'll update the hash.