### PR TITLE
Cmake Option - USE_GIT_PROTOCOL

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -17,9 +17,9 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/Common.cmake)
 #-----------------------------------------------------------------------------
 # Git protocol option
 #-----------------------------------------------------------------------------
-option(${CMAKE_PROJECT_NAME}_USE_GIT_PROTOCOL "If behind a firewall turn this off to use http instead." ON)
+option(USE_GIT_PROTOCOL "If behind a firewall turn this off to use http instead." ON)
 set(git_protocol "git")
-if(NOT ${CMAKE_PROJECT_NAME}_USE_GIT_PROTOCOL)
+if(NOT USE_GIT_PROTOCOL)
   set(git_protocol "https")
 endif()
 


### PR DESCRIPTION
Why not call the option for choosing between `git://` and `https://` protocols simply:

`USE_GIT_PROTOCOL` 

instead of:  

`${CMAKE_PROJECT_NAME}_USE_GIT_PROTOCOL` 

that become:

`SuperBuild_ANTS_USE_GIT_PROTOC`?