### PR TITLE
Fix ANTSPATH needing trailing slash

### DIFF
--- a/Scripts/antsJointLabelFusion.sh
+++ b/Scripts/antsJointLabelFusion.sh
@@ -39,10 +39,10 @@ if [[ ${#ANTSPATH} -le 3 ]];
 ANTS=${ANTSPATH}/antsRegistration
 WARP=${ANTSPATH}/antsApplyTransforms
 JLF=${ANTSPATH}/antsJointFusion
-PEXEC=${ANTSPATH}ANTSpexec.sh
-SGE=${ANTSPATH}waitForSGEQJobs.pl
-PBS=${ANTSPATH}waitForPBSQJobs.pl
-XGRID=${ANTSPATH}waitForXGridJobs.pl
+PEXEC=${ANTSPATH}/ANTSpexec.sh
+SGE=${ANTSPATH}/waitForSGEQJobs.pl
+PBS=${ANTSPATH}/waitForPBSQJobs.pl
+XGRID=${ANTSPATH}/waitForXGridJobs.pl
 SLURM=${ANTSPATH}/waitForSlurmJobs.pl
 
 fle_error=0

--- a/Scripts/antsJointLabelFusion2.sh
+++ b/Scripts/antsJointLabelFusion2.sh
@@ -40,10 +40,10 @@ JLF=${ANTSPATH}/antsJointFusion
 ANTS=${ANTSPATH}/antsRegistration
 WARP=${ANTSPATH}/antsApplyTransforms
 SMOOTH=${ANTSPATH}/SmoothDisplacementField
-PEXEC=${ANTSPATH}ANTSpexec.sh
-SGE=${ANTSPATH}waitForSGEQJobs.pl
-PBS=${ANTSPATH}waitForPBSQJobs.pl
-XGRID=${ANTSPATH}waitForXGridJobs.pl
+PEXEC=${ANTSPATH}/ANTSpexec.sh
+SGE=${ANTSPATH}/waitForSGEQJobs.pl
+PBS=${ANTSPATH}/waitForPBSQJobs.pl
+XGRID=${ANTSPATH}/waitForXGridJobs.pl
 SLURM=${ANTSPATH}/waitForSlurmJobs.pl
 
 fle_error=0

--- a/Scripts/antsLongitudinalJointLabelFusion.sh
+++ b/Scripts/antsLongitudinalJointLabelFusion.sh
@@ -39,10 +39,10 @@ if [[ ${#ANTSPATH} -le 3 ]];
 ANTS=${ANTSPATH}/antsRegistration
 WARP=${ANTSPATH}/antsApplyTransforms
 JLF=${ANTSPATH}/antsJointFusion
-PEXEC=${ANTSPATH}ANTSpexec.sh
-SGE=${ANTSPATH}waitForSGEQJobs.pl
-PBS=${ANTSPATH}waitForPBSQJobs.pl
-XGRID=${ANTSPATH}waitForXGridJobs.pl
+PEXEC=${ANTSPATH}/ANTSpexec.sh
+SGE=${ANTSPATH}/waitForSGEQJobs.pl
+PBS=${ANTSPATH}/waitForPBSQJobs.pl
+XGRID=${ANTSPATH}/waitForXGridJobs.pl
 SLURM=${ANTSPATH}/waitForSlurmJobs.pl
 
 fle_error=0


### PR DESCRIPTION
Ran into these scripts throwing errors despite having ANTSPATH defined. Looks like some trailing slashes got dropped in the check for the functions.

This way, the check works as long as the path contains the needed commands.