### PR TITLE
COMP: Future proof vnl_math_XXX function usage.

### DIFF
--- a/Examples/ANTS.cxx
+++ b/Examples/ANTS.cxx
@@ -219,11 +219,11 @@ private:
       + std::string( "," ) + std::string( argv[2] ) + std::string( ",1,3] " );
     std::string outputNaming( " -o ANTS.nii.gz " );
 
-    long maxSize = vnl_math_min( fixedImageIO->GetDimensions( 0 ),
+    long maxSize = std::min( fixedImageIO->GetDimensions( 0 ),
                                  movingImageIO->GetDimensions( 0 ) );
     for( unsigned int d = 1; d < fdim; d++ )
       {
-      long tmpMax = vnl_math_max( fixedImageIO->GetDimensions( d ),
+      long tmpMax = std::max( fixedImageIO->GetDimensions( d ),
                                   movingImageIO->GetDimensions( d ) );
       if( maxSize < tmpMax )
         {

--- a/Examples/ANTSIntegrateVectorField.cxx
+++ b/Examples/ANTSIntegrateVectorField.cxx
@@ -53,7 +53,7 @@ SmoothImage(typename TImage::Pointer image, float sig)
   for( vfIter.GoToBegin(); !vfIter.IsAtEnd(); ++vfIter )
     {
     typename TImage::PixelType v1 = vfIter.Get();
-    if( vnl_math_isnan(v1) )
+    if( std::isnan(v1) )
       {
       vfIter.Set(0);
       }

--- a/Examples/Atropos.cxx
+++ b/Examples/Atropos.cxx
@@ -70,7 +70,7 @@ public:
       * std::pow( filter->GetAnnealingRate(), static_cast<RealType>(
                    filter->GetElapsedIterations() ) );
 
-    annealingTemperature = vnl_math_max( annealingTemperature,
+    annealingTemperature = std::max( annealingTemperature,
                                          filter->GetMinimumAnnealingTemperature() );
 
     std::cout << " (annealing temperature = "

--- a/Examples/AverageImages.cxx
+++ b/Examples/AverageImages.cxx
@@ -238,7 +238,7 @@ int AverageImages(unsigned int argc, char *argv[])
       {
       PixelType val = vfIter2.Get();
       double    valnorm = val.GetNorm();
-      if( !vnl_math_isnan( valnorm  ) &&  !vnl_math_isinf( valnorm  )   )
+      if( !std::isnan( valnorm  ) &&  !std::isinf( valnorm  )   )
         {
         val = val / (float)numberofimages;
         PixelType oldval = averageimage->GetPixel( vfIter2.GetIndex() );

--- a/Examples/ConformalMapping.cxx
+++ b/Examples/ConformalMapping.cxx
@@ -697,7 +697,7 @@ RemoveNaNs(typename TImage::Pointer image, float replaceval )
   for( vfIter.GoToBegin(); !vfIter.IsAtEnd(); ++vfIter )
     {
     typename TImage::PixelType v1 = vfIter.Get();
-    if( vnl_math_isnan(v1) )
+    if( std::isnan(v1) )
       {
       vfIter.Set(replaceval);
       }

--- a/Examples/CreateDTICohort.cxx
+++ b/Examples/CreateDTICohort.cxx
@@ -57,8 +57,8 @@ double CalculateFractionalAnisotropy( TensorType tensor )
   double denominator = 0.0;
   for( unsigned int d = 0; d < TensorType::Dimension; d++ )
     {
-    numerator += vnl_math_sqr( eigenvalues[d] - mean );
-    denominator += vnl_math_sqr( eigenvalues[d] );
+    numerator += itk::Math::sqr ( eigenvalues[d] - mean );
+    denominator += itk::Math::sqr ( eigenvalues[d] );
     }
   fa = std::sqrt( ( 3.0 * numerator ) / ( 2.0 * denominator ) );
 
@@ -707,7 +707,7 @@ int CreateDTICohort( itk::ants::CommandLineParser *parser )
         }
       for( unsigned int d = 0; d < ImageDimension; d++ )
         {
-        if( vnl_math_isnan( newEigenvalues[d] ) )
+        if( std::isnan( newEigenvalues[d] ) )
           {
           newEigenvalues[d] = 0.0;
           }
@@ -836,7 +836,7 @@ int CreateDTICohort( itk::ants::CommandLineParser *parser )
           TensorType tensor = It.Get();
           for( unsigned int i = 0; i < tensor.GetNumberOfComponents(); i++ )
             {
-            if( vnl_math_isnan( tensor[i] ) )
+            if( std::isnan( tensor[i] ) )
               {
               tensor[i] = 0.0;
               }
@@ -861,9 +861,9 @@ int CreateDTICohort( itk::ants::CommandLineParser *parser )
           if( noiseSigma > 0.0 )
             {
             realNoise = randomizer->GetNormalVariate( 0.0,
-                                                      vnl_math_sqr( noiseSigma ) );
+                                                      itk::Math::sqr ( noiseSigma ) );
             imagNoise = randomizer->GetNormalVariate( 0.0,
-                                                      vnl_math_sqr( noiseSigma ) );
+                                                      itk::Math::sqr ( noiseSigma ) );
             }
           RealType realSignal = signal + realNoise;
           RealType imagSignal = imagNoise;

--- a/Examples/CreateTiledMosaic.cxx
+++ b/Examples/CreateTiledMosaic.cxx
@@ -279,7 +279,7 @@ int CreateMosaic( itk::ants::CommandLineParser *parser )
 
         ImageType::PointType::VectorType directionalVector = point - pointOrigin;
 
-        if( vnl_math_abs( directionalVector[physicalCoordinateComponent] ) > maxComponentValue )
+        if( itk::Math::abs ( directionalVector[physicalCoordinateComponent] ) > maxComponentValue )
           {
           direction = d;
           }
@@ -333,9 +333,9 @@ int CreateMosaic( itk::ants::CommandLineParser *parser )
           {
           if( d != direction )
             {
-            croppedSliceSize[count] = size[d] - ( vnl_math_abs( lowerBoundVector[count] )
-              + vnl_math_abs( upperBoundVector[count] ) );
-            croppedSliceIndex[count] = vnl_math_abs( lowerBoundVector[count] );
+            croppedSliceSize[count] = size[d] - ( itk::Math::abs ( lowerBoundVector[count] )
+              + itk::Math::abs ( upperBoundVector[count] ) );
+            croppedSliceIndex[count] = itk::Math::abs ( lowerBoundVector[count] );
             count++;
             }
           }
@@ -413,8 +413,8 @@ int CreateMosaic( itk::ants::CommandLineParser *parser )
             {
             if( d != direction )
               {
-              croppedSliceSize[count] = size[d] - 2 * vnl_math_abs( padWidth );
-              croppedSliceIndex[count] = vnl_math_abs( padWidth );
+              croppedSliceSize[count] = size[d] - 2 * itk::Math::abs ( padWidth );
+              croppedSliceIndex[count] = itk::Math::abs ( padWidth );
               count++;
               }
             }
@@ -566,16 +566,16 @@ int CreateMosaic( itk::ants::CommandLineParser *parser )
         endSlice = parser->Convert<unsigned int>( endSliceString );
         }
 
-      startingSlice = vnl_math_max( itk::NumericTraits<int>::ZeroValue(), startingSlice );
-      startingSlice = vnl_math_min( startingSlice, static_cast<int>( size[direction] - 1 ) );
+      startingSlice = std::max( itk::NumericTraits<int>::ZeroValue(), startingSlice );
+      startingSlice = std::min( startingSlice, static_cast<int>( size[direction] - 1 ) );
 
-      endSlice = vnl_math_max( itk::NumericTraits<int>::ZeroValue(), endSlice );
-      endSlice = vnl_math_min( endSlice, static_cast<int>( size[direction] - 1 ) );
+      endSlice = std::max( itk::NumericTraits<int>::ZeroValue(), endSlice );
+      endSlice = std::min( endSlice, static_cast<int>( size[direction] - 1 ) );
 
       whichSlices.clear();
       if( reverseOrder )
         {
-        for( int n = endSlice; n >= startingSlice; n -= vnl_math_abs( numberOfSlicesToIncrement ) )
+        for( int n = endSlice; n >= startingSlice; n -= itk::Math::abs ( numberOfSlicesToIncrement ) )
           {
           whichSlices.push_back( n );
           }
@@ -607,8 +607,8 @@ int CreateMosaic( itk::ants::CommandLineParser *parser )
       std::cerr << "Tile geometry is specified as numberOfRowsxnumberOfColumns" << std::endl;
       return EXIT_FAILURE;
       }
-    numberOfRows = vnl_math_min( static_cast<int>( layout[0] ), static_cast<int>( numberOfSlices ) );
-    numberOfColumns = vnl_math_min( static_cast<int>( layout[1] ), static_cast<int>( numberOfSlices ) );
+    numberOfRows = std::min( static_cast<int>( layout[0] ), static_cast<int>( numberOfSlices ) );
+    numberOfColumns = std::min( static_cast<int>( layout[1] ), static_cast<int>( numberOfSlices ) );
     }
 
   if( numberOfRows <= 0 && numberOfColumns > 0 )

--- a/Examples/ImageIntensityStatistics.cxx
+++ b/Examples/ImageIntensityStatistics.cxx
@@ -150,17 +150,17 @@ int ImageIntensityStatistics( int argc, char *argv[] )
       std::find( labels.begin(), labels.end(), *it );
     unsigned long index = it2 - labels.begin();
 
-    RealType m2 = vnl_math_sqr( stats->GetSigma( *it ) );
+    RealType m2 = itk::Math::sqr ( stats->GetSigma( *it ) );
     RealType k2 = ( N[index] ) / ( N[index] - 1.0 ) * m2;
 
-    RealType prefactor3 = vnl_math_sqr( N[index] ) / ( ( N[index] - 1.0 ) * ( N[index] - 2.0 ) );
+    RealType prefactor3 = itk::Math::sqr ( N[index] ) / ( ( N[index] - 1.0 ) * ( N[index] - 2.0 ) );
     RealType k3 = prefactor3 * m3[index];
 
-    RealType prefactor4 = vnl_math_sqr( N[index] ) / ( ( N[index] - 1.0 ) * ( N[index] - 2.0 ) * ( N[index] - 3.0 ) );
-    RealType k4 = prefactor4 * ( ( N[index] + 1 ) * m4[index] - 3 * ( N[index] - 1 ) * vnl_math_sqr( m2 ) );
+    RealType prefactor4 = itk::Math::sqr ( N[index] ) / ( ( N[index] - 1.0 ) * ( N[index] - 2.0 ) * ( N[index] - 3.0 ) );
+    RealType k4 = prefactor4 * ( ( N[index] + 1 ) * m4[index] - 3 * ( N[index] - 1 ) * itk::Math::sqr ( m2 ) );
 
     RealType skewness = k3 / std::sqrt( k2 * k2 * k2 );
-    RealType kurtosis = k4 / vnl_math_sqr( k2 );
+    RealType kurtosis = k4 / itk::Math::sqr ( k2 );
 
     std::cout << std::setw( 8  ) << *it;
     std::cout << std::setw( 14 ) << stats->GetMean( *it );

--- a/Examples/ImageMath_Templates.hxx
+++ b/Examples/ImageMath_Templates.hxx
@@ -249,7 +249,7 @@ void ClosestSimplifiedHeaderMatrix(int argc, char *argv[])
     for ( unsigned int dd = 0; dd < ImageDimension; dd++ )
       {
       RealType v = A_solution(d,dd);
-      long vlong = static_cast<long>( vnl_math_abs( v ) + 0.5 );
+      long vlong = static_cast<long>( itk::Math::abs ( v ) + 0.5 );
       if ( v < 0 ) vlong = vlong * (-1);
       mydir(d,dd) = static_cast<RealType>( vlong );
       }
@@ -980,7 +980,7 @@ int TruncateImageIntensity( unsigned int argc, char *argv[] )
       {
       ItM.Set( 0 );
       }
-    if( vnl_math_isnan( ItI.Get() ) || vnl_math_isinf( ItI.Get() ) )
+    if( std::isnan( ItI.Get() ) || std::isinf( ItI.Get() ) )
       {
       ItM.Set( 0 );
       }
@@ -2874,7 +2874,7 @@ int TimeSeriesRegionSCCA(int argc, char *argv[])
   bool         robust = false;
   unsigned int iterct = 20;
   bool         useL1 = false;
-  float        gradstep = vnl_math_abs( useL1 );
+  float        gradstep = itk::Math::abs ( useL1 );
   bool         keepPositive = false;
   float        sparsity = 1.0;
   unsigned int minClusterSize = 1;
@@ -3096,7 +3096,7 @@ int TimeSeriesRegionCorr(int argc, char *argv[])
           {
           corr = numer / denom;
           }
-        if( !vnl_math_isfinite( corr ) )
+        if( !std::isfinite( corr ) )
           {
           corr = 0.0;
           }
@@ -5448,7 +5448,7 @@ int ImageMath(int argc, char *argv[])
       }
     else if( strcmp(operation.c_str(), "max") == 0 )
       {
-      result = vnl_math_max( pix1, pix2 );
+      result = std::max( pix1, pix2 );
       }
     else if( strcmp(operation.c_str(), "abs") == 0 )
       {
@@ -6061,7 +6061,7 @@ int TensorFunctions(int argc, char *argv[])
     else if( strcmp(operation.c_str(), "TensorMeanDiffusion") == 0 )
       {
       result = GetTensorADC<TensorType>(tIter.Value(), 0);
-      if( vnl_math_isnan(result) )
+      if( std::isnan(result) )
         {
         result = 0;
         }
@@ -6070,7 +6070,7 @@ int TensorFunctions(int argc, char *argv[])
     else if( strcmp(operation.c_str(), "TensorRadialDiffusion") == 0 )
       {
       result = GetTensorADC<TensorType>(tIter.Value(), 2);
-      if( vnl_math_isnan(result) )
+      if( std::isnan(result) )
         {
         result = 0;
         }
@@ -6079,7 +6079,7 @@ int TensorFunctions(int argc, char *argv[])
     else if( strcmp(operation.c_str(), "TensorEigenvalue") == 0 )
       {
       result = GetTensorADC<TensorType>(tIter.Value(), 3 + whichvec);
-      if( vnl_math_isnan(result) )
+      if( std::isnan(result) )
         {
         result = 0;
         }
@@ -6088,7 +6088,7 @@ int TensorFunctions(int argc, char *argv[])
     else if( strcmp(operation.c_str(), "TensorAxialDiffusion") == 0 )
       {
       result = GetTensorADC<TensorType>(tIter.Value(), 5);
-      if( vnl_math_isnan(result) )
+      if( std::isnan(result) )
         {
         result = 0;
         }
@@ -6097,7 +6097,7 @@ int TensorFunctions(int argc, char *argv[])
     else if( strcmp(operation.c_str(), "TensorFANumerator") == 0 )
       {
       result = GetTensorFANumerator<TensorType>(tIter.Value() );
-      if( vnl_math_isnan(result) )
+      if( std::isnan(result) )
         {
         result = 0;
         }
@@ -6106,7 +6106,7 @@ int TensorFunctions(int argc, char *argv[])
     else if( strcmp(operation.c_str(), "TensorFADenominator") == 0 )
       {
       result = GetTensorFADenominator<TensorType>(tIter.Value() );
-      if( vnl_math_isnan(result) )
+      if( std::isnan(result) )
         {
         result = 0;
         }
@@ -6442,7 +6442,7 @@ int CompareHeadersAndImages(int argc, char *argv[])
         {
         pix2 = image2->GetPixel(ind);
         }
-      if( vnl_math_isnan(pix2) || vnl_math_isinf(pix2) )
+      if( std::isnan(pix2) || std::isinf(pix2) )
         {
         pix2 = 0; image2->SetPixel(ind, 0);
         }
@@ -7650,14 +7650,14 @@ int SmoothImage(int argc, char *argv[])
 
   if( sigmaVector.size() == 1 )
     {
-    filter->SetVariance( vnl_math_sqr( sigmaVector[0] ) );
+    filter->SetVariance( itk::Math::sqr ( sigmaVector[0] ) );
     }
   else if( sigmaVector.size() == ImageDimension )
     {
     typename dgf::ArrayType varianceArray;
     for( unsigned int d = 0; d < ImageDimension; d++ )
       {
-      varianceArray[d] = vnl_math_sqr( sigmaVector[d] );
+      varianceArray[d] = itk::Math::sqr ( sigmaVector[d] );
       }
     filter->SetVariance( varianceArray );
     }
@@ -8821,7 +8821,7 @@ int PoissonDiffusion( int argc, char *argv[])
     // std::cout << "  Iteration " << iterations << ": " << convergence << std::endl;
     typedef itk::DiscreteGaussianImageFilter<ImageType, ImageType> SmootherType;
     typename SmootherType::Pointer smoother = SmootherType::New();
-    smoother->SetVariance( vnl_math_sqr( sigma ) );
+    smoother->SetVariance( itk::Math::sqr ( sigma ) );
     smoother->SetMaximumError( 0.01f );
     smoother->SetInput( output );
 
@@ -10883,7 +10883,7 @@ int PValueImage(      int argc, char *argv[])
   for(  vfIter.GoToBegin(); !vfIter.IsAtEnd(); ++vfIter )
     {
     float val = image->GetPixel(vfIter.GetIndex() );
-    if( !vnl_math_isnan(val) && !vnl_math_isinf(val) )
+    if( !std::isnan(val) && !std::isinf(val) )
       {
       if( fabs( val ) > 0 )
         {
@@ -12515,7 +12515,7 @@ TRealType PatchCorrelation(  itk::NeighborhoodIterator<TImageType> GHood,  itk::
     correlation = 0;
     }
 
-  if( vnl_math_isnan( correlation ) || vnl_math_isinf( correlation )  )
+  if( std::isnan( correlation ) || std::isinf( correlation )  )
     {
     return 0;
     }
@@ -13502,7 +13502,7 @@ int BlobDetector( int argc, char *argv[] )
         unsigned int kct = 0;
         for( unsigned int bp2 = 0; bp2 < blobpairs.size(); bp2++ )
           {
-          if( ( bp2 != bp ) && ( vnl_math_abs( distratiomat( bp2, bp ) - 1 ) <  dthresh ) )
+          if( ( bp2 != bp ) && ( itk::Math::abs ( distratiomat( bp2, bp ) - 1 ) <  dthresh ) )
             {
             kct++;
             }
@@ -13747,7 +13747,7 @@ int MatchBlobs( int argc, char *argv[] )
       kVectorType kLog1( kneighborhoodval, 0 );
       for( unsigned int bp2 = 0; bp2 < blobpairs.size(); bp2++ )
         {
-        if( ( bp2 != bp ) && ( vnl_math_abs( distratiomat( bp2, bp ) - 1 ) <  dthresh )
+        if( ( bp2 != bp ) && ( itk::Math::abs ( distratiomat( bp2, bp ) - 1 ) <  dthresh )
             //	  &&   ( blobpairs[bp2].first->GetScaleSpaceValue() != blobpairs[bp].first->GetScaleSpaceValue() )
             //   &&   ( blobpairs[bp2].second->GetScaleSpaceValue() != blobpairs[bp].second->GetScaleSpaceValue() )
             )

--- a/Examples/KellySlater.cxx
+++ b/Examples/KellySlater.cxx
@@ -90,7 +90,7 @@ SmoothImage(typename TImage::Pointer image, double sig)
   for( vfIter.GoToBegin(); !vfIter.IsAtEnd(); ++vfIter )
     {
     typename TImage::PixelType v1 = vfIter.Get();
-    if( vnl_math_isnan(v1) )
+    if( std::isnan(v1) )
       {
       vfIter.Set(0);
       }
@@ -781,7 +781,7 @@ int LaplacianThicknessExpDiff2(int argc, char *argv[])
           wmag = sqrt(wmag);
           if( checknans )
             {
-            if( vnl_math_isnan(wmag) || vnl_math_isinf(wmag) || wmag == 0 )
+            if( std::isnan(wmag) || std::isinf(wmag) || wmag == 0 )
               {
               wgradval.Fill(0);
               lapgrad2->SetPixel(speedindex, wgradval);
@@ -802,7 +802,7 @@ int LaplacianThicknessExpDiff2(int argc, char *argv[])
           dd *= gm->GetPixel(speedindex);
           if( checknans )
             {
-            if( vnl_math_isnan(dd) || vnl_math_isinf(dd) )
+            if( std::isnan(dd) || std::isinf(dd) )
               {
               dd = 0;
               }
@@ -864,11 +864,11 @@ int LaplacianThicknessExpDiff2(int argc, char *argv[])
           RealType bval = bsurf->GetPixel(velind);
           if( checknans )
             {
-            if( vnl_math_isnan(dmag) || vnl_math_isinf(dmag) )
+            if( std::isnan(dmag) || std::isinf(dmag) )
               {
               dmag = 0;
               }
-            if( vnl_math_isnan(bval) || vnl_math_isinf(bval) )
+            if( std::isnan(bval) || std::isinf(bval) )
               {
               bval = 0;
               }

--- a/Examples/LaplacianThickness.cxx
+++ b/Examples/LaplacianThickness.cxx
@@ -51,7 +51,7 @@ SmoothImage(typename TImage::Pointer image, float sig)
   for( vfIter.GoToBegin(); !vfIter.IsAtEnd(); ++vfIter )
     {
     typename TImage::PixelType v1 = vfIter.Get();
-    if( vnl_math_isnan(v1) )
+    if( std::isnan(v1) )
       {
       vfIter.Set(0);
       }

--- a/Examples/SmoothDisplacementField.cxx
+++ b/Examples/SmoothDisplacementField.cxx
@@ -204,7 +204,7 @@ int SmoothDisplacementField( int argc, char *argv[] )
     ItR.Set( ( fieldIt.Get() - smoothedFieldIt.Get() ).GetSquaredNorm() );
     for( unsigned int d = 0; d < ImageDimension; d++ )
       {
-      rmse_comp[d] += vnl_math_sqr( fieldIt.Get()[d] - smoothedFieldIt.Get()[d] );
+      rmse_comp[d] += itk::Math::sqr ( fieldIt.Get()[d] - smoothedFieldIt.Get()[d] );
       }
     rmse += ( fieldIt.Get() - smoothedFieldIt.Get() ).GetSquaredNorm();
     N += 1.0;

--- a/Examples/StudentsTestOnImages.cxx
+++ b/Examples/StudentsTestOnImages.cxx
@@ -22,7 +22,7 @@
 #include <itkImageRegionIteratorWithIndex.h>
 
 #include "itkTDistribution.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 #include "vnl/vnl_erf.h"
 
 namespace ants

--- a/Examples/TileImages.cxx
+++ b/Examples/TileImages.cxx
@@ -89,8 +89,8 @@ int CreateMosaic( unsigned int argc, char *argv[] )
 
   unsigned long numberOfSlices = size[layout[0]];
 
-  int numberOfRows = vnl_math_min( static_cast<int>( layout[1] ), static_cast<int>( numberOfSlices ) );
-  int numberOfColumns = vnl_math_min( static_cast<int>( layout[2] ), static_cast<int>( numberOfSlices ) );
+  int numberOfRows = std::min( static_cast<int>( layout[1] ), static_cast<int>( numberOfSlices ) );
+  int numberOfColumns = std::min( static_cast<int>( layout[2] ), static_cast<int>( numberOfSlices ) );
 
   if( numberOfRows <= 0 && numberOfColumns > 0 )
     {

--- a/Examples/TimeSCCAN.cxx
+++ b/Examples/TimeSCCAN.cxx
@@ -217,7 +217,7 @@ bool RegionSCCA(typename NetworkType::Pointer network, typename NetworkType::Poi
           VectorType pVec = cca->GetVariateP();
           for ( unsigned int ip=0; ip<pVec.size(); ip++)
             {
-            pVec[ip] = vnl_math_abs( pVec[ip] );
+            pVec[ip] = itk::Math::abs ( pVec[ip] );
             }
           // pVec = pVec.normalize();
           pVec = P * pVec;
@@ -225,13 +225,13 @@ bool RegionSCCA(typename NetworkType::Pointer network, typename NetworkType::Poi
           VectorType qVec = cca->GetVariateQ();
           for ( unsigned int iq=0; iq<qVec.size(); iq++)
             {
-            qVec[iq] = vnl_math_abs( qVec[iq] );
+            qVec[iq] = itk::Math::abs ( qVec[iq] );
             }
           //qVec = qVec.normalize();
           qVec = Q * qVec;
 
           double final_corr = vnl_pearson_corr(pVec,qVec);
-          if ( ! vnl_math_isfinite( final_corr ) )
+          if ( ! std::isfinite( final_corr ) )
             {
             final_corr = 0.0;
             }
@@ -360,7 +360,7 @@ for (unsigned int i=0; i<N; i++)
 
         double corr = vnl_pearson_corr(p,q);
 
-        if ( ! vnl_math_isfinite( corr ) )
+        if ( ! std::isfinite( corr ) )
           {
           corr = 0.0;
           }
@@ -550,7 +550,7 @@ int timesccan( itk::ants::CommandLineParser *parser )
       NetworkType::Pointer labelMat = ITK_NULLPTR;
       ReadImage<NetworkType>( labelMat, labelMatrixName.c_str() );
 
-      float gradstep = -0.5 + vnl_math_abs( usel1 );
+      float gradstep = -0.5 + itk::Math::abs ( usel1 );
 
       RegionSCCA<NetworkType>( network, timeMat, labelMat, nLabels, roiSize, evec_ct, iterations,
                                sparsity, robustify, usel1, gradstep, keepPositive, clusterSize );

--- a/Examples/WarpTimeSeriesImageMultiTransform.cxx
+++ b/Examples/WarpTimeSeriesImageMultiTransform.cxx
@@ -403,7 +403,7 @@ void WarpImageMultiTransformFourD(char *moving_image_filename, char *output_imag
         }
       }
 
-    if( timedim % vnl_math_max(timedims / 10, static_cast<unsigned int>(1) ) == 0 )
+    if( timedim % std::max(timedims / 10, static_cast<unsigned int>(1) ) == 0 )
       {
       std::cout << (float) timedim / (float)timedims * 100 << " % done ... " << std::flush;
       }

--- a/Examples/antsAI.cxx
+++ b/Examples/antsAI.cxx
@@ -293,7 +293,7 @@ TReal PatchCorrelation( itk::NeighborhoodIterator<TImage> fixedNeighborhood,
     RealType movingSd = std::sqrt( movingSamples.squared_magnitude() );
     correlation = inner_product( fixedSamples, movingSamples ) / ( fixedSd * movingSd );
 
-    if( vnl_math_isnan( correlation ) || vnl_math_isinf( correlation )  )
+    if( std::isnan( correlation ) || std::isinf( correlation )  )
       {
       correlation = 0.0;
       }
@@ -359,13 +359,13 @@ void GetBlobCorrespondenceMatrix( typename TImage::Pointer fixedImage,  typename
     RealType distance = 0.0;
     for( unsigned int j = 0; j < ImageDimension; j++ )
       {
-      distance += vnl_math_sqr( index[j] - zeroIndex[j] );
+      distance += itk::Math::sqr ( index[j] - zeroIndex[j] );
       }
     distance = std::sqrt( distance );
     if( distance <= radiusValue )
       {
       activeIndex.push_back( i );
-      RealType weight = std::exp( -1.0 * distance / vnl_math_sqr( radiusValue ) );
+      RealType weight = std::exp( -1.0 * distance / itk::Math::sqr ( radiusValue ) );
       weights.push_back( weight );
       weightSum += ( weight );
       }
@@ -734,7 +734,7 @@ int antsAI( itk::ants::CommandLineParser *parser )
   std::string transform = "";
   // std::string outputTransformTypeName = "";
   RealType learningRate = 0.1;
-  RealType searchFactor = 20.0 * vnl_math::pi / 180.0;
+  RealType searchFactor = 20.0 * itk::Math::pi / 180.0;
   RealType arcFraction = 1.0;
 
   itk::ants::CommandLineParser::OptionType::Pointer searchFactorOption = parser->GetOption( "search-factor" );
@@ -742,11 +742,11 @@ int antsAI( itk::ants::CommandLineParser *parser )
     {
     if( searchFactorOption->GetFunction( 0 )->GetNumberOfParameters() == 0 )
       {
-      searchFactor = parser->Convert<RealType>( searchFactorOption->GetFunction( 0 )->GetName() ) * vnl_math::pi / 180.0;
+      searchFactor = parser->Convert<RealType>( searchFactorOption->GetFunction( 0 )->GetName() ) * itk::Math::pi / 180.0;
       }
     if( searchFactorOption->GetFunction( 0 )->GetNumberOfParameters() > 0 )
       {
-      searchFactor = parser->Convert<RealType>( searchFactorOption->GetFunction( 0 )->GetParameter( 0 ) ) * vnl_math::pi / 180.0;
+      searchFactor = parser->Convert<RealType>( searchFactorOption->GetFunction( 0 )->GetParameter( 0 ) ) * itk::Math::pi / 180.0;
       }
     if( searchFactorOption->GetFunction( 0 )->GetNumberOfParameters() > 1 )
       {
@@ -1359,7 +1359,7 @@ int antsAI( itk::ants::CommandLineParser *parser )
   unsigned int trialCounter = 0;
 
   typename MultiStartOptimizerType::ParametersListType parametersList = multiStartOptimizer->GetParametersList();
-  for( RealType angle1 = ( vnl_math::pi * -arcFraction ); angle1 <= ( vnl_math::pi * arcFraction + 0.000001 ); angle1 += searchFactor )
+  for( RealType angle1 = ( itk::Math::pi * -arcFraction ); angle1 <= ( itk::Math::pi * arcFraction + 0.000001 ); angle1 += searchFactor )
     {
     if( ImageDimension == 2 )
       {
@@ -1412,9 +1412,9 @@ int antsAI( itk::ants::CommandLineParser *parser )
       }
     if( ImageDimension == 3 )
       {
-      for( RealType angle2 = ( vnl_math::pi * -arcFraction ); angle2 <= ( vnl_math::pi * arcFraction + 0.000001 ); angle2 += searchFactor )
+      for( RealType angle2 = ( itk::Math::pi * -arcFraction ); angle2 <= ( itk::Math::pi * arcFraction + 0.000001 ); angle2 += searchFactor )
         {
-        for( RealType angle3 = ( vnl_math::pi * -arcFraction ); angle3 <= ( vnl_math::pi * arcFraction + 0.000001 ); angle3 += searchFactor )
+        for( RealType angle3 = ( itk::Math::pi * -arcFraction ); angle3 <= ( itk::Math::pi * arcFraction + 0.000001 ); angle3 += searchFactor )
           {
           for ( RealType translation1 = -1.0 * translationSearchGrid[0];
                 translation1 <= translationSearchGrid[0] + 0.000001; translation1 += translationSearchStepSize )

--- a/Examples/antsAffineInitializer.cxx
+++ b/Examples/antsAffineInitializer.cxx
@@ -165,7 +165,7 @@ int antsAffineInitializerImp(int argc, char *argv[])
   typedef float  PixelType;
 
   /** Define All Parameters Here */
-  double       pi = vnl_math::pi;                // probably a vnl alternative
+  double       pi = itk::Math::pi;                // probably a vnl alternative
   RealType     searchfactor = 10;                // in degrees, passed by user
   unsigned int mibins = 32;                      // for mattes MI metric
   RealType     degtorad = 0.0174532925;          // to convert degrees to radians

--- a/Examples/antsMotionCorr.cxx
+++ b/Examples/antsMotionCorr.cxx
@@ -220,7 +220,7 @@ typename ImageType::Pointer PreprocessImage( ImageType * inputImage,
     calc->SetImage( inputImage );
     calc->ComputeMaximum();
     calc->ComputeMinimum();
-    if( vnl_math_abs( calc->GetMaximum() - calc->GetMinimum() ) < 1.e-9 )
+    if( itk::Math::abs ( calc->GetMaximum() - calc->GetMinimum() ) < 1.e-9 )
       {
       if ( verbose ) std::cout << "Warning: bad time point - too little intensity variation" << std::endl;
       return histogramMatchSourceImage;

--- a/Examples/antsSliceRegularizedRegistration.cxx
+++ b/Examples/antsSliceRegularizedRegistration.cxx
@@ -220,7 +220,7 @@ typename ImageType::Pointer sliceRegularizedPreprocessImage( ImageType * inputIm
     calc->SetImage( inputImage );
     calc->ComputeMaximum();
     calc->ComputeMinimum();
-    if( vnl_math_abs( calc->GetMaximum() - calc->GetMinimum() ) < 1.e-9 )
+    if( itk::Math::abs ( calc->GetMaximum() - calc->GetMinimum() ) < 1.e-9 )
       {
       std::cout << "Warning: bad time point - too little intensity variation"
         << calc->GetMinimum() << " " <<  calc->GetMaximum() << std::endl;

--- a/Examples/antsSurf.cxx
+++ b/Examples/antsSurf.cxx
@@ -43,7 +43,7 @@
 #include "vtkTextProperty.h"
 #include "vtkWindowToImageFilter.h"
 
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 #include <vector>
 #include <string>

--- a/Examples/antsUtilitiesTesting.cxx
+++ b/Examples/antsUtilitiesTesting.cxx
@@ -125,7 +125,7 @@ private:
   // Get rotation sampling resolution
 
   unsigned int rotationNumberOfSamples = static_cast<unsigned int>( atoi( argv[5] ) );
-  double rotationDelta = ( 2.0 * vnl_math::pi - 0.0 ) / static_cast<double>( rotationNumberOfSamples - 1 );
+  double rotationDelta = ( 2.0 * itk::Math::pi - 0.0 ) / static_cast<double>( rotationNumberOfSamples - 1 );
 
   // Set up metric
   typedef itk::ImageToImageMetricv4<ImageType, ImageType, ImageType> ImageMetricType;
@@ -229,7 +229,7 @@ private:
 
     initializer->InitializeTransform();
 
-    for( double angle = 0.0; angle < 2.0 * vnl_math::pi; angle += rotationDelta )
+    for( double angle = 0.0; angle < 2.0 * itk::Math::pi; angle += rotationDelta )
       {
       AffineTransformType::MatrixType rotationMatrix;
       rotationMatrix( 0, 0 ) = rotationMatrix( 1, 1 ) = std::cos( angle );

--- a/Examples/antsVol.cxx
+++ b/Examples/antsVol.cxx
@@ -27,7 +27,7 @@
 #include "vtkVolumeProperty.h"
 #include "vtkWindowToImageFilter.h"
 
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 #include <vector>
 #include <string>

--- a/Examples/itkantsRegistrationHelper.hxx
+++ b/Examples/itkantsRegistrationHelper.hxx
@@ -607,16 +607,16 @@ RegistrationHelper<TComputeType, VImageDimension>
     if( shrinkFactorsPerDimension[n] == 0 )
       {
       SpacingValueType newMinSpacing = spacing[n] * static_cast<SpacingValueType>( factor );
-      RealType minDifferenceFromMinSpacing = vnl_math_abs( newMinSpacing - newSpacing[minIndex] );
+      RealType minDifferenceFromMinSpacing = itk::Math::abs ( newMinSpacing - newSpacing[minIndex] );
       unsigned int minFactor = factor;
       for( unsigned int f = factor - 1; f > 0; f-- )
         {
         newMinSpacing = spacing[n] * static_cast<SpacingValueType>( f );
 
         // We use <= such that the smaller factor is preferred if distances are the same
-        if( vnl_math_abs( newMinSpacing - newSpacing[minIndex] ) <= minDifferenceFromMinSpacing )
+        if( itk::Math::abs ( newMinSpacing - newSpacing[minIndex] ) <= minDifferenceFromMinSpacing )
           {
-          minDifferenceFromMinSpacing = vnl_math_abs( newMinSpacing - newSpacing[minIndex] );
+          minDifferenceFromMinSpacing = itk::Math::abs ( newMinSpacing - newSpacing[minIndex] );
           minFactor = f;
           }
         }

--- a/Examples/sccan.cxx
+++ b/Examples/sccan.cxx
@@ -1151,7 +1151,7 @@ int SVD_One_View( itk::ants::CommandLineParser *sccanparser, unsigned int permct
     }
   itk::ants::CommandLineParser::OptionType::Pointer option =
     sccanparser->GetOption( "svd" );
-  PixelType gradstep = vnl_math_abs( usel1 );
+  PixelType gradstep = itk::Math::abs ( usel1 );
   sccanobj->SetCovering( covering );
   sccanobj->SetSilent(  ! verbosity  );
   if( usel1 > 0 )
@@ -1411,7 +1411,7 @@ int SCCA_vnl( itk::ants::CommandLineParser *sccanparser, unsigned int permct, un
     {
     sccanobj->SetUseLongitudinalFormulation( uselong );
     }
-  PixelType gradstep = vnl_math_abs( usel1 );
+  PixelType gradstep = itk::Math::abs ( usel1 );
   if( usel1 > 0 )
     {
     sccanobj->SetUseL1( true );

--- a/ImageRegistration/ANTS_affine_registration2.h
+++ b/ImageRegistration/ANTS_affine_registration2.h
@@ -868,7 +868,7 @@ ImagePointer  ShrinkImageToScale(ImagePointer image,  float scalingFactor )
   ImagePointer current_image = image;
   for( unsigned int d = 0; d < ImageType::ImageDimension; d++ )
     {
-    RealType scaling = vnl_math_min( scalingFactor * minimumSpacing / inputSpacing[d],
+    RealType scaling = std::min( scalingFactor * minimumSpacing / inputSpacing[d],
                                      static_cast<RealType>( inputSize[d] ) / 32.0 );
     outputSpacing[d] = inputSpacing[d] * scaling;
     outputSize[d] = static_cast<unsigned long>( inputSpacing[d]

--- a/ImageRegistration/itkANTSImageRegistrationOptimizer.cxx
+++ b/ImageRegistration/itkANTSImageRegistrationOptimizer.cxx
@@ -27,7 +27,7 @@
 #include "itkVectorGaussianInterpolateImageFunction.h"
 #include "itkResampleImageFilter.h"
 #include "itkVectorNeighborhoodOperatorImageFilter.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 #include "ANTS_affine_registration2.h"
 #include "itkWarpImageMultiTransformFilter.h"
 // #include "itkVectorImageFileWriter.h"

--- a/ImageRegistration/itkANTSImageRegistrationOptimizer.h
+++ b/ImageRegistration/itkANTSImageRegistrationOptimizer.h
@@ -721,7 +721,7 @@ public:
 //    RealType maximumSpacing = inputSpacing.GetVnlVector().max_value();
     for( unsigned int d = 0; d < Dimension; d++ )
       {
-      RealType scaling = vnl_math_min( scalingFactor * minimumSpacing / inputSpacing[d],
+      RealType scaling = std::min( scalingFactor * minimumSpacing / inputSpacing[d],
                                        static_cast<RealType>( inputSize[d] ) / 32.0 );
       outputSpacing[d] = inputSpacing[d] * scaling;
       outputSize[d] = static_cast<unsigned long>( inputSpacing[d]
@@ -751,7 +751,7 @@ public:
   {
     typedef DiscreteGaussianImageFilter<ImageType, ImageType> SmootherType;
     typename SmootherType::Pointer smoother = SmootherType::New();
-    smoother->SetVariance( vnl_math_sqr( sigma ) );
+    smoother->SetVariance( itk::Math::sqr ( sigma ) );
     smoother->SetMaximumError( 0.01 );
     smoother->SetInput( image );
 
@@ -1079,7 +1079,7 @@ public:
 
       if( this->m_SubsamplingFactors.size() == 0 )
         {
-        scaling = vnl_math_min( this->m_ScaleFactor * minimumSpacing
+        scaling = std::min( this->m_ScaleFactor * minimumSpacing
                                 / this->m_FullDomainSpacing[d],
                                 static_cast<RealType>( this->m_FullDomainSize[d] ) / 32.0 );
         }

--- a/ImageRegistration/itkANTSImageTransformation.cxx
+++ b/ImageRegistration/itkANTSImageTransformation.cxx
@@ -31,7 +31,7 @@
 #include "itkTransformFileWriter.h"
 #include "itkDisplacementFieldTransform.h"
 
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 namespace itk
 {

--- a/ImageRegistration/itkAvantsMutualInformationRegistrationFunction.cxx
+++ b/ImageRegistration/itkAvantsMutualInformationRegistrationFunction.cxx
@@ -22,7 +22,7 @@
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageIterator.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 #include "itkDiscreteGaussianImageFilter.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
 

--- a/ImageRegistration/itkCrossCorrelationRegistrationFunction.cxx
+++ b/ImageRegistration/itkCrossCorrelationRegistrationFunction.cxx
@@ -16,7 +16,7 @@
 
 #include "itkCrossCorrelationRegistrationFunction.h"
 #include "itkExceptionObject.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 #include "itkImageFileWriter.h"
 #include "itkImageLinearConstIteratorWithIndex.h"
 #include "itkDiscreteGaussianImageFilter.h"

--- a/ImageRegistration/itkCrossCorrelationRegistrationFunction.h
+++ b/ImageRegistration/itkCrossCorrelationRegistrationFunction.h
@@ -224,7 +224,7 @@ public:
     unsigned int j = 0;
     for( j = 0; j < ImageDimension; j++ )
       {
-      fixedGradientSquaredMagnitude += vnl_math_sqr( fixedGradient[j] );
+      fixedGradientSquaredMagnitude += itk::Math::sqr ( fixedGradient[j] );
       }
     double    movingValue;
     PointType mappedPoint;
@@ -251,11 +251,11 @@ public:
       {
       speedValue = 0;
       }
-    double denominator = vnl_math_sqr( speedValue ) / m_Normalizer
+    double denominator = itk::Math::sqr ( speedValue ) / m_Normalizer
       + fixedGradientSquaredMagnitude;
     double DenominatorThreshold = 1e-9;
     double IntensityDifferenceThreshold = 0.001;
-    if( vnl_math_abs(speedValue) < IntensityDifferenceThreshold ||
+    if( itk::Math::abs (speedValue) < IntensityDifferenceThreshold ||
         denominator < DenominatorThreshold )
       {
       for( j = 0; j < ImageDimension; j++ )

--- a/ImageRegistration/itkExpectationBasedPointSetRegistrationFunction.hxx
+++ b/ImageRegistration/itkExpectationBasedPointSetRegistrationFunction.hxx
@@ -16,7 +16,7 @@
 
 #include "itkExpectationBasedPointSetRegistrationFunction.h"
 #include "itkExceptionObject.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 #include "itkBSplineScatteredDataPointSetToImageFilter.h"
 #include "itkPointSet.h"
@@ -826,7 +826,7 @@ ExpectationBasedPointSetRegistrationFunction<TFixedImage, TMovingImage, TDisplac
         RealType distance = 0.0;
         for( unsigned int d = 0; d < PointDimension; d++ )
           {
-          distance += vnl_math_sqr( ItM.Value()[d] + vector[d]
+          distance += itk::Math::sqr ( ItM.Value()[d] + vector[d]
             - ItF.Value()[d] );
           }
         this->m_Energy += ItW.Value() * std::sqrt( distance );

--- a/ImageRegistration/itkJensenHavrdaCharvatTsallisPointSetMetric.hxx
+++ b/ImageRegistration/itkJensenHavrdaCharvatTsallisPointSetMetric.hxx
@@ -441,7 +441,7 @@ JensenHavrdaCharvatTsallisPointSetMetric<TPointSet>
         }
       else
         {
-        mean /= vnl_math_sqr(
+        mean /= itk::Math::sqr (
             densityFunctions[1]->GetGaussian( neighbors[n] )->GetSigma() );
         }
 
@@ -515,7 +515,7 @@ JensenHavrdaCharvatTsallisPointSetMetric<TPointSet>
           }
         else
           {
-          mean /= vnl_math_sqr(
+          mean /= itk::Math::sqr (
               densityFunctions[1]->GetGaussian( neighbors[i] )->GetSigma() );
           }
 
@@ -689,7 +689,7 @@ JensenHavrdaCharvatTsallisPointSetMetric<TPointSet>
         }
       else
         {
-        mean /= vnl_math_sqr(
+        mean /= itk::Math::sqr (
             densityFunctions[1]->GetGaussian( neighbors[n] )->GetSigma() );
         }
 
@@ -787,7 +787,7 @@ JensenHavrdaCharvatTsallisPointSetMetric<TPointSet>
           }
         else
           {
-          mean /= vnl_math_sqr(
+          mean /= itk::Math::sqr (
               densityFunctions[1]->GetGaussian( neighbors[i] )->GetSigma() );
           }
 

--- a/ImageRegistration/itkPICSLAdvancedNormalizationToolKit.hxx
+++ b/ImageRegistration/itkPICSLAdvancedNormalizationToolKit.hxx
@@ -42,7 +42,7 @@
 
 // #include "itkJensenTsallisBSplineRegistrationFunction.h"
 
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 #include "ANTS_affine_registration2.h"
 
@@ -327,7 +327,7 @@ PICSLAdvancedNormalizationToolKit<TDimension, TReal>
   for( It.GoToBegin(); !It.IsAtEnd(); ++It )
     {
     PixelType pixel = It.Get();
-    if( vnl_math_isinf( pixel ) || vnl_math_isnan( pixel ) )
+    if( std::isinf( pixel ) || std::isnan( pixel ) )
       {
       It.Set( value );
       }
@@ -360,7 +360,7 @@ PICSLAdvancedNormalizationToolKit<TDimension, TReal>
   for( It2.GoToBegin(); !It2.IsAtEnd(); ++It2 )
     {
     PixelType pixel = It2.Get();
-    if( vnl_math_isinf( pixel ) || vnl_math_isnan( pixel ) )
+    if( std::isinf( pixel ) || std::isnan( pixel ) )
       {
       It2.Set( value );
       }

--- a/ImageRegistration/itkProbabilisticRegistrationFunction.cxx
+++ b/ImageRegistration/itkProbabilisticRegistrationFunction.cxx
@@ -16,7 +16,7 @@
 
 #include "itkProbabilisticRegistrationFunction.h"
 #include "itkExceptionObject.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 #include "itkImageFileWriter.h"
 #include "itkDiscreteGaussianImageFilter.h"
 #include "itkMeanImageFilter.h"

--- a/ImageRegistration/itkProbabilisticRegistrationFunction.h
+++ b/ImageRegistration/itkProbabilisticRegistrationFunction.h
@@ -218,7 +218,7 @@ public:
     unsigned int j = 0;
     for( j = 0; j < ImageDimension; j++ )
       {
-      fixedGradientSquaredMagnitude += vnl_math_sqr( fixedGradient[j] );
+      fixedGradientSquaredMagnitude += itk::Math::sqr ( fixedGradient[j] );
       }
     double movingValue;
 
@@ -246,11 +246,11 @@ public:
       {
       speedValue = 0;
       }
-    double denominator = vnl_math_sqr( speedValue ) / m_Normalizer
+    double denominator = itk::Math::sqr ( speedValue ) / m_Normalizer
       + fixedGradientSquaredMagnitude;
     double DenominatorThreshold = 1e-9;
     double IntensityDifferenceThreshold = 0.001;
-    if( vnl_math_abs(speedValue) < IntensityDifferenceThreshold ||
+    if( itk::Math::abs (speedValue) < IntensityDifferenceThreshold ||
         denominator < DenominatorThreshold )
       {
       for( j = 0; j < ImageDimension; j++ )

--- a/ImageRegistration/itkSpatialMutualInformationRegistrationFunction.cxx
+++ b/ImageRegistration/itkSpatialMutualInformationRegistrationFunction.cxx
@@ -21,7 +21,7 @@
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageIterator.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 #include "itkDiscreteGaussianImageFilter.h"
 #include "itkImageRegionConstIteratorWithIndex.h"
 

--- a/ImageRegistration/itkSyNDemonsRegistrationFunction.cxx
+++ b/ImageRegistration/itkSyNDemonsRegistrationFunction.cxx
@@ -16,7 +16,7 @@
 
 #include "itkSyNDemonsRegistrationFunction.h"
 #include "itkExceptionObject.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 namespace itk
 {
@@ -196,7 +196,7 @@ SyNDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>
       {
       gradient[j] = gradient[j] + mgradient[j];
       }
-    gradientSquaredMagnitude += vnl_math_sqr( gradient[j] );
+    gradientSquaredMagnitude += itk::Math::sqr ( gradient[j] );
     }
 
   /**
@@ -220,18 +220,18 @@ SyNDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>
   GlobalDataStruct *globalData = reinterpret_cast<GlobalDataStruct *>( gd );
   if( globalData )
     {
-    globalData->m_SumOfSquaredDifference += vnl_math_sqr( speedValue );
+    globalData->m_SumOfSquaredDifference += itk::Math::sqr ( speedValue );
     globalData->m_NumberOfPixelsProcessed += 1;
     }
 
-  double denominator = vnl_math_sqr( speedValue ) / m_Normalizer
+  double denominator = itk::Math::sqr ( speedValue ) / m_Normalizer
     + gradientSquaredMagnitude;
   this->m_Energy += speedValue * speedValue;
   if( m_UseSSD )
     {
     denominator = 1;
     }
-  if( vnl_math_abs(speedValue) < m_IntensityDifferenceThreshold ||
+  if( itk::Math::abs (speedValue) < m_IntensityDifferenceThreshold ||
       denominator < m_DenominatorThreshold )
     {
     for( j = 0; j < ImageDimension; j++ )
@@ -245,7 +245,7 @@ SyNDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>
     update[j] = speedValue * gradient[j] / denominator;
     if( globalData )
       {
-      globalData->m_SumOfSquaredChange += vnl_math_sqr( update[j] );
+      globalData->m_SumOfSquaredChange += itk::Math::sqr ( update[j] );
       }
     }
 
@@ -284,7 +284,7 @@ SyNDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>
   gradient = m_MovingImageGradientCalculator->EvaluateAtIndex( index );
   for( j = 0; j < ImageDimension; j++ )
     {
-    gradientSquaredMagnitude += vnl_math_sqr( gradient[j] );
+    gradientSquaredMagnitude += itk::Math::sqr ( gradient[j] );
     }
 
   /**
@@ -308,14 +308,14 @@ SyNDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>
   GlobalDataStruct *globalData = reinterpret_cast<GlobalDataStruct *>( gd );
   if( globalData )
     {
-    globalData->m_SumOfSquaredDifference += vnl_math_sqr( speedValue );
+    globalData->m_SumOfSquaredDifference += itk::Math::sqr ( speedValue );
     globalData->m_NumberOfPixelsProcessed += 1;
     }
 
-  double denominator = vnl_math_sqr( speedValue ) / m_Normalizer
+  double denominator = itk::Math::sqr ( speedValue ) / m_Normalizer
     + gradientSquaredMagnitude;
 
-  if( vnl_math_abs(speedValue) < m_IntensityDifferenceThreshold ||
+  if( itk::Math::abs (speedValue) < m_IntensityDifferenceThreshold ||
       denominator < m_DenominatorThreshold )
     {
     for( j = 0; j < ImageDimension; j++ )
@@ -329,7 +329,7 @@ SyNDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>
     update[j] = speedValue * gradient[j] / denominator;
     if( globalData )
       {
-      globalData->m_SumOfSquaredChange += vnl_math_sqr( update[j] );
+      globalData->m_SumOfSquaredChange += itk::Math::sqr ( update[j] );
       }
     }
 

--- a/ImageSegmentation/antsAtroposSegmentationImageFilter.h
+++ b/ImageSegmentation/antsAtroposSegmentationImageFilter.h
@@ -470,8 +470,8 @@ public:
    */
   void SetAdaptiveSmoothingWeight( unsigned int idx, RealType weight )
   {
-    RealType clampedWeight = vnl_math_min( NumericTraits<RealType>::OneValue(),
-                                           vnl_math_max( NumericTraits<RealType>::ZeroValue(), weight ) );
+    RealType clampedWeight = std::min( NumericTraits<RealType>::OneValue(),
+                                           std::max( NumericTraits<RealType>::ZeroValue(), weight ) );
 
     if( idx >= this->m_AdaptiveSmoothingWeights.size() )
       {

--- a/ImageSegmentation/antsAtroposSegmentationImageFilter.hxx
+++ b/ImageSegmentation/antsAtroposSegmentationImageFilter.hxx
@@ -1625,8 +1625,8 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
         this->m_MixtureModelProportions[k], priorProbability, 1,
         mrfPriorProbability, likelihood, It.GetIndex(), k + 1 );
 
-    if( vnl_math_isnan( posteriorProbability ) ||
-        vnl_math_isinf( posteriorProbability ) )
+    if( std::isnan( posteriorProbability ) ||
+        std::isinf( posteriorProbability ) )
       {
       posteriorProbability = 0.0;
       }
@@ -1642,8 +1642,8 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
 
   maxPosteriorProbability /= sumPosteriorProbability;
 
-  if( vnl_math_isnan( maxPosteriorProbability ) ||
-      vnl_math_isinf( maxPosteriorProbability ) )
+  if( std::isnan( maxPosteriorProbability ) ||
+      std::isinf( maxPosteriorProbability ) )
     {
     maxPosteriorProbability = 0.0;
     }
@@ -1760,10 +1760,10 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
 
   RealType probabilityEpsilon = 1.0e-10;
 
-  spatialPriorProbability = vnl_math_max( static_cast<RealType>( probabilityEpsilon ), spatialPriorProbability );
-  distancePriorProbability = vnl_math_max( static_cast<RealType>( probabilityEpsilon ), distancePriorProbability );
-  mrfPriorProbability = vnl_math_max( static_cast<RealType>( probabilityEpsilon ), mrfPriorProbability );
-  likelihood = vnl_math_max( static_cast<RealType>( probabilityEpsilon ), likelihood );
+  spatialPriorProbability = std::max( static_cast<RealType>( probabilityEpsilon ), spatialPriorProbability );
+  distancePriorProbability = std::max( static_cast<RealType>( probabilityEpsilon ), distancePriorProbability );
+  mrfPriorProbability = std::max( static_cast<RealType>( probabilityEpsilon ), mrfPriorProbability );
+  likelihood = std::max( static_cast<RealType>( probabilityEpsilon ), likelihood );
 
   RealType posteriorProbability = 0.0;
 
@@ -1857,14 +1857,14 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
     RealType annealingTemperature = this->m_InitialAnnealingTemperature
       * std::pow( this->m_AnnealingRate, static_cast<RealType>( this->m_ElapsedIterations ) );
 
-    annealingTemperature = vnl_math_max( annealingTemperature,
+    annealingTemperature = std::max( annealingTemperature,
                                          this->m_MinimumAnnealingTemperature );
 
     posteriorProbability = std::pow( static_cast<RealType>( posteriorProbability ),
                                     static_cast<RealType>( 1.0 / annealingTemperature ) );
     }
-  if( vnl_math_isnan( posteriorProbability ) ||
-      vnl_math_isinf( posteriorProbability ) )
+  if( std::isnan( posteriorProbability ) ||
+      std::isinf( posteriorProbability ) )
     {
     posteriorProbability = 0.0;
     }
@@ -1914,7 +1914,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
         RealType distance = 0.0;
         for( unsigned int d = 0; d < ImageDimension; d++ )
           {
-          distance += vnl_math_sqr( offset[d] * this->m_ImageSpacing[d] );
+          distance += itk::Math::sqr ( offset[d] * this->m_ImageSpacing[d] );
           }
         distance = std::sqrt( distance );
 
@@ -2208,8 +2208,8 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
                 distancePriorProbability, mrfPriorProbability, likelihood,
                 ItO.GetIndex(), c + 1 );
 
-            if( vnl_math_isnan( posteriorProbability ) ||
-                vnl_math_isinf( posteriorProbability ) )
+            if( std::isnan( posteriorProbability ) ||
+                std::isinf( posteriorProbability ) )
               {
               posteriorProbability = 0.0;
               }
@@ -2456,8 +2456,8 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
               distancePriorProbability, mrfPriorProbability, likelihood,
               ItO.GetIndex(), whichClass );
 
-          if( vnl_math_isnan( posteriorProbability ) ||
-              vnl_math_isinf( posteriorProbability ) )
+          if( std::isnan( posteriorProbability ) ||
+              std::isinf( posteriorProbability ) )
             {
             posteriorProbability = 0.0;
             }
@@ -2664,9 +2664,9 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
         for( ItD.GoToBegin(); !ItD.IsAtEnd(); ++ItD )
           {
           if( ItD.Get() < 0 &&
-              maximumInteriorDistance < vnl_math_abs( ItD.Get() ) )
+              maximumInteriorDistance < itk::Math::abs ( ItD.Get() ) )
             {
-            maximumInteriorDistance = vnl_math_abs( ItD.Get() );
+            maximumInteriorDistance = itk::Math::abs ( ItD.Get() );
             }
           }
 
@@ -2701,7 +2701,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
           else if( ItD.Get() < 0 )
             {
             ItD.Set( 1.0 - ( 1.0 - labelBoundaryProbability )
-                     * ( maximumInteriorDistance - vnl_math_abs( ItD.Get() ) )
+                     * ( maximumInteriorDistance - itk::Math::abs ( ItD.Get() ) )
                      / ( maximumInteriorDistance ) );
             }
           }
@@ -2894,9 +2894,9 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
       for( ItD.GoToBegin(); !ItD.IsAtEnd(); ++ItD )
         {
         if( ItD.Get() < 0 &&
-            maximumInteriorDistance < vnl_math_abs( ItD.Get() ) )
+            maximumInteriorDistance < itk::Math::abs ( ItD.Get() ) )
           {
-          maximumInteriorDistance = vnl_math_abs( ItD.Get() );
+          maximumInteriorDistance = itk::Math::abs ( ItD.Get() );
           }
         }
 
@@ -2931,7 +2931,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
         else if( ItD.Get() < 0 )
           {
           ItD.Set( 1.0 - ( 1.0 - labelBoundaryProbability )
-                   * ( maximumInteriorDistance - vnl_math_abs( ItD.Get() ) )
+                   * ( maximumInteriorDistance - itk::Math::abs ( ItD.Get() ) )
                    / ( maximumInteriorDistance ) );
           }
         }

--- a/ImageSegmentation/antsGrubbsRosnerListSampleFilter.hxx
+++ b/ImageSegmentation/antsGrubbsRosnerListSampleFilter.hxx
@@ -97,7 +97,7 @@ GrubbsRosnerListSampleFilter<TScalarListSample>
 
     count += 1.0;
     variance += ( count - 1.0 )
-      * vnl_math_sqr( inputMeasurement[0] - mean ) / count;
+      * itk::Math::sqr ( inputMeasurement[0] - mean ) / count;
     mean = mean + ( inputMeasurement[0] - mean ) / count;
     ++It;
     }
@@ -126,7 +126,7 @@ GrubbsRosnerListSampleFilter<TScalarListSample>
           - this->m_OutlierInstanceIdentifiers.size();
         mean = ( mean * count2 - measurement[0] ) / ( count2 - 1.0 );
         variance = ( count2 - 1.0 ) * variance - ( count2 - 1.0 )
-          * vnl_math_sqr( measurement[0] - mean ) / count2;
+          * itk::Math::sqr ( measurement[0] - mean ) / count2;
         variance /= ( count2 - 2.0 );
         this->m_OutlierInstanceIdentifiers.push_back( id );
         }
@@ -199,9 +199,9 @@ GrubbsRosnerListSampleFilter<TScalarListSample>
                    this->m_OutlierInstanceIdentifiers.end(), inputID ) ==
         this->m_OutlierInstanceIdentifiers.end() )
       {
-      if( vnl_math_abs( inputMeasurement[0] - mean ) > maximumDeviation )
+      if( itk::Math::abs ( inputMeasurement[0] - mean ) > maximumDeviation )
         {
-        maximumDeviation = vnl_math_abs( inputMeasurement[0] - mean );
+        maximumDeviation = itk::Math::abs ( inputMeasurement[0] - mean );
         maximumID = inputID;
         }
       }
@@ -233,7 +233,7 @@ GrubbsRosnerListSampleFilter<TScalarListSample>
   RealType nu = static_cast<RealType>( N - 1 );
   RealType g = nu / std::sqrt( nu + 1.0 ) * std::sqrt( t * t / ( nu - 1 + t * t ) );
 
-  return g < ( vnl_math_abs( x - mean ) / std::sqrt( variance ) );
+  return g < ( itk::Math::abs ( x - mean ) / std::sqrt( variance ) );
 }
 
 template <class TScalarListSample>

--- a/ImageSegmentation/antsJointHistogramParzenShapeAndOrientationListSampleFunction.hxx
+++ b/ImageSegmentation/antsJointHistogramParzenShapeAndOrientationListSampleFunction.hxx
@@ -125,17 +125,17 @@ JointHistogramParzenShapeAndOrientationListSampleFunction<TListSample, TOutput, 
     /** linear addition */
     shapeIdx[0] = static_cast<IndexValueType>( std::floor( shapeCidx[0] ) );
     shapeIdx[1] = static_cast<IndexValueType>( std::floor( shapeCidx[1] ) );
-    RealType distance1 = std::sqrt( vnl_math_sqr( shapeCidx[0] - shapeIdx[0] )
-                                   + vnl_math_sqr( shapeCidx[1] - shapeIdx[1] ) );
+    RealType distance1 = std::sqrt( itk::Math::sqr ( shapeCidx[0] - shapeIdx[0] )
+                                   + itk::Math::sqr ( shapeCidx[1] - shapeIdx[1] ) );
     shapeIdx[0]++;
-    RealType distance2 = std::sqrt( vnl_math_sqr( shapeCidx[0] - shapeIdx[0] )
-                                   + vnl_math_sqr( shapeCidx[1] - shapeIdx[1] ) );
+    RealType distance2 = std::sqrt( itk::Math::sqr ( shapeCidx[0] - shapeIdx[0] )
+                                   + itk::Math::sqr ( shapeCidx[1] - shapeIdx[1] ) );
     shapeIdx[1]++;
-    RealType distance3 = std::sqrt( vnl_math_sqr( shapeCidx[0] - shapeIdx[0] )
-                                   + vnl_math_sqr( shapeCidx[1] - shapeIdx[1] ) );
+    RealType distance3 = std::sqrt( itk::Math::sqr ( shapeCidx[0] - shapeIdx[0] )
+                                   + itk::Math::sqr ( shapeCidx[1] - shapeIdx[1] ) );
     shapeIdx[0]--;
-    RealType distance4 = std::sqrt( vnl_math_sqr( shapeCidx[0] - shapeIdx[0] )
-                                   + vnl_math_sqr( shapeCidx[1] - shapeIdx[1] ) );
+    RealType distance4 = std::sqrt( itk::Math::sqr ( shapeCidx[0] - shapeIdx[0] )
+                                   + itk::Math::sqr ( shapeCidx[1] - shapeIdx[1] ) );
     RealType sumDistance = distance1 + distance2 + distance3 + distance4;
     distance1 /= sumDistance;
     distance2 /= sumDistance;
@@ -233,7 +233,7 @@ JointHistogramParzenShapeAndOrientationListSampleFunction<TListSample, TOutput, 
   // if x and y are 0.0 or very close, return phi == 0
   // we do this to eliminate redundancy in the distribution of orientations.
 
-  if( vnl_math_abs( x ) + vnl_math_abs( y ) < 1e-9 )
+  if( itk::Math::abs ( x ) + itk::Math::abs ( y ) < 1e-9 )
     {
     tp[1] = 0.0;
     }
@@ -247,7 +247,7 @@ JointHistogramParzenShapeAndOrientationListSampleFunction<TListSample, TOutput, 
         }
       else
         {
-        tp[1] = vnl_math::pi;
+        tp[1] = itk::Math::pi;
         }
       }
     else if( x == 0.0 )
@@ -255,11 +255,11 @@ JointHistogramParzenShapeAndOrientationListSampleFunction<TListSample, TOutput, 
       // avoid div by zero
       if( y > 0 )
         {
-        tp[1] = vnl_math::pi_over_2;
+        tp[1] = itk::Math::pi_over_2;
         }
       else
         {
-        tp[1] = -vnl_math::pi_over_2;
+        tp[1] = -itk::Math::pi_over_2;
         }
       }
     else if( x > 0.0 && y > 0.0 )
@@ -268,11 +268,11 @@ JointHistogramParzenShapeAndOrientationListSampleFunction<TListSample, TOutput, 
       }
     else if( x < 0.0 && y > 0.0 )
       {     // second quadrant
-      tp[1] = vnl_math::pi + std::atan( y / x );
+      tp[1] = itk::Math::pi + std::atan( y / x );
       }
     else if( x < 0.0 && y < 0.0 )
       {     // third quadrant
-      tp[1] =  vnl_math::pi + atan( y / x );
+      tp[1] =  itk::Math::pi + atan( y / x );
       }
     else
       {     // fourth quadrant
@@ -284,9 +284,9 @@ JointHistogramParzenShapeAndOrientationListSampleFunction<TListSample, TOutput, 
 
 // note, if a point maps to 0 or 2*pi then it should contribute to both bins -- pretty much only difference between this
 // function and matlab code is the next 15 or so lines, as far as we see
-  orientPoint[0] = psi / (vnl_math::pi ) *
+  orientPoint[0] = psi / (itk::Math::pi ) *
     ( this->m_NumberOfOrientationJointHistogramBins - 1) + 1;
-  orientPoint[1] = ( theta + vnl_math::pi_over_2 ) / vnl_math::pi
+  orientPoint[1] = ( theta + itk::Math::pi_over_2 ) / itk::Math::pi
     * ( this->m_NumberOfOrientationJointHistogramBins - 1 );
 
   ContinuousIndex<double, 2> orientCidx;
@@ -316,17 +316,17 @@ JointHistogramParzenShapeAndOrientationListSampleFunction<TListSample, TOutput, 
     {
     orientIdx[0] = static_cast<IndexValueType>( std::floor( orientCidx[0] ) );
     orientIdx[1] = static_cast<IndexValueType>( std::floor( orientCidx[1] ) );
-    RealType distance1 = std::sqrt( vnl_math_sqr( orientCidx[0] - orientIdx[0] )
-                                   + vnl_math_sqr( orientCidx[1] - orientIdx[1] ) );
+    RealType distance1 = std::sqrt( itk::Math::sqr ( orientCidx[0] - orientIdx[0] )
+                                   + itk::Math::sqr ( orientCidx[1] - orientIdx[1] ) );
     orientIdx[0]++;
-    RealType distance2 = std::sqrt( vnl_math_sqr( orientCidx[0] - orientIdx[0] )
-                                   + vnl_math_sqr( orientCidx[1] - orientIdx[1] ) );
+    RealType distance2 = std::sqrt( itk::Math::sqr ( orientCidx[0] - orientIdx[0] )
+                                   + itk::Math::sqr ( orientCidx[1] - orientIdx[1] ) );
     orientIdx[1]++;
-    RealType distance3 = std::sqrt( vnl_math_sqr( orientCidx[0] - orientIdx[0] )
-                                   + vnl_math_sqr( orientCidx[1] - orientIdx[1] ) );
+    RealType distance3 = std::sqrt( itk::Math::sqr ( orientCidx[0] - orientIdx[0] )
+                                   + itk::Math::sqr ( orientCidx[1] - orientIdx[1] ) );
     orientIdx[0]--;
-    RealType distance4 = std::sqrt( vnl_math_sqr( orientCidx[0] - orientIdx[0] )
-                                   + vnl_math_sqr( orientCidx[1] - orientIdx[1] ) );
+    RealType distance4 = std::sqrt( itk::Math::sqr ( orientCidx[0] - orientIdx[0] )
+                                   + itk::Math::sqr ( orientCidx[1] - orientIdx[1] ) );
     RealType sumDistance = distance1 + distance2 + distance3 + distance4;
     distance1 /= sumDistance;
     distance2 /= sumDistance;

--- a/ImageSegmentation/antsLogEuclideanGaussianListSampleFunction.hxx
+++ b/ImageSegmentation/antsLogEuclideanGaussianListSampleFunction.hxx
@@ -129,7 +129,7 @@ LogEuclideanGaussianListSampleFunction<TListSample, TOutput, TCoordRep>
         weight = ( *this->GetListSampleWeights() )[N++];
         }
 
-      this->m_Dispersion += ( weight * vnl_math_sqr( distance ) );
+      this->m_Dispersion += ( weight * itk::Math::sqr ( distance ) );
       ++It;
       }
 
@@ -233,9 +233,9 @@ LogEuclideanGaussianListSampleFunction<TListSample, TOutput, TCoordRep>
     }
   RealType distance = this->CalculateTensorDistance( T, this->m_MeanTensor );
   RealType preFactor = 1.0
-    / ( std::sqrt( 2.0 * vnl_math::pi * this->m_Dispersion ) );
+    / ( std::sqrt( 2.0 * itk::Math::pi * this->m_Dispersion ) );
   RealType probability = preFactor * std::exp( -0.5
-                                              * vnl_math_sqr( distance ) / this->m_Dispersion );
+                                              * itk::Math::sqr ( distance ) / this->m_Dispersion );
 
   return probability;
 }

--- a/ImageSegmentation/antsManifoldParzenWindowsListSampleFunction.hxx
+++ b/ImageSegmentation/antsManifoldParzenWindowsListSampleFunction.hxx
@@ -105,7 +105,7 @@ ManifoldParzenWindowsListSampleFunction<TListSample, TOutput, TCoordRep>
 
       typename TreeGeneratorType::KdTreeType
       ::InstanceIdentifierVectorType neighbors;
-      unsigned int numberOfNeighbors = vnl_math_min(
+      unsigned int numberOfNeighbors = std::min(
           this->m_CovarianceKNeighborhood, static_cast<unsigned int>(
             this->GetInputListSample()->Size() ) );
       this->m_KdTreeGenerator->GetOutput()->Search(
@@ -190,7 +190,7 @@ ManifoldParzenWindowsListSampleFunction<TListSample, TOutput, TCoordRep>
 {
   try
     {
-    unsigned int numberOfNeighbors = vnl_math_min(
+    unsigned int numberOfNeighbors = std::min(
         this->m_EvaluationKNeighborhood,
         static_cast<unsigned int>( this->m_Gaussians.size() ) );
 

--- a/ImageSegmentation/antsPartialVolumeGaussianListSampleFunction.hxx
+++ b/ImageSegmentation/antsPartialVolumeGaussianListSampleFunction.hxx
@@ -145,9 +145,9 @@ PartialVolumeGaussianListSampleFunction<TListSample, TOutput, TCoordRep>
   for( unsigned int d = 0; d < mean.Size(); d++ )
     {
     mean[d] = 0.5 * ( this->m_Mean[0][d] + this->m_Mean[1][d] );
-    covariance( d, d ) = 1.0 / 12.0 * vnl_math_sqr( this->m_Mean[0][d] )
+    covariance( d, d ) = 1.0 / 12.0 * itk::Math::sqr ( this->m_Mean[0][d] )
       + -1.0 / 6.0 * this->m_Mean[0][d] * this->m_Mean[1][d]
-      + 1.0 / 12.0 * vnl_math_sqr( this->m_Mean[1][d] );
+      + 1.0 / 12.0 * itk::Math::sqr ( this->m_Mean[1][d] );
     }
 
   this->m_Gaussian->SetMean( mean );

--- a/ImageSegmentation/itkWeightedVotingFusionImageFilter.hxx
+++ b/ImageSegmentation/itkWeightedVotingFusionImageFilter.hxx
@@ -339,7 +339,7 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
       squaredDistances[n].second = 0.0;
       for( unsigned int d = 0; d < ImageDimension; d++ )
         {
-        squaredDistances[n].second += vnl_math_sqr( offset[d] * spacing[d] );
+        squaredDistances[n].second += itk::Math::sqr ( offset[d] * spacing[d] );
         }
       }
     std::sort( squaredDistances.begin(), squaredDistances.end(), DistanceIndexComparator() );
@@ -383,7 +383,7 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
           squaredDistances[n].second = 0.0;
           for( unsigned int d = 0; d < ImageDimension; d++ )
             {
-            squaredDistances[n].second += vnl_math_sqr( offset[d] * spacing[d] );
+            squaredDistances[n].second += itk::Math::sqr ( offset[d] * spacing[d] );
             }
           }
         std::sort( squaredDistances.begin(), squaredDistances.end(), DistanceIndexComparator() );
@@ -614,7 +614,7 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
     else
       {
       vnl_cholesky cholesky( MxBar, vnl_cholesky::estimate_condition );
-      if( cholesky.rcond() > vnl_math::sqrteps )
+      if( cholesky.rcond() > itk::Math::sqrteps )
         {
         // well-conditioned matrix
         W = cholesky.solve( ones );

--- a/Temporary/antsFastMarchingImageFilter.h
+++ b/Temporary/antsFastMarchingImageFilter.h
@@ -20,7 +20,7 @@ Program:   Advanced Normalization Tools
 #include "itkLevelSet.h"
 #include "itkNeighborhoodIterator.h"
 
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 #include <functional>
 #include <queue>
@@ -244,7 +244,7 @@ private:
   void SetSpeedConstant( double value )
   {
     m_SpeedConstant = value;
-    m_InverseSpeed = -1.0 * vnl_math_sqr( 1.0 / m_SpeedConstant );
+    m_InverseSpeed = -1.0 * itk::Math::sqr ( 1.0 / m_SpeedConstant );
     this->Modified();
   }
 

--- a/Temporary/antsFastMarchingImageFilter.hxx
+++ b/Temporary/antsFastMarchingImageFilter.hxx
@@ -21,7 +21,7 @@
 #include "itkNumericTraits.h"
 #include "itkRelabelComponentImageFilter.h"
 
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 #include <algorithm>
 
@@ -410,8 +410,8 @@ FMarchingImageFilter<TLevelSet, TSpeedImage>
                 }
               else
                 {
-                minLabel = vnl_math_min( ItC.GetNext( d ), ItC.GetPrevious( d ) );
-                otherLabel = vnl_math_max( ItC.GetNext( d ), ItC.GetPrevious( d ) );
+                minLabel = std::min( ItC.GetNext( d ), ItC.GetPrevious( d ) );
+                otherLabel = std::max( ItC.GetNext( d ), ItC.GetPrevious( d ) );
                 }
               break;
               }
@@ -611,7 +611,7 @@ FMarchingImageFilter<TLevelSet, TSpeedImage>
   if( speedImage )
     {
     cc = (double) speedImage->GetPixel( index ) / this->m_NormalizationFactor;
-    cc = -1.0 * vnl_math_sqr( 1.0 / cc );
+    cc = -1.0 * itk::Math::sqr ( 1.0 / cc );
     }
   else
     {
@@ -628,13 +628,13 @@ FMarchingImageFilter<TLevelSet, TSpeedImage>
     if( solution >= node.GetValue() )
       {
       const int    axis = node.GetAxis();
-      const double spaceFactor = vnl_math_sqr( 1.0 / spacing[axis] );
+      const double spaceFactor = itk::Math::sqr ( 1.0 / spacing[axis] );
       const double value = double(node.GetValue() );
       aa += spaceFactor;
       bb += value * spaceFactor;
-      cc += vnl_math_sqr( value ) * spaceFactor;
+      cc += itk::Math::sqr ( value ) * spaceFactor;
 
-      discrim = vnl_math_sqr( bb ) - aa * cc;
+      discrim = itk::Math::sqr ( bb ) - aa * cc;
       if( discrim < 0.0 )
         {
         // Discriminant of quadratic eqn. is negative

--- a/Temporary/deprecate_itkFEMElement3DC0LinearTriangular.cxx
+++ b/Temporary/deprecate_itkFEMElement3DC0LinearTriangular.cxx
@@ -17,7 +17,7 @@
 #endif
 
 #include "itkFEMElement3DC0LinearTriangular.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 #include "vnl/algo/vnl_svd.h"
 #include "vnl/algo/vnl_qr.h"

--- a/Temporary/itkDijkstrasAlgorithm.h
+++ b/Temporary/itkDijkstrasAlgorithm.h
@@ -45,7 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <queue>
 #include <map>
 
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 // #include "vnl/vnl_matrix_fixed.h"
 // #include "vnl/vnl_vector_fixed.h"
 #include "itkImage.h"

--- a/Temporary/itkFEMConformalMap.cxx
+++ b/Temporary/itkFEMConformalMap.cxx
@@ -27,7 +27,7 @@
 #include <vnl/vnl_real_polynomial.h>
 #include <vnl/vnl_vector.h>
 #include <vnl/vnl_vector_fixed.h>
-#include <vnl/vnl_math.h>
+#include <itkMath.h>
 
 #include "itkFEMConformalMap.h"
 #include "itkFEMLoadNode.h"

--- a/Temporary/itkFEMDiscConformalMap.cxx
+++ b/Temporary/itkFEMDiscConformalMap.cxx
@@ -20,7 +20,7 @@
 #include <vnl/vnl_real_polynomial.h>
 #include <vnl/vnl_vector.h>
 #include <vnl/vnl_vector_fixed.h>
-#include <vnl/vnl_math.h>
+#include <itkMath.h>
 #include "vtkDelaunay2D.h"
 #include "vtkSelectPolyData.h"
 #include "vtkFloatArray.h"

--- a/Temporary/itkMeanSquaresPointSetToPointSetIntensityMetricv4.hxx
+++ b/Temporary/itkMeanSquaresPointSetToPointSetIntensityMetricv4.hxx
@@ -300,11 +300,11 @@ MeanSquaresPointSetToPointSetIntensityMetricv4<TFixedPointSet, TMovingPointSet, 
 
   // Now determine the sigma using a reasonable heuristic.
 
-  this->m_IntensityDistanceSigma = vnl_math_max( maxMovingIntensity, maxFixedIntensity )
-    - vnl_math_min( minMovingIntensity, maxMovingIntensity );
+  this->m_IntensityDistanceSigma = std::max( maxMovingIntensity, maxFixedIntensity )
+    - std::min( minMovingIntensity, maxMovingIntensity );
   if( this->m_IntensityDistanceSigma == 0 )
     {
-    this->m_IntensityDistanceSigma = vnl_math_max( maxMovingIntensity, maxFixedIntensity );
+    this->m_IntensityDistanceSigma = std::max( maxMovingIntensity, maxFixedIntensity );
     }
 }
 
@@ -341,7 +341,7 @@ MeanSquaresPointSetToPointSetIntensityMetricv4<TFixedPointSet, TMovingPointSet, 
 
   // the probabilistic icp term
   const MeasureType euclideanDistance = point.EuclideanDistanceTo( closestPoint );
-  MeasureType distanceProbability = std::exp( -0.5 * vnl_math_sqr( euclideanDistance / this->m_EuclideanDistanceSigma ) );
+  MeasureType distanceProbability = std::exp( -0.5 * itk::Math::sqr ( euclideanDistance / this->m_EuclideanDistanceSigma ) );
 
   SizeValueType numberOfVoxelsInNeighborhood = pixel.size() / ( 1 + PointDimension );
   SizeValueType centerIntensityIndex = static_cast<SizeValueType>( 0.5 * numberOfVoxelsInNeighborhood )
@@ -349,7 +349,7 @@ MeanSquaresPointSetToPointSetIntensityMetricv4<TFixedPointSet, TMovingPointSet, 
 
   // the probabilistic intensity term
   MeasureType intensityDistance = pixel[centerIntensityIndex] - closestPixel[centerIntensityIndex];
-  MeasureType intensityProbability = std::exp( -0.5 * vnl_math_sqr( intensityDistance / this->m_IntensityDistanceSigma ) );
+  MeasureType intensityProbability = std::exp( -0.5 * itk::Math::sqr ( intensityDistance / this->m_IntensityDistanceSigma ) );
 
   const MeasureType measure = ( -1.0 ) * intensityProbability * distanceProbability;
 
@@ -389,7 +389,7 @@ MeanSquaresPointSetToPointSetIntensityMetricv4<TFixedPointSet, TMovingPointSet, 
 
   // the probabilistic icp term
   const MeasureType euclideanDistance = point.EuclideanDistanceTo( closestPoint );
-  MeasureType distanceProbability = std::exp( -0.5 * vnl_math_sqr( euclideanDistance / this->m_EuclideanDistanceSigma ) );
+  MeasureType distanceProbability = std::exp( -0.5 * itk::Math::sqr ( euclideanDistance / this->m_EuclideanDistanceSigma ) );
 
   SizeValueType numberOfVoxelsInNeighborhood = pixel.size() / ( 1 + PointDimension );
   SizeValueType centerIntensityIndex =
@@ -397,7 +397,7 @@ MeanSquaresPointSetToPointSetIntensityMetricv4<TFixedPointSet, TMovingPointSet, 
 
   // the probabilistic intensity term
   MeasureType intensityDistance = pixel[centerIntensityIndex] - closestPixel[centerIntensityIndex];
-  MeasureType intensityProbability = std::exp( -0.5 * vnl_math_sqr( intensityDistance / this->m_IntensityDistanceSigma ) );
+  MeasureType intensityProbability = std::exp( -0.5 * itk::Math::sqr ( intensityDistance / this->m_IntensityDistanceSigma ) );
 
   measure = ( -1.0 ) * intensityProbability * distanceProbability;
 

--- a/Tensor/TensorFunctions.h
+++ b/Tensor/TensorFunctions.h
@@ -170,7 +170,7 @@ TensorType TensorLogAndExp( TensorType dtv, bool takelog, bool & success)
     {
     float ff = dtv[jj];
     mag += ff * ff;
-    if( vnl_math_isnan( ff ) || vnl_math_isinf(ff)   )
+    if( std::isnan( ff ) || std::isinf(ff)   )
       {
       dtv.Fill(0); // dtv[0]=eps;   dtv[3]=eps;  dtv[5]=eps;
       success = false;
@@ -249,9 +249,9 @@ TensorType TensorLogAndExp( TensorType dtv, bool takelog, bool & success)
     eigmat(2, 2) = exp(e3);
     }
 
-  if( vnl_math_isnan(eigmat(0, 0) ) ||
-      vnl_math_isnan(eigmat(1, 1) ) ||
-      vnl_math_isnan(eigmat(2, 2) ) )
+  if( std::isnan(eigmat(0, 0) ) ||
+      std::isnan(eigmat(1, 1) ) ||
+      std::isnan(eigmat(2, 2) ) )
     {
     dtv.Fill(0);
     success = false;
@@ -284,7 +284,7 @@ bool IsRealTensor( TensorType dtv )
 
   for( unsigned int i = 0; i < 6; i++ )
     {
-    if( !vnl_math_isfinite( dtv[i] ) )
+    if( !std::isfinite( dtv[i] ) )
       {
       isreal = false;
       }
@@ -520,7 +520,7 @@ float  GetTensorADC( TTensorType dtv,  unsigned int opt = 0)
     {
     float ff = dtv[jj];
     mag += ff * ff;
-    if( vnl_math_isnan( ff ) || vnl_math_isinf(ff)   )
+    if( std::isnan( ff ) || std::isinf(ff)   )
       {
       return 0;
       }
@@ -599,7 +599,7 @@ itk::RGBPixel<unsigned char>   GetTensorRGB( TTensorType dtv )
     {
     float ff = dtv[jj];
     mag += ff * ff;
-    if( vnl_math_isnan( ff ) || vnl_math_isinf(ff)   )
+    if( std::isnan( ff ) || std::isinf(ff)   )
       {
       return zero;
       }
@@ -642,7 +642,7 @@ itk::RGBPixel<float>   GetTensorPrincipalEigenvector( TTensorType dtv )
     {
     float ff = dtv[jj];
     mag += ff * ff;
-    if( vnl_math_isnan( ff ) || vnl_math_isinf(ff)   )
+    if( std::isnan( ff ) || std::isinf(ff)   )
       {
       return zero;
       }
@@ -722,7 +722,7 @@ itk::Vector<float>   GetTensorPrincipalEigenvector( TTensorType dtv, unsigned in
     {
     float ff = dtv[jj];
     mag += ff * ff;
-    if( vnl_math_isnan( ff ) || vnl_math_isinf(ff)   )
+    if( std::isnan( ff ) || std::isinf(ff)   )
       {
       return zero;
       }

--- a/Tensor/itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.cxx
+++ b/Tensor/itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.cxx
@@ -237,7 +237,7 @@ PreservationOfPrincipalDirectionTensorReorientationImageFilter<TTensorImage, TVe
     {
     for( unsigned int jy = 0; jy < ImageDimension; jy++ )
       {
-      if( !vnl_math_isfinite(jMatrix(jx, jy) )  )
+      if( !std::isfinite(jMatrix(jx, jy) )  )
         {
         oktosample = false;
         }
@@ -335,7 +335,7 @@ PreservationOfPrincipalDirectionTensorReorientationImageFilter<TTensorImage, TVe
     bool hasNans = false;
     for( unsigned int jj = 0; jj < 6; jj++ )
       {
-      if( vnl_math_isnan( inTensor[jj] ) || vnl_math_isinf( inTensor[jj]) )
+      if( std::isnan( inTensor[jj] ) || std::isinf( inTensor[jj]) )
         {
         hasNans = true;;
         }
@@ -380,7 +380,7 @@ PreservationOfPrincipalDirectionTensorReorientationImageFilter<TTensorImage, TVe
     // valid values?
     for( unsigned int jj = 0; jj < 6; jj++ )
       {
-      if( vnl_math_isnan( outTensor[jj] ) || vnl_math_isinf( outTensor[jj]) )
+      if( std::isnan( outTensor[jj] ) || std::isinf( outTensor[jj]) )
         {
         outTensor[jj] = 0;
         }

--- a/Tensor/itkWarpTensorImageMultiTransformFilter.hxx
+++ b/Tensor/itkWarpTensorImageMultiTransformFilter.hxx
@@ -335,7 +335,7 @@ WarpTensorImageMultiTransformFilter<TInputImage, TOutputImage, TDisplacementFiel
         InputImagePointer image = const_cast<InputImageType *> (this->GetInput());
         for ( unsigned int d = 0; d < ImageDimension; d++ )
         {
-            double scaling = vnl_math_min( 1.0 / scale * minimumSpacing / inputSpacing[d],
+            double scaling = std::min( 1.0 / scale * minimumSpacing / inputSpacing[d],
                     static_cast<double>( inputSize[d] ) / 32.0 );
             outputSpacing[d] = inputSpacing[d] * scaling;
             outputSize[d] = static_cast<unsigned long>( inputSpacing[d] *

--- a/Utilities/antsSCCANObject.h
+++ b/Utilities/antsSCCANObject.h
@@ -772,7 +772,7 @@ protected:
       {
       if( x_k1[i] < 0 )
         {
-        x_k1[i] = vnl_math_abs( x_k1[i] );
+        x_k1[i] = itk::Math::abs ( x_k1[i] );
         x_k1[i] = 0;
         }
       }
@@ -780,7 +780,7 @@ protected:
 
   void SparsifyOther( VectorType& x_k1 , bool doclassic = false )
   {
-    RealType fnp = vnl_math_abs( this->m_RowSparseness );
+    RealType fnp = itk::Math::abs ( this->m_RowSparseness );
     if( fnp < 1.e-11 )
       {
       return;
@@ -791,7 +791,7 @@ protected:
       if ( fnp > x_k1.max_value() ) fnp = x_k1.max_value() * 0.9;
       for ( unsigned int i = 0; i < x_k1.size(); i++ )
 	{
-	RealType delta = vnl_math_abs( x_k1( i ) ) - fnp;
+	RealType delta = itk::Math::abs ( x_k1( i ) ) - fnp;
 	if ( delta < 0 ) delta = 0; else if ( x_k1( i ) < 0 ) delta *= ( -1 );
 	x_k1( i ) = delta;
 	}
@@ -802,7 +802,7 @@ protected:
       if ( fnp > x_k1.max_value() ) fnp = x_k1.max_value() * 0.9;
       for ( unsigned int i = 0; i < x_k1.size(); i++ )
 	{
-	RealType delta = vnl_math_abs( x_k1( i ) ) - fnp;
+	RealType delta = itk::Math::abs ( x_k1( i ) ) - fnp;
 	if ( delta < 0 ) delta = 0;
 	x_k1( i ) = delta;
 	}
@@ -823,13 +823,13 @@ protected:
 
   void SparsifyP( VectorType& x_k1 )
   {
-    RealType fnp = vnl_math_abs( this->m_FractionNonZeroP  );
+    RealType fnp = itk::Math::abs ( this->m_FractionNonZeroP  );
     this->Sparsify( x_k1, fnp, this->m_KeepPositiveP, this->m_MinClusterSizeP, this->m_MaskImageP);
   }
 
   void SparsifyQ( VectorType& x_k1 )
   {
-    RealType fnp = vnl_math_abs( this->m_FractionNonZeroQ  );
+    RealType fnp = itk::Math::abs ( this->m_FractionNonZeroQ  );
     this->Sparsify( x_k1, fnp, this->m_KeepPositiveQ, this->m_MinClusterSizeQ, this->m_MaskImageQ);
   }
 
@@ -852,7 +852,7 @@ protected:
       return;
       }
     bool negate = false;
-    if ( vnl_math_abs( x_k1.min_value() ) > x_k1.max_value() )
+    if ( itk::Math::abs ( x_k1.min_value() ) > x_k1.max_value() )
       {
       negate = true;
       }
@@ -877,7 +877,7 @@ protected:
       RealType  maxval = x_k1sort[ maxjind ];
       RealType  minval = x_k1sort[ minjind ];
       RealType    high = maxval;
-      if ( vnl_math_abs( minval ) > high ) high = vnl_math_abs( minval );
+      if ( itk::Math::abs ( minval ) > high ) high = itk::Math::abs ( minval );
       //    if ( high * 0.2  > 0 ) low = high * 0.2; // hack to speed convergence
       RealType     eng = fnp;
       RealType     mid = low + 0.5 * ( high - low );
@@ -885,7 +885,7 @@ protected:
       RealType     fnm = 0;
       RealType     lastfnm = 1;
       while( ( ( eng > (fnp*0.1) )  &&
-               ( vnl_math_abs( high - low ) > this->m_Epsilon )  &&
+               ( itk::Math::abs ( high - low ) > this->m_Epsilon )  &&
                ( its < 20 ) ) || its < 3  )
         {
         mid = low + 0.5 * ( high - low );
@@ -906,7 +906,7 @@ protected:
           {
   	      high = mid; // 0.5 * ( high + mid  );
           }
-        eng = vnl_math_abs( fnp - fnm );
+        eng = itk::Math::abs ( fnp - fnm );
         its++;
         }
       this->SoftClustThreshold( x_k1, mid, keeppos,  clust, mask  );
@@ -914,7 +914,7 @@ protected:
     else
       {
       for ( unsigned long j = 0; j < x_k1.size(); ++j )
-        if ( vnl_math_abs( x_k1[ j ] ) < (1.0-fnp) )  x_k1[ j ] = 0;
+        if ( itk::Math::abs ( x_k1[ j ] ) < (1.0-fnp) )  x_k1[ j ] = 0;
       this->SoftClustThreshold( x_k1, 0, keeppos,  clust, mask  );
       }
     x_k1 = this->SpatiallySmoothVector( x_k1, mask );
@@ -962,7 +962,7 @@ protected:
     RealType     fnm = 0;
     RealType     lastfnm = 1;
     while( ( ( eng > 5.e-3 )  &&
-             ( vnl_math_abs( high - low ) > this->m_Epsilon )  &&
+             ( itk::Math::abs ( high - low ) > this->m_Epsilon )  &&
              ( its < 50 ) ) ||
 	     its < 5
 	 )
@@ -982,7 +982,7 @@ protected:
         {
         high = mid;
         }
-      eng = vnl_math_abs( fnp - fnm );
+      eng = itk::Math::abs ( fnp - fnm );
       its++;
       }
 
@@ -1041,7 +1041,7 @@ protected:
 
     for( unsigned int i = 0; i < v.size(); i++ )
       {
-      if( vnl_math_abs( v[i] ) > this->m_Epsilon )
+      if( itk::Math::abs ( v[i] ) > this->m_Epsilon )
         {
         ct++;
         }
@@ -1053,7 +1053,7 @@ protected:
   {
     RealType eps = this->m_Epsilon * 5.0;
     //    eps = 0.0001;
-    if ( vnl_math_abs( x - itk::NumericTraits<RealType>::ZeroValue() ) < eps ) return true;
+    if ( itk::Math::abs ( x - itk::NumericTraits<RealType>::ZeroValue() ) < eps ) return true;
     return false;
   }
 
@@ -1074,7 +1074,7 @@ protected:
       {
       return 0;
       }
-    return vnl_math_abs( numer / denom );
+    return itk::Math::abs ( numer / denom );
   }
 
   RealType RPearsonCorr(VectorType v1, VectorType v2 )
@@ -1116,7 +1116,7 @@ protected:
       {
       return 0;
       }
-    return vnl_math_abs( numer / denom );
+    return itk::Math::abs ( numer / denom );
   }
 
 

--- a/Utilities/antsSCCANObject.hxx
+++ b/Utilities/antsSCCANObject.hxx
@@ -271,9 +271,9 @@ antsSCCANObject<TInputImage, TRealType>
         x[kk] = 0;
         zct++;
         }
-      else if( vnl_math_abs( x[kk] ) > 1.e-6 )
+      else if( itk::Math::abs ( x[kk] ) > 1.e-6 )
         {
-        kappa += vnl_math_abs( grad );
+        kappa += itk::Math::abs ( grad );
         x[kk] = x[kk] + grad;
         nzct++;
         }
@@ -672,7 +672,7 @@ antsSCCANObject<TInputImage, TRealType>
 ::SpatiallySmoothVector( typename antsSCCANObject<TInputImage, TRealType>::VectorType vec,
                          typename TInputImage::Pointer mask, bool surface  )
 {
-  if( mask.IsNull() || vnl_math_abs( this->m_Smoother ) < 1.e-9 )
+  if( mask.IsNull() || itk::Math::abs ( this->m_Smoother ) < 1.e-9 )
     {
     return vec;
     }
@@ -691,7 +691,7 @@ antsSCCANObject<TInputImage, TRealType>
       TInputImage > FilterType;
     typename FilterType::Pointer filter = FilterType::New();
     filter->SetInput( image );
-    filter->SetNumberOfIterations( vnl_math_abs( this->m_Smoother ) );
+    filter->SetNumberOfIterations( itk::Math::abs ( this->m_Smoother ) );
     TRealType mytimestep = spacingsize / std::pow( 2.0 , static_cast<double>(ImageDimension+1) );
     TRealType reftimestep = 0.5 / std::pow( 2.0 , static_cast<double>(ImageDimension+1) );
     if ( mytimestep > reftimestep ) mytimestep = reftimestep;
@@ -894,7 +894,7 @@ antsSCCANObject<TInputImage, TRealType>
     RealType val = v_in(i);
     if ( keep_positive && val < 0 ) val = 0 ;
     // if ( keep_positive && val < 0 ) val *= ( -1 );
-    if( vnl_math_abs( val ) < soft_thresh )
+    if( itk::Math::abs ( val ) < soft_thresh )
       {
       v_in(i) = 0;
       }
@@ -1850,7 +1850,7 @@ TRealType antsSCCANObject<TInputImage, TRealType>
       RealType fnz = 0;
       for( unsigned int y = 0; y < this->m_OriginalMatrixPriorROI.cols(); y++ )
 	      {
-      	if( vnl_math_abs( priorrow( y ) ) > 1.e-10 )
+      	if( itk::Math::abs ( priorrow( y ) ) > 1.e-10 )
           {
       	  fnz += 1;
       	  }
@@ -2130,12 +2130,12 @@ TRealType antsSCCANObject<TInputImage, TRealType>
       RealType fnz = 0;
       for( unsigned int y = 0; y < this->m_OriginalMatrixPriorROI.cols(); y++ )
       	{
-      	if(vnl_math_abs( priorrow( y ) ) > 1.e-8 )
+      	if(itk::Math::abs ( priorrow( y ) ) > 1.e-8 )
           {
       	  fnz += 1;
       	  }
       	}
-      if ( vnl_math_abs( this->m_FractionNonZeroP ) < 1.e-11 )
+      if ( itk::Math::abs ( this->m_FractionNonZeroP ) < 1.e-11 )
         sparsenessparams( x ) = 1.0 * (RealType) fnz / (RealType) this->m_OriginalMatrixPriorROI.cols();
       priorrow = priorrow/priorrow.two_norm();
       this->m_MatrixPriorROI.set_row( x , priorrow );
@@ -2175,7 +2175,7 @@ TRealType antsSCCANObject<TInputImage, TRealType>
         RealType maxval = 0;
     	  for( unsigned int j = 0; j < n_vecs; j++ )
     	    {
-    	    RealType myval = vnl_math_abs( this->m_VariatesP( i, j ) );
+    	    RealType myval = itk::Math::abs ( this->m_VariatesP( i, j ) );
     	    if (  myval > maxval )
     	      {
     	      maxvals( i ) = j;
@@ -2659,7 +2659,7 @@ TRealType antsSCCANObject<TInputImage, TRealType>
           VectorType voxels = this->m_MatrixP.get_column( vox );
           RealType  lmerror = this->ConjGrad(  A ,  lmsol , voxels , 0 , 100 );
           VectorType proj =   A * lmsol;
-          if ( vnl_math_isnan( lmerror ) ) { lmerror = 0 ; proj.fill(0); }
+          if ( std::isnan( lmerror ) ) { lmerror = 0 ; proj.fill(0); }
           reconmat.set_column( vox , proj );
           totalerr += lmerror;
           }
@@ -3267,7 +3267,7 @@ TRealType antsSCCANObject<TInputImage, TRealType>
          ( ( deltaminerr > 1.e-10 ) && ( minerr > convcrit ) && ( ct < maxits ) )
          )
     {
-    //    RealType spgoal = 100.0 * ( 1 - vnl_math_abs( this->m_FractionNonZeroP ) );
+    //    RealType spgoal = 100.0 * ( 1 - itk::Math::abs ( this->m_FractionNonZeroP ) );
     RealType alpha_denom = inner_product( p_k,  A.transpose() * ( A * p_k ) );
     RealType iprk = inner_product( r_k, z_k );
     RealType alpha_k = iprk / alpha_denom;
@@ -3299,7 +3299,7 @@ TRealType antsSCCANObject<TInputImage, TRealType>
       }
     VectorType yk = r_k1 - r_k;
     RealType   temp = inner_product( z_k, r_k );
-    if( vnl_math_abs( temp ) < 1.e-9 )
+    if( itk::Math::abs ( temp ) < 1.e-9 )
       {
       temp = 1;
       }
@@ -3368,7 +3368,7 @@ TRealType antsSCCANObject<TInputImage, TRealType>
   */
   A = A - A.min_value();
   VectorType evec = evecin;
-  unsigned int maxcoltoorth = ( unsigned int ) ( 1.0 / vnl_math_abs( this->m_FractionNonZeroP ) ) - 1;
+  unsigned int maxcoltoorth = ( unsigned int ) ( 1.0 / itk::Math::abs ( this->m_FractionNonZeroP ) ) - 1;
   if( evecin.two_norm() ==  0 )
     {
     evec = this->InitializeV( this->m_MatrixP, false );
@@ -3452,7 +3452,7 @@ TRealType antsSCCANObject<TInputImage, TRealType>
                      typename antsSCCANObject<TInputImage, TRealType>::VectorType& evecin,
                      unsigned int maxits, unsigned int maxorth )
 {
-  unsigned int maxcoltoorth = ( unsigned int ) ( 1.0 / vnl_math_abs( this->m_FractionNonZeroP ) ) - 1;
+  unsigned int maxcoltoorth = ( unsigned int ) ( 1.0 / itk::Math::abs ( this->m_FractionNonZeroP ) ) - 1;
   VectorType proj = evecin;
   RealType   rayquo = 0;
   RealType     bestrayquo = 0;
@@ -3523,8 +3523,8 @@ template <class TInputImage, class TRealType>
 TRealType antsSCCANObject<TInputImage, TRealType>
 ::RidgeCCA(unsigned int n_vecs)
 {
-  RealType taup = vnl_math_abs( this->m_FractionNonZeroP );
-  RealType tauq = vnl_math_abs( this->m_FractionNonZeroQ );
+  RealType taup = itk::Math::abs ( this->m_FractionNonZeroP );
+  RealType tauq = itk::Math::abs ( this->m_FractionNonZeroQ );
 
   if ( ! this->m_Silent )  std::cout << " ridge cca : taup " << taup << " tauq " << tauq << std::endl;
 
@@ -4045,7 +4045,7 @@ TRealType antsSCCANObject<TInputImage, TRealType>
                                  unsigned int maxits, bool makesparse )
 {
   x_k.fill( 0 );
-  RealType spgoal = 100.0 * ( 1 - vnl_math_abs( this->m_FractionNonZeroP ) );
+  RealType spgoal = 100.0 * ( 1 - itk::Math::abs ( this->m_FractionNonZeroP ) );
   RealType lambda = 1.e2;
   if ( ! this->m_Silent )  std::cout << "SparseConjGradRidgeRegression: lambda " << lambda << " Soft? " <<   this->m_UseL1 << " fnp "
                    << this->m_FractionNonZeroP << std::endl;
@@ -4276,15 +4276,15 @@ TRealType antsSCCANObject<TInputImage, TRealType>
     VectorType corrb( x_k );
     for( unsigned int mm = 0; mm < A.cols(); mm++ )
       {
-      corrb( mm ) = vnl_math_abs( this->PearsonCorr( resid, A.get_column( mm ) ) );
+      corrb( mm ) = itk::Math::abs ( this->PearsonCorr( resid, A.get_column( mm ) ) );
       }
-    this->ReSoftThreshold( corrb, vnl_math_abs( this->m_FractionNonZeroP ), true );
+    this->ReSoftThreshold( corrb, itk::Math::abs ( this->m_FractionNonZeroP ), true );
 
     /** this debiases the solution */
     unsigned int nzct = 0;
     for( unsigned int mm = 0; mm < A.cols(); mm++ )
       {
-      if( vnl_math_abs( corrb( mm ) ) > 0 )
+      if( itk::Math::abs ( corrb( mm ) ) > 0 )
         {
         this->m_Indicator( mm, mm ) = 1;
         }
@@ -4300,7 +4300,7 @@ TRealType antsSCCANObject<TInputImage, TRealType>
         x_k( mm ) = lmsolv( nzct ); nzct++;
         }
       }
-    this->ReSoftThreshold( x_k, vnl_math_abs( this->m_FractionNonZeroP ), true );
+    this->ReSoftThreshold( x_k, itk::Math::abs ( this->m_FractionNonZeroP ), true );
     this->ClusterThresholdVariate( x_k, this->m_MaskImageP, this->m_MinClusterSizeP );
 
     this->m_Intercept = this->ComputeIntercept(  A, x_k, this->m_OriginalB );
@@ -4638,8 +4638,8 @@ template <class TInputImage, class TRealType>
 TRealType antsSCCANObject<TInputImage, TRealType>
 ::SparseArnoldiSVD_Other( typename antsSCCANObject<TInputImage, TRealType>::MatrixType& A )
 {
-  if ( vnl_math_abs(this->m_RowSparseness) <= 1.e-9 ) return 0;
-  unsigned int maxrowtoorth = ( unsigned int ) ( 1.0 / vnl_math_abs( this->m_RowSparseness ) ) - 0;
+  if ( itk::Math::abs (this->m_RowSparseness) <= 1.e-9 ) return 0;
+  unsigned int maxrowtoorth = ( unsigned int ) ( 1.0 / itk::Math::abs ( this->m_RowSparseness ) ) - 0;
   unsigned int maxloop = 10;
   unsigned int loop = 0;
   double       convcrit = 1;
@@ -5295,8 +5295,8 @@ TRealType antsSCCANObject<TInputImage, TRealType>
     this->SparsifyOther( qvec2 );
     qvec2 = qvec2 * this->m_MatrixQ;
     if (  qvec2.two_norm() > this->m_Epsilon ) qvec2 = qvec2 / qvec2.two_norm();
-    if ( vnl_math_abs(  this->PearsonCorr(  this->m_MatrixP * vec2,  this->m_MatrixQ * qvec2 )  ) >
-	 vnl_math_abs(  this->PearsonCorr(  this->m_MatrixP * vec,  this->m_MatrixQ * qvec )  ) )
+    if ( itk::Math::abs (  this->PearsonCorr(  this->m_MatrixP * vec2,  this->m_MatrixQ * qvec2 )  ) >
+	 itk::Math::abs (  this->PearsonCorr(  this->m_MatrixP * vec,  this->m_MatrixQ * qvec )  ) )
       {
       vec = vec2;
       qvec = qvec2;
@@ -5323,16 +5323,16 @@ TRealType antsSCCANObject<TInputImage, TRealType>
       }
     this->SparsifyP( vec );
     this->SparsifyQ( qvec );
-    RealType locor = vnl_math_abs( this->PearsonCorr(  this->m_MatrixP * vec,  this->m_MatrixQ * qvec ) );
-    if ( vnl_math_isnan( qvec.two_norm() ) )
+    RealType locor = itk::Math::abs ( this->PearsonCorr(  this->m_MatrixP * vec,  this->m_MatrixQ * qvec ) );
+    if ( std::isnan( qvec.two_norm() ) )
       {
       qvec = this->m_VariatesQ.get_column( kk );
-      locor = vnl_math_abs( this->PearsonCorr(  this->m_MatrixP * vec,  this->m_MatrixQ * qvec ) );
+      locor = itk::Math::abs ( this->PearsonCorr(  this->m_MatrixP * vec,  this->m_MatrixQ * qvec ) );
       }
-    if ( vnl_math_isnan( vec.two_norm() ) )
+    if ( std::isnan( vec.two_norm() ) )
       {
       vec = this->m_VariatesP.get_column( kk );
-      locor = vnl_math_abs( this->PearsonCorr(  this->m_MatrixP * vec,  this->m_MatrixQ * qvec ) );
+      locor = itk::Math::abs ( this->PearsonCorr(  this->m_MatrixP * vec,  this->m_MatrixQ * qvec ) );
       }
     this->m_VariatesP.set_column( kk, vec  );
     this->m_VariatesQ.set_column( kk, qvec );
@@ -5378,7 +5378,7 @@ TRealType antsSCCANObject<TInputImage, TRealType>
     this->m_VariatesP.set_column( kk, vec );
     this->m_VariatesQ.set_column( kk, qvec );
     this->NormalizeWeights( kk );
-    totalcorr += vnl_math_abs( this->PearsonCorr(  this->m_MatrixP * vec,  this->m_MatrixQ * qvec ) );
+    totalcorr += itk::Math::abs ( this->PearsonCorr(  this->m_MatrixP * vec,  this->m_MatrixQ * qvec ) );
     }
   return totalcorr*0.5;
   //  this->CCAUpdate( n_vecs , false );
@@ -5535,7 +5535,7 @@ TRealType antsSCCANObject<TInputImage, TRealType>
     bool changedgrad = this->CCAUpdate( n_vecs_in, true , normbycov, k );
     lastenergy = energy;
     energy = this->m_CanonicalCorrelations.one_norm() / ( float ) n_vecs_in;
-    if( this->m_GradStep < 1.e-12 ) // || ( vnl_math_abs( energy - lastenergy ) < this->m_Epsilon  && !changedgrad ) )
+    if( this->m_GradStep < 1.e-12 ) // || ( itk::Math::abs ( energy - lastenergy ) < this->m_Epsilon  && !changedgrad ) )
       {
       if ( ! this->m_Silent )  std::cout << " this->m_GradStep : " << this->m_GradStep << " energy : " << energy << " changedgrad : " << changedgrad << std::endl;
       }
@@ -5734,7 +5734,7 @@ TRealType antsSCCANObject<TInputImage, TRealType>
     energy = this->m_CanonicalCorrelations.one_norm() / n_vecs;
     if ( ! this->m_Silent )  std::cout << " Loop " << loop << " Corrs : " << this->m_CanonicalCorrelations << " CorrMean : " << energy
                      << std::endl;
-    if( vnl_math_abs( energy - lastenergy ) < 1.e-8 || energy < lastenergy )
+    if( itk::Math::abs ( energy - lastenergy ) < 1.e-8 || energy < lastenergy )
       {
       energyincreases = false;
       }

--- a/Utilities/itkAdaptiveNonLocalMeansDenoisingImageFilter.hxx
+++ b/Utilities/itkAdaptiveNonLocalMeansDenoisingImageFilter.hxx
@@ -210,12 +210,12 @@ AdaptiveNonLocalMeansDenoisingImageFilter<TInputImage, TOutputImage, TMaskImage>
               }
             RealType neighborhoodInputImagePixel = static_cast<RealType>( inputImage->GetPixel( neighborhoodPatchIndex ) );
             RealType neighborhoodMeanImagePixel = this->m_MeanImage->GetPixel( neighborhoodPatchIndex );
-            averageDistance += vnl_math_sqr( neighborhoodInputImagePixel - neighborhoodMeanImagePixel );
+            averageDistance += itk::Math::sqr ( neighborhoodInputImagePixel - neighborhoodMeanImagePixel );
 
             count += 1.0;
             }
           averageDistance /= count;
-          minimumDistance = vnl_math_min( averageDistance, minimumDistance );
+          minimumDistance = std::min( averageDistance, minimumDistance );
           }
         }
 
@@ -296,7 +296,7 @@ AdaptiveNonLocalMeansDenoisingImageFilter<TInputImage, TOutputImage, TMaskImage>
                                  this->m_MeanImage->GetPixel( searchNeighborhoodPatchIndex );
             RealType distance2 = inputImage->GetPixel( centerNeighborhoodPatchIndex ) -
                                  this->m_MeanImage->GetPixel( centerNeighborhoodPatchIndex );
-            averageDistance += vnl_math_sqr( distance1 - distance2 );
+            averageDistance += itk::Math::sqr ( distance1 - distance2 );
             count += 1.0;
             }
           averageDistance /= count;
@@ -322,7 +322,7 @@ AdaptiveNonLocalMeansDenoisingImageFilter<TInputImage, TOutputImage, TMaskImage>
                 }
               if( this->m_UseRicianNoiseModel )
                 {
-                weightedAverageIntensities[n] += weight * vnl_math_sqr( inputImage->GetPixel( neighborhoodPatchIndex ) );
+                weightedAverageIntensities[n] += weight * itk::Math::sqr ( inputImage->GetPixel( neighborhoodPatchIndex ) );
                 }
               else
                 {
@@ -353,7 +353,7 @@ AdaptiveNonLocalMeansDenoisingImageFilter<TInputImage, TOutputImage, TMaskImage>
         }
       if( this->m_UseRicianNoiseModel )
         {
-        weightedAverageIntensities[n] += maxWeight * vnl_math_sqr( inputImage->GetPixel( neighborhoodPatchIndex ) );
+        weightedAverageIntensities[n] += maxWeight * itk::Math::sqr ( inputImage->GetPixel( neighborhoodPatchIndex ) );
         }
       else
         {
@@ -418,7 +418,7 @@ AdaptiveNonLocalMeansDenoisingImageFilter<TInputImage, TOutputImage, TMaskImage>
 
         RealType bias = 2.0 * ItS.Get() / this->CalculateCorrectionFactor( snr );
 
-        if( vnl_math_isnan( bias ) || vnl_math_isinf( bias ) )
+        if( std::isnan( bias ) || std::isinf( bias ) )
           {
           bias = 0.0;
           }
@@ -468,10 +468,10 @@ typename AdaptiveNonLocalMeansDenoisingImageFilter<TInputImage, TOutputImage, TM
 AdaptiveNonLocalMeansDenoisingImageFilter<TInputImage, TOutputImage, TMaskImage>
 ::CalculateCorrectionFactor( RealType snr )
 {
-   const RealType snrSquared = vnl_math_sqr( snr );
+   const RealType snrSquared = itk::Math::sqr ( snr );
 
    RealType value = 2.0 + snrSquared - 0.125 * Math::pi * std::exp( -0.5 * snrSquared ) *
-     vnl_math_sqr( ( 2.0 + snrSquared ) * this->m_ModifiedBesselCalculator.ModifiedBesselI0( 0.25 * snrSquared ) +
+     itk::Math::sqr ( ( 2.0 + snrSquared ) * this->m_ModifiedBesselCalculator.ModifiedBesselI0( 0.25 * snrSquared ) +
      snrSquared * this->m_ModifiedBesselCalculator.ModifiedBesselI1( 0.25 * snrSquared ) );
 
    if( value < 0.001 || value > 10.0 )

--- a/Utilities/itkDiReCTImageFilter.hxx
+++ b/Utilities/itkDiReCTImageFilter.hxx
@@ -358,7 +358,7 @@ DiReCTImageFilter<TInputImage, TOutputImage>
         if( ItSegmentationImage.Get() == grayMatterPixel )
           {
           RealType norm = ( ItGradientImage.Get() ).GetNorm();
-          if( norm > 1e-3 && !vnl_math_isnan( norm ) && !vnl_math_isinf( norm ) )
+          if( norm > 1e-3 && !std::isnan( norm ) && !std::isinf( norm ) )
             {
             ItGradientImage.Set( ItGradientImage.Get() / norm );
             }
@@ -367,10 +367,10 @@ DiReCTImageFilter<TInputImage, TOutputImage>
             ItGradientImage.Set( zeroVector );
             }
           RealType delta = ( ItWarpedWhiteMatterProbabilityMap.Get() - ItGrayMatterProbabilityMap.Get() );
-          currentEnergy += vnl_math_abs( delta );
+          currentEnergy += itk::Math::abs ( delta );
           numberOfGrayMatterVoxels++;
           RealType speedValue = -1.0 * delta * ItGrayMatterProbabilityMap.Get() * this->m_CurrentGradientStep;
-          if( vnl_math_isnan( speedValue ) || vnl_math_isinf( speedValue ) )
+          if( std::isnan( speedValue ) || std::isinf( speedValue ) )
             {
             speedValue = 0.0;
             }
@@ -584,7 +584,7 @@ DiReCTImageFilter<TInputImage, TOutputImage>
           if( ! this->m_ThicknessPriorImage && ( thicknessValue > this->m_ThicknessPriorEstimate ) )
             {
             RealType fraction = this->m_ThicknessPriorEstimate / thicknessValue;
-            ItVelocityField.Set( ItVelocityField.Get() * vnl_math_sqr( fraction ) );
+            ItVelocityField.Set( ItVelocityField.Get() * itk::Math::sqr ( fraction ) );
             }
           else if( this->m_ThicknessPriorImage )
             {
@@ -593,11 +593,11 @@ DiReCTImageFilter<TInputImage, TOutputImage>
             if( ( thicknessPrior > NumericTraits<RealType>::ZeroValue() ) &&
                 ( thicknessValue > thicknessPrior ) )
               {
-              priorEnergy += vnl_math_abs( thicknessPrior - thicknessValue );
+              priorEnergy += itk::Math::abs ( thicknessPrior - thicknessValue );
               priorEnergyCount++;
 
               RealType fraction = thicknessPrior / thicknessValue;
-              ItVelocityField.Set( ItVelocityField.Get() * vnl_math_sqr( fraction ) );
+              ItVelocityField.Set( ItVelocityField.Get() * itk::Math::sqr ( fraction ) );
               }
             }
           }

--- a/Utilities/itkGeometricJacobianDeterminantImageFilter.hxx
+++ b/Utilities/itkGeometricJacobianDeterminantImageFilter.hxx
@@ -325,7 +325,7 @@ GeometricJacobianDeterminantImageFilter< TInputImage, TRealType, TOutputImage >
   vnl_vector<double> bd = ( b - d ).GetVnlVector();
   vnl_vector<double> cd = ( c - d ).GetVnlVector();
   vnl_vector<double> bdxcd = vnl_cross_3d( bd, cd );
-  RealType volume = vnl_math_abs( ad[0] * bdxcd[0] +  ad[1] * bdxcd[1] + ad[2] * bdxcd[2] ) / 6.0;
+  RealType volume = itk::Math::abs ( ad[0] * bdxcd[0] +  ad[1] * bdxcd[1] + ad[2] * bdxcd[2] ) / 6.0;
   return volume;
 }
 
@@ -338,7 +338,7 @@ GeometricJacobianDeterminantImageFilter< TInputImage, TRealType, TOutputImage >
   RealVectorType ab = ( a - b );
   RealVectorType ac = ( a - c );
 
-  RealType area = 0.5 * vnl_math_abs( ab[0] * ac[1] - ac[0] * ab[1] );
+  RealType area = 0.5 * itk::Math::abs ( ab[0] * ac[1] - ac[0] * ab[1] );
 
   return area;
 }

--- a/Utilities/itkManifoldParzenWindowsPointSetFunction.hxx
+++ b/Utilities/itkManifoldParzenWindowsPointSetFunction.hxx
@@ -17,7 +17,7 @@
 #include "itkManifoldParzenWindowsPointSetFunction.h"
 
 #include "vnl/vnl_vector.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 namespace itk
 {
@@ -242,7 +242,7 @@ ManifoldParzenWindowsPointSetFunction<TPointSet, TOutput, TCoordRep>
       queryPoint[d] = point[d];
       }
 
-    unsigned int numberOfNeighbors = vnl_math_min(
+    unsigned int numberOfNeighbors = std::min(
         this->m_EvaluationKNeighborhood,
         static_cast<unsigned int>( this->m_Gaussians.size() ) );
 

--- a/Utilities/itkMultiScaleLaplacianBlobDetectorImageFilter.h
+++ b/Utilities/itkMultiScaleLaplacianBlobDetectorImageFilter.h
@@ -67,7 +67,7 @@ public:
   /** The radius of the object if it is a solid hyper-sphere */
   double GetObjectRadius( void ) const
   {
-    return this->GetSigma() *  vnl_math::sqrt2;
+    return this->GetSigma() *  itk::Math::sqrt2;
   }
 
   /** The sigma of the laplacian where the extrema occoured */

--- a/Utilities/itkMultiScaleLaplacianBlobDetectorImageFilter.hxx
+++ b/Utilities/itkMultiScaleLaplacianBlobDetectorImageFilter.hxx
@@ -107,7 +107,7 @@ void MultiScaleLaplacianBlobDetectorImageFilter<TInputImage>
     // simga' = k^i * initial_sigma
     // t = sigma^2
     const double sigma = initial_sigma * std::pow( k, double( numberOfScales - i - 1 ) );
-    //    const double t = vnl_math_sqr( initial_sigma * std::pow( k, double( numberOfScales - i - 1 ) ) );
+    //    const double t = itk::Math::sqr ( initial_sigma * std::pow( k, double( numberOfScales - i - 1 ) ) );
 
     itkDebugMacro( << "i: " << i << " sigma: " << sigma << " k: " << k );
 

--- a/Utilities/itkN3MRIBiasFieldCorrectionImageFilter.hxx
+++ b/Utilities/itkN3MRIBiasFieldCorrectionImageFilter.hxx
@@ -90,7 +90,7 @@ N3BiasFieldScaleCostFunction<TInputImage, TBiasFieldImage, TMaskImage,
         && ( !this->m_ConfidenceImage ||
              this->m_ConfidenceImage->GetPixel( ItI.GetIndex() ) > 0.0 ) )
       {
-      value += vnl_math_sqr( ( ItI.Get() / ( parameters[0]
+      value += itk::Math::sqr ( ( ItI.Get() / ( parameters[0]
                                              * ( static_cast<MeasureType>( ItB.Get() ) - 1.0 ) + 1.0 ) ) / mu - 1.0 );
       }
     }
@@ -146,7 +146,7 @@ N3BiasFieldScaleCostFunction<TInputImage, TBiasFieldImage, TMaskImage,
       MeasureType t = static_cast<MeasureType>( ItI.Get() ) / d;
       MeasureType dt = -t * ( static_cast<MeasureType>( ItB.Get() ) - 1.0 );
       value += ( ( t / mu - 1.0 )
-                 * ( dt / mu - dmu * t / ( vnl_math_sqr( mu ) ) ) );
+                 * ( dt / mu - dmu * t / ( itk::Math::sqr ( mu ) ) ) );
       }
     }
   derivative.SetSize( 1 );
@@ -218,7 +218,7 @@ N3MRIBiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
         && ( !this->GetConfidenceImage() ||
              this->GetConfidenceImage()->GetPixel( It.GetIndex() ) > 0.0 ) )
       {
-      if( vnl_math_isnan( It.Get() ) || vnl_math_isinf( It.Get() )
+      if( std::isnan( It.Get() ) || std::isinf( It.Get() )
           || It.Get() < 0.0 )
         {
         It.Set( 0.0 );
@@ -363,7 +363,7 @@ N3MRIBiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
 
       float cidx = ( static_cast<RealType>( pixel ) - binMinimum )
         / histogramSlope;
-      unsigned int idx = vnl_math_floor( cidx );
+      unsigned int idx = itk::Math::floor ( cidx );
       RealType     offset = cidx - static_cast<RealType>( idx );
 
       if( offset == 0.0 )
@@ -409,9 +409,9 @@ N3MRIBiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
    * Create the Gaussian filter.
    */
   RealType scaledFWHM = this->m_BiasFieldFullWidthAtHalfMaximum / histogramSlope;
-  RealType expFactor = 4.0 * std::log( 2.0 ) / vnl_math_sqr( scaledFWHM );
+  RealType expFactor = 4.0 * std::log( 2.0 ) / itk::Math::sqr ( scaledFWHM );
   RealType scaleFactor = 2.0 * std::sqrt( std::log( 2.0 )
-                                         / vnl_math::pi ) / scaledFWHM;
+                                         / itk::Math::pi ) / scaledFWHM;
 
   vnl_vector<std::complex<RealType> > F( paddedHistogramSize,
                                         std::complex<RealType>( 0.0, 0.0 ) );
@@ -421,13 +421,13 @@ N3MRIBiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
   for( unsigned int n = 1; n <= halfSize; n++ )
     {
     F[n] = F[paddedHistogramSize - n] = std::complex<RealType>(
-          scaleFactor * std::exp( -vnl_math_sqr( static_cast<RealType>( n ) )
+          scaleFactor * std::exp( -itk::Math::sqr ( static_cast<RealType>( n ) )
                                  * expFactor ), 0.0 );
     }
   if( paddedHistogramSize % 2 == 0 )
     {
     F[halfSize] = std::complex<RealType>( scaleFactor * std::exp( 0.25
-                                                                * -vnl_math_sqr( static_cast<RealType>(
+                                                                * -itk::Math::sqr ( static_cast<RealType>(
                                                                                    paddedHistogramSize ) )
                                                                 * expFactor ), 0.0 );
     }
@@ -456,7 +456,7 @@ N3MRIBiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
   fft.bwd_transform( U );
   for( unsigned int n = 0; n < paddedHistogramSize; n++ )
     {
-    U[n] = std::complex<RealType>( vnl_math_max(
+    U[n] = std::complex<RealType>( std::max(
                                     U[n].real(), static_cast<RealType>( 0.0 ) ), 0.0 );
     }
 
@@ -489,7 +489,7 @@ N3MRIBiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
   for( unsigned int n = 0; n < paddedHistogramSize; n++ )
     {
     E[n] = numerator[n].real() / denominator[n].real();
-    if( vnl_math_isinf( E[n] ) || vnl_math_isnan( E[n] ) )
+    if( std::isinf( E[n] ) || std::isnan( E[n] ) )
       {
       E[n] = 0.0;
       }
@@ -516,7 +516,7 @@ N3MRIBiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
              this->GetConfidenceImage()->GetPixel( ItU.GetIndex() ) > 0.0 ) )
       {
       float        cidx = ( ItU.Get() - binMinimum ) / histogramSlope;
-      unsigned int idx = vnl_math_floor( cidx );
+      unsigned int idx = itk::Math::floor ( cidx );
 
       RealType correctedPixel = 0;
       if( idx < E.size() - 1 )
@@ -663,7 +663,7 @@ N3MRIBiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
 
       if( N > 1.0 )
         {
-        sigma = sigma + vnl_math_sqr( pixel - mu ) * ( N - 1.0 ) / N;
+        sigma = sigma + itk::Math::sqr ( pixel - mu ) * ( N - 1.0 ) / N;
         }
       mu = mu * ( 1.0 - 1.0 / N ) + pixel / N;
       }

--- a/Utilities/itkNonLocalPatchBasedImageFilter.hxx
+++ b/Utilities/itkNonLocalPatchBasedImageFilter.hxx
@@ -143,12 +143,12 @@ NonLocalPatchBasedImageFilter<TInputImage, TOutputImage>
     if( std::isfinite( *it ) )
       {
       sum += *it;
-      sumOfSquares += vnl_math_sqr( *it );
+      sumOfSquares += itk::Math::sqr ( *it );
       count += 1.0;
       }
     }
   mean = sum / count;
-  standardDeviation = std::sqrt( ( sumOfSquares - count * vnl_math_sqr( mean ) ) / ( count - 1.0 ) );
+  standardDeviation = std::sqrt( ( sumOfSquares - count * itk::Math::sqr ( mean ) ) / ( count - 1.0 ) );
 }
 
 template <class TInputImage, class TOutputImage>
@@ -183,10 +183,10 @@ NonLocalPatchBasedImageFilter<TInputImage, TOutputImage>
         RealType y = static_cast<RealType>( patchVectorY[count] );
 
         sumX += x;
-        sumOfSquaresX += vnl_math_sqr( x );
+        sumOfSquaresX += itk::Math::sqr ( x );
         sumXY += ( x * y );
 
-        sumOfSquaredDifferencesXY += vnl_math_sqr( y - x );
+        sumOfSquaredDifferencesXY += itk::Math::sqr ( y - x );
         N += 1.0;
         }
       ++count;
@@ -203,10 +203,10 @@ NonLocalPatchBasedImageFilter<TInputImage, TOutputImage>
 
   if( this->m_SimilarityMetric == PEARSON_CORRELATION )
     {
-    RealType varianceX = sumOfSquaresX - vnl_math_sqr( sumX ) / N;
+    RealType varianceX = sumOfSquaresX - itk::Math::sqr ( sumX ) / N;
     varianceX = std::max( varianceX, static_cast<RealType>( 1.0e-6 ) );
 
-    RealType measure = vnl_math_sqr( sumXY ) / varianceX;
+    RealType measure = itk::Math::sqr ( sumXY ) / varianceX;
     if( sumXY > 0 )
       {
       return -measure;

--- a/Utilities/itkNonLocalSuperresolutionImageFilter.hxx
+++ b/Utilities/itkNonLocalSuperresolutionImageFilter.hxx
@@ -315,7 +315,7 @@ NonLocalSuperresolutionImageFilter<TInputImage, TOutputImage>
         It.GetCenterPixel() - highResolutionInputImage->GetPixel( searchIndex );
 
       if( std::fabs( intensityDifference ) > 3.0 * this->m_IntensityDifferenceSigma *
-        vnl_math_sqr( this->m_ScaleLevels[this->m_CurrentIteration] ) )
+        itk::Math::sqr ( this->m_ScaleLevels[this->m_CurrentIteration] ) )
         {
         continue;
         }
@@ -323,10 +323,10 @@ NonLocalSuperresolutionImageFilter<TInputImage, TOutputImage>
       RealType patchSimilarity = this->ComputeNeighborhoodPatchSimilarity(
         highResolutionInputImageList, searchIndex, highResolutionPatch, true );
 
-      RealType intensityWeight = vnl_math_sqr( intensityDifference /
+      RealType intensityWeight = itk::Math::sqr ( intensityDifference /
         ( this->m_IntensityDifferenceSigma * this->m_ScaleLevels[this->m_CurrentIteration] ) );
 
-      RealType patchWeight = vnl_math_sqr( patchSimilarity /
+      RealType patchWeight = itk::Math::sqr ( patchSimilarity /
         ( this->m_PatchSimilaritySigma * this->m_ScaleLevels[this->m_CurrentIteration] ) );
 
       RealType weight = std::exp( -( intensityWeight + patchWeight ) );

--- a/Utilities/itkSurfaceCurvatureBase.hxx
+++ b/Utilities/itkSurfaceCurvatureBase.hxx
@@ -22,7 +22,7 @@
 // #include <vnl/algo/vnl_rpoly_roots.h>
 #include <vnl/vnl_vector.h>
 #include <vnl/vnl_vector_fixed.h>
-#include <vnl/vnl_math.h>
+#include <itkMath.h>
 
 #include "itkSurfaceCurvatureBase.h"
 

--- a/Utilities/itkSurfaceImageCurvature.hxx
+++ b/Utilities/itkSurfaceImageCurvature.hxx
@@ -634,12 +634,12 @@ void  SurfaceImageCurvature<TSurface>
     D(j, 0) = 1.0;
     RealType dfuv_u = 0;
     RealType dfuv_v = 0;
-    if ( ( vnl_math_abs(u1) > 0 ) && ( vnl_math_abs(u2) < 1.e-6 ) )
-      dfuv_u = vnl_math_abs( f_uv - 1.0 ) / vnl_math_abs(u1) * 100.0;
-    if ( ( vnl_math_abs(u2) > 0 ) && ( vnl_math_abs(u1) < 1.e-6 ) )
-      dfuv_v = vnl_math_abs( f_uv - 1.0 ) / vnl_math_abs(u2) * 100.0;
+    if ( ( itk::Math::abs (u1) > 0 ) && ( itk::Math::abs (u2) < 1.e-6 ) )
+      dfuv_u = itk::Math::abs ( f_uv - 1.0 ) / itk::Math::abs (u1) * 100.0;
+    if ( ( itk::Math::abs (u2) > 0 ) && ( itk::Math::abs (u1) < 1.e-6 ) )
+      dfuv_v = itk::Math::abs ( f_uv - 1.0 ) / itk::Math::abs (u2) * 100.0;
     // this->m_Area += sqrt( 1.0 + dfuv_u*dfuv_u + dfuv_v*dfuv_v );
-    this->m_Area += vnl_math_abs( f_uv - 1.0 );
+    this->m_Area += itk::Math::abs ( f_uv - 1.0 );
     }
   this->m_Area *= areaelt;
   vnl_svd<double>    svd(D);
@@ -1145,7 +1145,7 @@ void  SurfaceImageCurvature<TSurface>
 //        fval = 0;
 //        }
       kpix = this->m_kSign * fval; // sulci
-      if( vnl_math_isnan(kpix)  || vnl_math_isinf(kpix) )
+      if( std::isnan(kpix)  || std::isinf(kpix) )
         {
         this->m_Kappa1 = 0.0;
         this->m_Kappa2 = 0.0;

--- a/Utilities/itkVarianceImageFilter.hxx
+++ b/Utilities/itkVarianceImageFilter.hxx
@@ -84,12 +84,12 @@ VarianceImageFilter< TInputImage, TOutputImage >
       for ( i = 0; i < neighborhoodSize; ++i )
         {
         sum += static_cast< InputRealType >( bit.GetPixel(i) );
-        sumOfSquares += vnl_math_sqr( static_cast< InputRealType >( bit.GetPixel(i) ) );
+        sumOfSquares += itk::Math::sqr ( static_cast< InputRealType >( bit.GetPixel(i) ) );
         }
 
       // get the variance value
       const double num = static_cast< double >( neighborhoodSize );
-      OutputPixelType var = ( sumOfSquares - ( vnl_math_sqr( sum ) / num ) ) / ( num - 1.0 );
+      OutputPixelType var = ( sumOfSquares - ( itk::Math::sqr ( sum ) / num ) ) / ( num - 1.0 );
 
       it.Set( var );
 

--- a/Utilities/itkVectorGaussianInterpolateImageFunction.h
+++ b/Utilities/itkVectorGaussianInterpolateImageFunction.h
@@ -145,8 +145,8 @@ public:
     //      std::cout << " index " << index << " VD " << VDim << std::endl;
     for( size_t d = 0; d < VDim; d++ )
       {
-      if( index[d] <= 0 || index[d] >= this->m_ImageSize[d] - 1  || vnl_math_isnan(index[d]) ||
-          vnl_math_isinf(index[d]) )
+      if( index[d] <= 0 || index[d] >= this->m_ImageSize[d] - 1  || std::isnan(index[d]) ||
+          std::isinf(index[d]) )
         {
         return Vout;
         }
@@ -217,7 +217,7 @@ public:
           grad[q] /= -1.4142135623730951 * this->sigma[q];
           }
         }
-      if( vnl_math_isnan(rc) )
+      if( std::isnan(rc) )
         {
         rc = 0;
         }

--- a/Utilities/itkWarpImageMultiTransformFilter.hxx
+++ b/Utilities/itkWarpImageMultiTransformFilter.hxx
@@ -270,7 +270,7 @@ WarpImageMultiTransformFilter<TInputImage, TOutputImage, TDisplacementField, TTr
         InputImagePointer image = const_cast<InputImageType *> (this->GetInput());
         for ( unsigned int d = 0; d < ImageDimension; d++ )
         {
-            double scaling = vnl_math_min( 1.0 / scale * minimumSpacing / inputSpacing[d],
+            double scaling = std::min( 1.0 / scale * minimumSpacing / inputSpacing[d],
                     static_cast<double>( inputSize[d] ) / 32.0 );
             outputSpacing[d] = inputSpacing[d] * scaling;
             outputSize[d] = static_cast<unsigned long>( inputSpacing[d] *

--- a/Utilities/itkWarpImageWAffineFilter.hxx
+++ b/Utilities/itkWarpImageWAffineFilter.hxx
@@ -317,7 +317,7 @@ WarpImageWAffineFilter<TInputImage, TOutputImage, TDisplacementField, TTransform
     InputImagePointer image = const_cast<InputImageType *>(this->GetInput() );
     for( unsigned int d = 0; d < ImageDimension; d++ )
       {
-      double scaling = vnl_math_min( 1.0 / scale * minimumSpacing / inputSpacing[d],
+      double scaling = std::min( 1.0 / scale * minimumSpacing / inputSpacing[d],
                                      static_cast<double>( inputSize[d] ) / 32.0 );
       outputSpacing[d] = inputSpacing[d] * scaling;
       outputSize[d] = static_cast<unsigned long>( inputSpacing[d]

--- a/Utilities/itkWarpTensorImageMultiTransformFilter.hxx
+++ b/Utilities/itkWarpTensorImageMultiTransformFilter.hxx
@@ -252,7 +252,7 @@ WarpTensorImageMultiTransformFilter<TInputImage, TOutputImage, TDisplacementFiel
         InputImagePointer image = const_cast<InputImageType *> (this->GetInput());
         for ( unsigned int d = 0; d < ImageDimension; d++ )
         {
-            double scaling = vnl_math_min( 1.0 / scale * minimumSpacing / inputSpacing[d],
+            double scaling = std::min( 1.0 / scale * minimumSpacing / inputSpacing[d],
                     static_cast<double>( inputSize[d] ) / 32.0 );
             outputSpacing[d] = inputSpacing[d] * scaling;
             outputSize[d] = static_cast<unsigned long>( inputSpacing[d] *


### PR DESCRIPTION
Prefer C++ over aliased names vnl_math_[min|max] -> std::[min|max]
Prefer vnl_math::abs over deprecated alias vnl_math_abs

In all compilers currently supported by VXL, vnl_math_[min|max]
could be replaced with std::[min|max] without loss of
functionality.  This also circumvents part of the backwards
compatibility requirements as vnl_math_ has been recently
replaced with a namespace of vnl_math::.

Since Wed Nov 14 07:42:48 2012:
The vnl_math_* functions use #define aliases to their
vnl_math::* counterparts in the "real" vnl_math:: namespace.

The new syntax should be backwards compatible to
VXL versions as old as 2012.

Prefer to use itk::Math:: over vnl_math:: namespace