### PR TITLE
Fix some bracket globbing cases

### DIFF
--- a/Scripts/ants.sh
+++ b/Scripts/ants.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -f
 
 NUMPARAMS=$#
 

--- a/Scripts/antsAtroposN4.sh
+++ b/Scripts/antsAtroposN4.sh
@@ -2,6 +2,8 @@
 
 VERSION="0.0"
 
+set -f
+
 if [[ ! -s ${ANTSPATH}/N4BiasFieldCorrection ]]; then
   echo we cant find the N4 program -- does not seem to exist.  please \(re\)define \$ANTSPATH in your environment.
   exit

--- a/Scripts/antsIntroduction.sh
+++ b/Scripts/antsIntroduction.sh
@@ -5,6 +5,8 @@ VERSION="0.0.8 dev"
 # trap keyboard interrupt (control-c)
 trap control_c SIGINT
 
+set -f
+
 function setPath {
     cat <<SETPATH
 
@@ -728,6 +730,7 @@ ${ANTSPATH}/ImageMath $DIM ${OUTPUTNAME}dicestats.txt DiceAndMinDistSum  ${OUTPU
 fi
 
 # save output in starting dir - remove inputs, then remove tempdir
+set +f
 rm `basename ${FIXED}`
 rm `basename ${MOVING}`
 cp * ../

--- a/Scripts/antsLongitudinalCorticalThickness.sh
+++ b/Scripts/antsLongitudinalCorticalThickness.sh
@@ -210,6 +210,14 @@ function logCmd() {
   return $cmdExit
 }
 
+if [[ `echo ?` != '?' ]];
+  then
+    echo "*** The following file(s) were found in the current directory ($PWD): `echo ?`"
+    echo "The presence of files named with a single character may cause failures later."
+    echo "Aborting for safety."
+    exit 1;
+  fi
+
 ################################################################################
 #
 # Main routine

--- a/Scripts/antsLongitudinalJointLabelFusion.sh
+++ b/Scripts/antsLongitudinalJointLabelFusion.sh
@@ -65,6 +65,13 @@ if [[ $fle_error = 1 ]];
     exit 1
   fi
 
+if [[ `echo ?` != '?' ]];
+  then
+    echo "*** The following file(s) were found in the current directory ($PWD): `echo ?`"
+    echo "The presence of files named with a single character may cause failures later."
+    echo "Aborting for safety."
+    exit 1;
+  fi
 
 #assuming .nii.gz as default file type. This is the case for ANTS 1.7 and up
 

--- a/Scripts/antsMultivariateTemplateConstruction.sh
+++ b/Scripts/antsMultivariateTemplateConstruction.sh
@@ -64,6 +64,14 @@ if [[ $fle_error = 1 ]];
     exit 1
 fi
 
+if [[ `echo ?` != '?' ]];
+  then
+    echo "*** The following file(s) were found in the current directory ($PWD): `echo ?`"
+    echo "The presence of files named with a single character may cause failures later."
+    echo "Aborting for safety."
+    exit 1;
+  fi
+
 function Usage {
     cat <<USAGE
 

--- a/Scripts/antsMultivariateTemplateConstruction2.sh
+++ b/Scripts/antsMultivariateTemplateConstruction2.sh
@@ -66,6 +66,14 @@ if [[ $fle_error = 1 ]];
     exit 1
   fi
 
+if [[ `echo ?` != '?' ]];
+  then
+    echo "*** The following file(s) were found in the current directory ($PWD): `echo ?`"
+    echo "The presence of files named with a single character may cause failures later."
+    echo "Aborting for safety."
+    exit 1;
+  fi
+
 function Usage {
     cat <<USAGE
 

--- a/Scripts/antsRegistrationSpaceTime.sh
+++ b/Scripts/antsRegistrationSpaceTime.sh
@@ -5,6 +5,8 @@ VERSION="0.0.0 test"
 # trap keyboard interrupt (control-c)
 trap control_c SIGINT
 
+set -f
+
 function setPath {
     cat <<SETPATH
 

--- a/Scripts/antsRegistrationSyN.sh
+++ b/Scripts/antsRegistrationSyN.sh
@@ -5,6 +5,8 @@ VERSION="0.0.0 test"
 # trap keyboard interrupt (control-c)
 trap control_c SIGINT
 
+set -f
+
 function setPath {
     cat <<SETPATH
 

--- a/Scripts/antsRegistrationSyNQuick.sh
+++ b/Scripts/antsRegistrationSyNQuick.sh
@@ -5,6 +5,8 @@ VERSION="0.0.0 test"
 # trap keyboard interrupt (control-c)
 trap control_c SIGINT
 
+set -f
+
 function setPath {
     cat <<SETPATH
 

--- a/Scripts/antsaffine.sh
+++ b/Scripts/antsaffine.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -f
 if [ ${#ANTSPATH} -le 3 ] ; then
   echo we guess at your ants path
   export ANTSPATH=${ANTSPATH:="$HOME/bin/ants/"} # EDIT THIS

--- a/Scripts/asymmetry.sh
+++ b/Scripts/asymmetry.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -f
 usage=" $0 -d 3 -f symmetric_template.nii.gz -m moving.nii.gz -o output_prefix "
 :<<supercalifragilisticexpialidocious
 


### PR DESCRIPTION
Tentative fix related to #712
File globbing can badly interact with ANTs bracket syntax in some cases. Here i suggest:
Some scripts do not need file-globbing; this is deactivated with "set -f".
Other scripts relies on file-globbing, so instead, potential error-cases are detected with preventive abort.

This PR only affects some scripts, as i didn't exhaustively check all of them.