### PR TITLE
COMP: remove deprecated dynamic exception specifiers

### DIFF
--- a/ImageRegistration/itkJensenHavrdaCharvatTsallisLabeledPointSetMetric.h
+++ b/ImageRegistration/itkJensenHavrdaCharvatTsallisLabeledPointSetMetric.h
@@ -92,8 +92,7 @@ public:
 
   /** Initialize the Metric by making sure that all the components
    *  are present and plugged together correctly     */
-  virtual void Initialize( void )
-  throw ( ExceptionObject );
+  virtual void Initialize( void );
 
   /** Get the number of values */
   unsigned int GetNumberOfValues() const;

--- a/ImageRegistration/itkJensenHavrdaCharvatTsallisPointSetMetric.h
+++ b/ImageRegistration/itkJensenHavrdaCharvatTsallisPointSetMetric.h
@@ -92,8 +92,7 @@ public:
 
   /** Initialize the Metric by making sure that all the components
    *  are present and plugged together correctly     */
-  virtual void Initialize( void )
-  throw ( ExceptionObject );
+  virtual void Initialize( void );
 
   /** Get the number of values */
   unsigned int GetNumberOfValues() const;

--- a/ImageRegistration/itkVectorParameterizedNeighborhoodOperatorImageFilter.h
+++ b/ImageRegistration/itkVectorParameterizedNeighborhoodOperatorImageFilter.h
@@ -125,8 +125,7 @@ public:
    * execution model.
    *
    * \sa ProcessObject::GenerateInputRequestedRegion() */
-  void GenerateInputRequestedRegion()
-    throw (InvalidRequestedRegionError) override;
+  void GenerateInputRequestedRegion() override;
 
   void SetParameterImage( ParameterImagePointer I)
   {

--- a/ImageRegistration/itkVectorParameterizedNeighborhoodOperatorImageFilter.hxx
+++ b/ImageRegistration/itkVectorParameterizedNeighborhoodOperatorImageFilter.hxx
@@ -27,7 +27,6 @@ template <typename TInputImage, typename TOutputImage, typename TParamImage>
 void
 VectorParameterizedNeighborhoodOperatorImageFilter<TInputImage, TOutputImage, TParamImage>
 ::GenerateInputRequestedRegion()
-throw (InvalidRequestedRegionError)
 {
   // call the superclass' implementation of this method. this should
   // copy the output requested region to the input requested region

--- a/Temporary/itkMeanSquaresPointSetToPointSetIntensityMetricv4.h
+++ b/Temporary/itkMeanSquaresPointSetToPointSetIntensityMetricv4.h
@@ -133,7 +133,7 @@ public:
    /**
     * Initialize the metric by estimating the intensity and distance sigmas
     */
-  void Initialize( void ) throw ( ExceptionObject ) override;
+  void Initialize( void ) override;
 
   /**
    * Prepare point sets for use.

--- a/Temporary/itkMeanSquaresPointSetToPointSetIntensityMetricv4.hxx
+++ b/Temporary/itkMeanSquaresPointSetToPointSetIntensityMetricv4.hxx
@@ -47,7 +47,7 @@ MeanSquaresPointSetToPointSetIntensityMetricv4<TFixedPointSet, TMovingPointSet, 
 template<typename TFixedPointSet, typename TMovingPointSet, typename TInternalComputationValueType>
 void
 MeanSquaresPointSetToPointSetIntensityMetricv4<TFixedPointSet, TMovingPointSet, TInternalComputationValueType>
-::Initialize( void ) throw ( ExceptionObject )
+::Initialize( void )
 {
   Superclass::Initialize();
 

--- a/Utilities/itkDeformationFieldGradientTensorImageFilter.h
+++ b/Utilities/itkDeformationFieldGradientTensorImageFilter.h
@@ -89,7 +89,7 @@ public:
    * pipeline execution model.
    *
    * \sa ImageToImageFilter::GenerateInputRequestedRegion() */
-  void GenerateInputRequestedRegion() throw( InvalidRequestedRegionError ) override;
+  void GenerateInputRequestedRegion() override;
 
   itkSetClampMacro( Order, unsigned int, 1, 2 );
   itkGetConstReferenceMacro( Order, unsigned int );

--- a/Utilities/itkDeformationFieldGradientTensorImageFilter.hxx
+++ b/Utilities/itkDeformationFieldGradientTensorImageFilter.hxx
@@ -41,7 +41,7 @@ DeformationFieldGradientTensorImageFilter<TInputImage, TRealType, TOutputImage>
 template <typename TInputImage, typename TRealType, typename TOutputImage>
 void
 DeformationFieldGradientTensorImageFilter<TInputImage, TRealType, TOutputImage>
-::GenerateInputRequestedRegion() throw( InvalidRequestedRegionError )
+::GenerateInputRequestedRegion()
 {
   // call the superclass' implementation of this method
   Superclass::GenerateInputRequestedRegion();

--- a/Utilities/itkGeometricJacobianDeterminantImageFilter.h
+++ b/Utilities/itkGeometricJacobianDeterminantImageFilter.h
@@ -84,7 +84,7 @@ public:
    * pipeline execution model.
    *
    * \sa ImageToImageFilter::GenerateInputRequestedRegion() */
-  void GenerateInputRequestedRegion() throw( InvalidRequestedRegionError ) override;
+  void GenerateInputRequestedRegion() override;
 
   /** Get access to the input image casted as real pixel values */
   itkGetConstObjectMacro( RealValuedInputImage, RealVectorImageType );

--- a/Utilities/itkGeometricJacobianDeterminantImageFilter.hxx
+++ b/Utilities/itkGeometricJacobianDeterminantImageFilter.hxx
@@ -39,7 +39,7 @@ GeometricJacobianDeterminantImageFilter<TInputImage, TRealType, TOutputImage>
 template <typename TInputImage, typename TRealType, typename TOutputImage>
 void
 GeometricJacobianDeterminantImageFilter<TInputImage, TRealType, TOutputImage>
-::GenerateInputRequestedRegion() throw( InvalidRequestedRegionError )
+::GenerateInputRequestedRegion()
 {
   // call the superclass' implementation of this method
   Superclass::GenerateInputRequestedRegion();

--- a/Utilities/itkOptimalSharpeningImageFilter.h
+++ b/Utilities/itkOptimalSharpeningImageFilter.h
@@ -83,8 +83,7 @@ public:
    * execution model.
    *
    * \sa ImageToImageFilter::GenerateInputRequestedRegion()  */
-  virtual void GenerateInputRequestedRegion()
-  throw (InvalidRequestedRegionError);
+  virtual void GenerateInputRequestedRegion();
 
   void SetSValue(float s)
   {

--- a/Utilities/itkOptimalSharpeningImageFilter.hxx
+++ b/Utilities/itkOptimalSharpeningImageFilter.hxx
@@ -38,7 +38,6 @@ template <typename TInputImage, typename TOutputImage>
 void
 OptimalSharpeningImageFilter<TInputImage, TOutputImage>
 ::GenerateInputRequestedRegion()
-throw (InvalidRequestedRegionError)
 {
   // call the superclass' implementation of this method. this should
   // copy the output requested region to the input requested region


### PR DESCRIPTION
See https://discourse.itk.org/t/warning-dynamic-exception-specifications-are-deprecated-in-c-11/470

Allows to compile against ITK5 w/ `-std=c++17`.