### PR TITLE
WIP: Change tensor / vector treatment in antsApplyTransforms

### DIFF
--- a/Examples/RebaseTensorImage.cxx
+++ b/Examples/RebaseTensorImage.cxx
@@ -123,7 +123,8 @@ private:
     std::cout << " -> " << convert << " space";
     ImageType::Pointer target;
     ReadImage<ImageType>( target, convert );
-    direction =  img_mov->GetDirection().GetTranspose() * target->GetDirection().GetVnlMatrix();
+    // converting from LOCAL to a reference LOCAL space
+    direction = target->GetDirection().GetTranspose() * img_mov->GetDirection().GetVnlMatrix();
     }
 
   // direction = direction.transpose(); // to accomodate for how

--- a/Examples/antsApplyTransforms.cxx
+++ b/Examples/antsApplyTransforms.cxx
@@ -36,8 +36,10 @@ CorrectImageTensorDirection( TensorImageType * movingTensorImage, ImageType * re
 {
   typedef typename TensorImageType::DirectionType    DirectionType;
   typedef typename DirectionType::InternalMatrixType MatrixType;
-  MatrixType direction =
-    movingTensorImage->GetDirection().GetTranspose() * referenceImage->GetDirection().GetVnlMatrix();
+
+  // Assume tensors start in moving voxel space, we want to put them in fixed voxel space
+
+  MatrixType direction = referenceImage->GetDirection().GetTranspose() * movingTensorImage->GetDirection().GetVnlMatrix();
 
   if( !direction.is_identity( 0.00001 ) )
     {
@@ -67,8 +69,9 @@ CorrectImageVectorDirection( DisplacementFieldType * movingVectorImage, ImageTyp
 {
   typedef typename DisplacementFieldType::DirectionType DirectionType;
 
+  // Assume vectors are initially described in the voxel space of the moving image, like tensors
   typename DirectionType::InternalMatrixType direction =
-    movingVectorImage->GetDirection().GetTranspose() * referenceImage->GetDirection().GetVnlMatrix();
+    referenceImage->GetDirection().GetTranspose() * movingVectorImage->GetDirection().GetVnlMatrix();
 
   typedef typename DisplacementFieldType::PixelType VectorType;
 


### PR DESCRIPTION
Now assume that tensor is based in the moving voxel space, and reorient
to the fixed voxel space before resampling. Same with vectors.

This fixes a bug where the tensors and vectors were transformed in the opposite direction.
RebaseTensorImage had the same error but only when the REFERENCE option was used.

Relates to issue: https://github.com/ANTsX/ANTs/issues/642

Test data and scripts: https://github.com/cookpa/antsDTOrientationTests