### PR TITLE
Fix glob problems by spacing square brackets in ANTs command lines

### DIFF
--- a/Examples/ImageMath_Templates.hxx
+++ b/Examples/ImageMath_Templates.hxx
@@ -5963,7 +5963,7 @@ int TensorFunctions(int argc, char *argv[])
     {
     // Might be a file or a number for whichvec
     fn2 = std::string(argv[argct]);
-    try 
+    try
       {
       whichvec = std::stoi(fn2.c_str() );
       }
@@ -5973,7 +5973,7 @@ int TensorFunctions(int argc, char *argv[])
       }
     argct++;
     }
-  
+
   if ( argc > argct )
     {
     // Throws exception if arg is not a valid float
@@ -10931,7 +10931,8 @@ int ConvertImageSetToMatrix(unsigned int argc, char *argv[])
   int argct = 2;
   if( argc < 5 )
     {
-    // std::cout << " need more args -- see usage   " << std::endl;  throw std::exception();
+    // std::cout << " need more args -- see usage   " << std::endl;
+    throw std::exception();
     }
   const std::string outname = std::string(argv[argct]);
   std::string       ext = itksys::SystemTools::GetFilenameExtension( outname );
@@ -10977,11 +10978,15 @@ int ConvertImageSetToMatrix(unsigned int argc, char *argv[])
   unsigned long xx1 = 0, yy1 = 0;
   if( rowcoloption == 0 )
     {
-    // std::cout << " row option " << std::endl;  xx1 = voxct;  yy1 = numberofimages;
+    // std::cout << " row option " << std::endl;
+    xx1 = voxct;
+    yy1 = numberofimages;
     }
   if( rowcoloption == 1 )
     {
-    // std::cout << " col option " << std::endl;  yy1 = voxct;  xx1 = numberofimages;
+    // std::cout << " col option " << std::endl;
+    yy1 = voxct;
+    xx1 = numberofimages;
     }
   unsigned long xsize = xx1;
   unsigned long ysize = yy1;
@@ -11036,7 +11041,14 @@ int ConvertImageSetToMatrix(unsigned int argc, char *argv[])
     WriterType::Pointer writer = WriterType::New();
     writer->SetFileName( outname );
     writer->SetInput( &matrix );
-    writer->SetColumnHeaders( ColumnHeaders );
+    if( rowcoloption == 0 )
+      {
+      writer->SetRowHeaders( ColumnHeaders );
+      }
+    if( rowcoloption == 1 )
+      {
+      writer->SetColumnHeaders( ColumnHeaders );
+      }
     try
       {
       writer->Write();

--- a/Examples/antsApplyTransforms.cxx
+++ b/Examples/antsApplyTransforms.cxx
@@ -257,14 +257,21 @@ int antsApplyTransforms( itk::ants::CommandLineParser::Pointer & parser, unsigne
     if( outputOption->GetFunction( 0 )->GetNumberOfParameters() > 1 &&
         parser->Convert<unsigned int>( outputOption->GetFunction( 0 )->GetParameter( 1 ) ) == 0 )
       {
-      if( verbose )
-        {
-        std::cerr << "An input image is required." << std::endl;
+      // Here we have no input image, valid usage is
+      // -o [warp.nii.gz, 1] or -o Linear[affine.mat, 0]  
+      // Exit failure with -o [outputImage.nii.gz,0] but no input to warp
+      std::string outputOptionName = outputOption->GetFunction( 0 )->GetName();
+      ConvertToLowerCase( outputOptionName );
+      if( std::strcmp( outputOptionName.c_str(), "linear" ) )
+        {      
+        if( verbose )
+          {
+          std::cerr << "An input image is required." << std::endl;
+          }
+        return EXIT_FAILURE;
         }
-      return EXIT_FAILURE;
       }
     }
-
   /**
    * Reference image option
    */

--- a/Scripts/ANTSpexec.sh
+++ b/Scripts/ANTSpexec.sh
@@ -7,7 +7,7 @@ function Usage {
 
 Usage:
 
-`basename $0` [-h] [-r] [-j nb_jobs] command arg_list
+`basename $0` [-h ] [-r ] [-j nb_jobs ] command arg_list
 
 Optional arguments:
 
@@ -40,7 +40,7 @@ Mac (Darwin) and Linux (CentOS 5).
 
 Usage:
 
-`basename $0` [-h] [-r] [-j nb_jobs] command arg_list
+`basename $0` [-h ] [-r ] [-j nb_jobs ] command arg_list
 
 Optional arguments:
 

--- a/Scripts/ANTSpexec.sh
+++ b/Scripts/ANTSpexec.sh
@@ -85,7 +85,7 @@ function regeneratequeuelinux {
     NUM=0
     for PID in $OLDREQUEUE
     do
-        if [ -d /proc/$PID  ] ; then
+        if [ -d /proc/$PID ] ; then
             QUEUE="$QUEUE $PID"
             NUM=$(($NUM+1))
         fi

--- a/Scripts/ants.sh
+++ b/Scripts/ants.sh
@@ -3,16 +3,16 @@
 NUMPARAMS=$#
 
 MAXITERATIONS=30x90x20
-if [ ${#ANTSPATH} -le 3 ] ; then
-  echo we guess at your ants path
-  export ANTSPATH=${ANTSPATH:="/ipldev/scratch/aghayoor/ANTS/release/bin"} # EDIT THIS
+if [[ -z ${ANTSPATH} ]] ; then
+  echo "Environment variable ANTSPATH must be defined"
+  exit 1
 fi
-if [ ! -s ${ANTSPATH}/ANTS ] ; then
-  echo we cant find the ANTS program -- does not seem to exist.  please \(re\)define \$ANTSPATH in your environment.
-  exit
+if [[ ! -f "${ANTSPATH}/ANTS" ]] ; then
+  echo "Cannot find the ANTS program. Please \(re\)define \$ANTSPATH in your environment."
+  exit 1
 fi
 
-if [ $NUMPARAMS -lt 3  ]
+if [ $NUMPARAMS -lt 3 ]
 then
 echo " USAGE ::  "
 echo "  sh   ants.sh  ImageDimension  fixed.ext  moving.ext  OPTIONAL-OUTPREFIX   OPTIONAL-max-iterations  OPTIONAL-Labels-In-Fixed-Image-Space-To-Deform-To-Moving-Image     Option-DoANTSQC "
@@ -22,7 +22,7 @@ echo "  J = max iterations at coarsest resolution (here, reduce by power of 2^2)
 echo " K = middle resolution iterations ( here, reduce by power of 2 ) "
 echo " L = fine resolution iterations ( here, full resolution ) -- this level takes much more time per iteration "
 echo " an extra  Ix before JxKxL would add another level "
-echo " Default ierations is  $MAXITERATIONS  -- you can often get away with fewer for many apps "
+echo " Default iterations is $MAXITERATIONS  -- you can often get away with fewer for many apps "
 echo " Other parameters are updates of the defaults used in the A. Klein evaluation paper in Neuroimage, 2009 "
 exit
 fi
@@ -67,36 +67,36 @@ fi
 OUTPUTNAME=` echo $MOVING | cut -d '.' -f 1 `
 
 
-if [ $NUMPARAMS -gt 4  ]
+if [ $NUMPARAMS -gt 4 ]
 then
  MAXITERATIONS=$5
 fi
 
 LABELIMAGE=0
-if [ $NUMPARAMS -gt 5  ]
+if [ $NUMPARAMS -gt 5 ]
 then
  LABELIMAGE=$6
 fi
 
 DoANTSQC=0
-if [ $NUMPARAMS -gt 6  ]
+if [ $NUMPARAMS -gt 6 ]
 then
  DoANTSQC=$7
 fi
 
-if [ $NUMPARAMS -gt 3  ]
+if [ $NUMPARAMS -gt 3 ]
 then
   OUTPUTNAME=${4}
 fi
 
 # Mapping Parameters
-  TRANSFORMATION=SyN[ 0.25]
+  TRANSFORMATION="SyN[ 0.25 ]"
   ITERATLEVEL=(`echo $MAXITERATIONS | tr 'x' ' '`)
   NUMLEVELS=${#ITERATLEVEL[@]}
   echo $NUMLEVELS
-  REGULARIZATION=Gauss[ 3,0]
+  REGULARIZATION="Gauss[ 3,0 ]"
   METRIC="CC[ "
-    METRICPARAMS=1,4]
+    METRICPARAMS="1,4 ]"
 # echo " $METRICPARAMS  &  $METRIC "
 # exit
 
@@ -116,7 +116,7 @@ echo " "
 
 
 if [[ ! -s ${OUTPUTNAME}repaired.nii.gz ]] ; then
-${ANTSPATH}/N4BiasFieldCorrection -d $DIM -i $MOVING -o ${OUTPUTNAME}repaired.nii.gz -s 2 -c [ 50x50x50x50,0.000001 ] -b [ 200]
+${ANTSPATH}/N4BiasFieldCorrection -d $DIM -i $MOVING -o ${OUTPUTNAME}repaired.nii.gz -s 2 -c [ 50x50x50x50,0.000001 ] -b [ 200 ]
 # ${ANTSPATH}/N3BiasFieldCorrection $DIM $MOVING   ${OUTPUTNAME}repaired.nii.gz  4
 fi
 exe=" ${ANTSPATH}/ANTS $DIM -m  ${METRIC}${FIXED},${OUTPUTNAME}repaired.nii.gz,${METRICPARAMS}  -t $TRANSFORMATION  -r $REGULARIZATION -o ${OUTPUTNAME}   -i $MAXITERATIONS   --use-Histogram-Matching  --number-of-affine-iterations 10000x10000x10000x10000x10000 --MI-option 32x16000  "

--- a/Scripts/ants.sh
+++ b/Scripts/ants.sh
@@ -116,7 +116,7 @@ echo " "
 
 
 if [[ ! -s ${OUTPUTNAME}repaired.nii.gz ]] ; then
-${ANTSPATH}/N4BiasFieldCorrection -d $DIM -i $MOVING -o ${OUTPUTNAME}repaired.nii.gz -s 2 -c [ 50x50x50x50,0.000001] -b [ 200]
+${ANTSPATH}/N4BiasFieldCorrection -d $DIM -i $MOVING -o ${OUTPUTNAME}repaired.nii.gz -s 2 -c [ 50x50x50x50,0.000001 ] -b [ 200]
 # ${ANTSPATH}/N3BiasFieldCorrection $DIM $MOVING   ${OUTPUTNAME}repaired.nii.gz  4
 fi
 exe=" ${ANTSPATH}/ANTS $DIM -m  ${METRIC}${FIXED},${OUTPUTNAME}repaired.nii.gz,${METRICPARAMS}  -t $TRANSFORMATION  -r $REGULARIZATION -o ${OUTPUTNAME}   -i $MAXITERATIONS   --use-Histogram-Matching  --number-of-affine-iterations 10000x10000x10000x10000x10000 --MI-option 32x16000  "

--- a/Scripts/antsASLProcessing.sh
+++ b/Scripts/antsASLProcessing.sh
@@ -315,7 +315,7 @@ logCmd ${ANTSPATH}/antsApplyTransforms -d 3 \
     -n MultiLabel \
     -t ${TRANSFORM_PREFIX}TemplateToSubject0Warp.nii.gz \
     -t ${TRANSFORM_PREFIX}TemplateToSubject1GenericAffine.mat \
-    -t [ ${OUTNAME}0GenericAffine.mat,1] \
+    -t [ ${OUTNAME}0GenericAffine.mat,1 ] \
     -t ${OUTNAME}1InverseWarp.nii.gz
 
 logCmd ${ANTSPATH}/antsApplyTransforms -d 3 \
@@ -331,7 +331,7 @@ logCmd ${ANTSPATH}/antsApplyTransforms -d 3 \
   -r ${OUTNAME}AveragePCASL.nii.gz \
   -o ${OUTNAME}SegmentationWarpedToPCASL.nii.gz \
   -n MultiLabel \
-  -t [ ${OUTNAME}0GenericAffine.mat,1] \
+  -t [ ${OUTNAME}0GenericAffine.mat,1 ] \
   -t ${OUTNAME}1InverseWarp.nii.gz \
 
 if ! $KEEP_TMP_FILES

--- a/Scripts/antsAtroposN4.sh
+++ b/Scripts/antsAtroposN4.sh
@@ -51,11 +51,11 @@ Optional arguments:
      -n:  max. Atropos iterations               Maximum number of (inner loop) iterations in Atropos.
      -p:  segmentation priors                   Prior probability images initializing the segmentation.
                                                 Specified using c-style formatting, e.g. -p labelsPriors%02d.nii.gz.
-     -r:  mrf                                   Specifies MRF prior (of the form '[weight,neighborhood]', e.g.
-                                                '[0.1,1x1x1]' which is default).
+     -r:  mrf                                   Specifies MRF prior (of the form '[ weight,neighborhood ]', e.g.
+                                                '[ 0.1,1x1x1 ]' which is default).
      -g:  denoise anatomical images             Denoise anatomical images (default = 0).
      -b:  posterior formulation                 Posterior formulation and whether or not to use mixture model proportions.
-                                                e.g 'Socrates[1]' (default) or 'Aristotle[1]'.  Choose the latter if you
+                                                e.g 'Socrates[ 1 ]' (default) or 'Aristotle[ 1 ]'.  Choose the latter if you
                                                 want use the distance priors (see also the -l option for label propagation
                                                 control).
      -l:  label propagation                     Incorporate a distance prior one the posterior formulation.  Should be
@@ -67,7 +67,7 @@ Optional arguments:
 
                                                 Intuitively, smaller lambda values will increase the spatial capture
                                                 range of the distance prior.  To apply to all label values, simply omit
-                                                specifying the label, i.e. -l [ lambda,boundaryProbability].
+                                                specifying the label, i.e. -l [ lambda,boundaryProbability ].
      -y:  posterior label for N4 weight mask    Which posterior probability image should be used to define the
                                                 N4 weight mask.  Can also specify multiple posteriors in which
                                                 case the chosen posteriors are combined.
@@ -179,15 +179,15 @@ ATROPOS_SEGMENTATION_PRIORS=""
 N4_ATROPOS_NUMBER_OF_ITERATIONS=15
 
 N4=${ANTSPATH}/N4BiasFieldCorrection
-N4_CONVERGENCE="[ 50x50x50x50,0.0000000001]"
+N4_CONVERGENCE="[ 50x50x50x50,0.0000000001 ]"
 N4_SHRINK_FACTOR=2
-N4_BSPLINE_PARAMS="[ 200]"
+N4_BSPLINE_PARAMS="[ 200 ]"
 N4_WEIGHT_MASK_POSTERIOR_LABELS=()
 
 ATROPOS=${ANTSPATH}/Atropos
 ATROPOS_SEGMENTATION_PRIOR_WEIGHT=0.0
 ATROPOS_SEGMENTATION_LIKELIHOOD="Gaussian"
-ATROPOS_SEGMENTATION_POSTERIOR_FORMULATION="Socrates[ 1]"
+ATROPOS_SEGMENTATION_POSTERIOR_FORMULATION="Socrates[ 1 ]"
 ATROPOS_SEGMENTATION_MASK=''
 ATROPOS_SEGMENTATION_NUMBER_OF_ITERATIONS=5
 ATROPOS_SEGMENTATION_NUMBER_OF_CLASSES=3
@@ -277,14 +277,14 @@ fi
 
 if [[ -z "$ATROPOS_SEGMENTATION_MRF" ]];
   then
-    ATROPOS_SEGMENTATION_MRF="[ 0.1,1x1x1]";
+    ATROPOS_SEGMENTATION_MRF="[ 0.1,1x1x1 ]";
     if [[ DIMENSION -eq 2 ]];
       then
-        ATROPOS_SEGMENTATION_MRF="[ 0.1,1x1]"
+        ATROPOS_SEGMENTATION_MRF="[ 0.1,1x1 ]"
       fi
   fi
 
-ATROPOS_SEGMENTATION_CONVERGENCE="[ ${ATROPOS_SEGMENTATION_NUMBER_OF_ITERATIONS},0.0]"
+ATROPOS_SEGMENTATION_CONVERGENCE="[ ${ATROPOS_SEGMENTATION_NUMBER_OF_ITERATIONS},0.0 ]"
 
 ################################################################################
 #
@@ -500,7 +500,7 @@ for (( i = 0; i < ${N4_ATROPOS_NUMBER_OF_ITERATIONS}; i++ ))
 
     if [[ $i -eq 0 ]];
       then
-        exe_segmentation="${exe_segmentation} -p Socrates[ 0]"
+        exe_segmentation="${exe_segmentation} -p Socrates[ 0 ]"
       else
         exe_segmentation="${exe_segmentation} -p ${ATROPOS_SEGMENTATION_POSTERIOR_FORMULATION}"
 

--- a/Scripts/antsAtroposN4.sh
+++ b/Scripts/antsAtroposN4.sh
@@ -59,7 +59,7 @@ Optional arguments:
                                                 want use the distance priors (see also the -l option for label propagation
                                                 control).
      -l:  label propagation                     Incorporate a distance prior one the posterior formulation.  Should be
-                                                of the form 'label[lambda,boundaryProbability]' where label is a value
+                                                of the form 'label[ lambda,boundaryProbability ]' where label is a value
                                                 of 1,2,3,... denoting label ID.  The label probability for anything
                                                 outside the current label
 
@@ -117,12 +117,12 @@ PARAMETERS
 DEBUG_MODE=0
 
 function logCmd() {
-  cmd="$*"
+  cmd="$@"
   echo "BEGIN >>>>>>>>>>>>>>>>>>>>"
   echo $cmd
 
   exec 5>&1
-  logCmdOutput=$( $cmd | tee >(cat - >&5) )
+  logCmdOutput=$( "$@" | tee >(cat - >&5) )
 
   cmdExit=${PIPESTATUS[0]}
 
@@ -311,7 +311,7 @@ FORMAT=${FORMAT%%d*}
 
 REPCHARACTER=''
 TOTAL_LENGTH=0
-if [ ${#FORMAT} -eq 2 ]
+if [[ ${#FORMAT} -eq 2 ]]
   then
     REPCHARACTER=${FORMAT:0:1}
     TOTAL_LENGTH=${FORMAT:1:1}
@@ -483,9 +483,9 @@ for (( i = 0; i < ${N4_ATROPOS_NUMBER_OF_ITERATIONS}; i++ ))
       then
         if [[ $i -eq 0 ]];
           then
-            INITIALIZATION="kmeans[ ${ATROPOS_SEGMENTATION_NUMBER_OF_CLASSES}]"
+            INITIALIZATION="kmeans[ ${ATROPOS_SEGMENTATION_NUMBER_OF_CLASSES} ]"
           else
-            INITIALIZATION="PriorProbabilityImages[ ${ATROPOS_SEGMENTATION_NUMBER_OF_CLASSES},${ATROPOS_SEGMENTATION_POSTERIORS},${ATROPOS_SEGMENTATION_PRIOR_WEIGHT}]"
+            INITIALIZATION="PriorProbabilityImages[ ${ATROPOS_SEGMENTATION_NUMBER_OF_CLASSES},${ATROPOS_SEGMENTATION_POSTERIORS},${ATROPOS_SEGMENTATION_PRIOR_WEIGHT} ]"
           fi
       fi
 
@@ -496,7 +496,7 @@ for (( i = 0; i < ${N4_ATROPOS_NUMBER_OF_ITERATIONS}; i++ ))
       done
 
     exe_segmentation="${ATROPOS} -d ${DIMENSION} -x ${ATROPOS_SEGMENTATION_MASK} -c ${ATROPOS_SEGMENTATION_CONVERGENCE} ${ATROPOS_ANATOMICAL_IMAGES_COMMAND_LINE} ${ATROPOS_LABEL_PROPAGATION_COMMAND_LINE} --verbose 1"
-    exe_segmentation="${exe_segmentation} -i ${INITIALIZATION} -k ${ATROPOS_SEGMENTATION_LIKELIHOOD} -m ${ATROPOS_SEGMENTATION_MRF} -o [ ${ATROPOS_SEGMENTATION},${ATROPOS_SEGMENTATION_POSTERIORS}] -r ${USE_RANDOM_SEEDING}"
+    exe_segmentation="${exe_segmentation} -i ${INITIALIZATION} -k ${ATROPOS_SEGMENTATION_LIKELIHOOD} -m ${ATROPOS_SEGMENTATION_MRF} -o [ ${ATROPOS_SEGMENTATION},${ATROPOS_SEGMENTATION_POSTERIORS} ] -r ${USE_RANDOM_SEEDING}"
 
     if [[ $i -eq 0 ]];
       then

--- a/Scripts/antsBrainExtraction.sh
+++ b/Scripts/antsBrainExtraction.sh
@@ -178,26 +178,26 @@ ATROPOS_CSF_CLASS_LABEL=1
 ATROPOS_GM_CLASS_LABEL=2
 ATROPOS_WM_CLASS_LABEL=3
 
-ATROPOS_BRAIN_EXTRACTION_INITIALIZATION="kmeans[ ${ATROPOS_NUM_CLASSES}]"
+ATROPOS_BRAIN_EXTRACTION_INITIALIZATION="kmeans[ ${ATROPOS_NUM_CLASSES} ]"
 ATROPOS_BRAIN_EXTRACTION_LIKELIHOOD="Gaussian"
-ATROPOS_BRAIN_EXTRACTION_CONVERGENCE="[ 3,0.0]"
+ATROPOS_BRAIN_EXTRACTION_CONVERGENCE="[ 3,0.0 ]"
 
 ANTS=${ANTSPATH}/antsRegistration
 ANTS_MAX_ITERATIONS="100x100x70x20"
-ANTS_TRANSFORMATION="SyN[ 0.1,3,0]"
+ANTS_TRANSFORMATION="SyN[ 0.1,3,0 ]"
 ANTS_LINEAR_METRIC_PARAMS="1,32,Regular,0.25"
-ANTS_LINEAR_CONVERGENCE="[ 1000x500x250x100,1e-8,10]"
+ANTS_LINEAR_CONVERGENCE="[ 1000x500x250x100,1e-8,10 ]"
 ANTS_METRIC="CC"
 ANTS_METRIC_PARAMS="1,4"
 
 WARP=${ANTSPATH}/antsApplyTransforms
 
 N4=${ANTSPATH}/N4BiasFieldCorrection
-N4_CONVERGENCE_1="[ 50x50x50x50,0.0000001]"
-N4_CONVERGENCE_2="[ 50x50x50x50,0.0000001]"
+N4_CONVERGENCE_1="[ 50x50x50x50,0.0000001 ]"
+N4_CONVERGENCE_2="[ 50x50x50x50,0.0000001 ]"
 N4_SHRINK_FACTOR_1=4
 N4_SHRINK_FACTOR_2=2
-N4_BSPLINE_PARAMS="[ 200]"
+N4_BSPLINE_PARAMS="[ 200 ]"
 
 USE_FLOAT_PRECISION=0
 
@@ -226,18 +226,18 @@ else
           c) #k-means segmentation params
        # Check conventional ANTs vector designation (i.e.,  'x')
        kmeansParamsArr=(${OPTARG//x/ })  
-       if [ ${#kmeansParamsArr[@]} -ne 4 ];
+       if [[ ${#kmeansParamsArr[@]} -ne 4 ]];
          then
            # Check alternative form
            kmeansParamsArr=(${OPTARG//,/ })  
-           if [ ${#kmeansParamsArr[@]} -ne 4 ];
+           if [[ ${#kmeansParamsArr[@]} -ne 4 ]];
              then
                echo "ERROR:  unrecognized kmeans option (-c)."
                exit 1
              fi
          fi
        ATROPOS_NUM_CLASSES=${kmeansParamsArr[0]}
-       ATROPOS_BRAIN_EXTRACTION_INITIALIZATION="kmeans[ ${ATROPOS_NUM_CLASSES}]"
+       ATROPOS_BRAIN_EXTRACTION_INITIALIZATION="kmeans[ ${ATROPOS_NUM_CLASSES} ]"
        ATROPOS_CSF_CLASS_LABEL=${kmeansParamsArr[1]}
        ATROPOS_GM_CLASS_LABEL=${kmeansParamsArr[2]} 
        ATROPOS_WM_CLASS_LABEL=${kmeansParamsArr[3]}
@@ -277,18 +277,18 @@ else
   done
 fi
 
-ATROPOS_BRAIN_EXTRACTION_MRF="[ 0.1,1x1x1]"
+ATROPOS_BRAIN_EXTRACTION_MRF="[ 0.1,1x1x1 ]"
 if [[ $DIMENSION -eq 2 ]];
   then
-    ATROPOS_BRAIN_EXTRACTION_MRF="[ 0.1,1x1]"
+    ATROPOS_BRAIN_EXTRACTION_MRF="[ 0.1,1x1 ]"
   fi
 
 if [[ -z "$ATROPOS_SEGMENTATION_MRF" ]];
   then
-    ATROPOS_SEGMENTATION_MRF="[ 0.1,1x1x1]";
+    ATROPOS_SEGMENTATION_MRF="[ 0.1,1x1x1 ]";
     if [[ $DIMENSION -eq 2 ]];
       then
-        ATROPOS_SEGMENTATION_MRF="[ 0.1,1x1]"
+        ATROPOS_SEGMENTATION_MRF="[ 0.1,1x1 ]"
       fi
   fi
 
@@ -329,7 +329,7 @@ if [[ $DEBUG_MODE -gt 0 ]];
    # certain things are hard coded elsewhere, eg number of levels
 
    ANTS_MAX_ITERATIONS="40x40x20x0"
-   ANTS_LINEAR_CONVERGENCE="[ 100x100x50x10,1e-8,10]"
+   ANTS_LINEAR_CONVERGENCE="[ 100x100x50x10,1e-8,10 ]"
 
    # Leave N4 / Atropos alone because they're pretty fast
 
@@ -462,10 +462,10 @@ if [[ ! -f ${EXTRACTION_MASK} || ! -f ${EXTRACTION_WM} ]];
 
 #             exe_initial_align="${ANTSPATH}/antsAffineInitializer ${DIMENSION} ${EXTRACTION_INITIAL_AFFINE_FIXED} ${EXTRACTION_INITIAL_AFFINE_MOVING} ${EXTRACTION_INITIAL_AFFINE} 15 0.1 0 10"
           exe_initial_align="${ANTSPATH}/antsAI -d ${DIMENSION} -v 1"
-          exe_initial_align="${exe_initial_align} -m Mattes[ ${EXTRACTION_INITIAL_AFFINE_FIXED},${EXTRACTION_INITIAL_AFFINE_MOVING},32,Regular,0.2]"
-          exe_initial_align="${exe_initial_align} -t Affine[ 0.1]"
-          exe_initial_align="${exe_initial_align} -s [ 20,0.12]"
-          exe_initial_align="${exe_initial_align} -g [ 40,0x40x40]"
+          exe_initial_align="${exe_initial_align} -m Mattes[ ${EXTRACTION_INITIAL_AFFINE_FIXED},${EXTRACTION_INITIAL_AFFINE_MOVING},32,Regular,0.2 ]"
+          exe_initial_align="${exe_initial_align} -t Affine[ 0.1 ]"
+          exe_initial_align="${exe_initial_align} -s [ 20,0.12 ]"
+          exe_initial_align="${exe_initial_align} -g [ 40,0x40x40 ]"
           exe_initial_align="${exe_initial_align} -p 0"
           exe_initial_align="${exe_initial_align} -c 10"
           exe_initial_align="${exe_initial_align} -o ${EXTRACTION_INITIAL_AFFINE}"
@@ -478,14 +478,14 @@ if [[ ! -f ${EXTRACTION_MASK} || ! -f ${EXTRACTION_WM} ]];
 
           logCmd $exe_initial_align
 
-          basecall="${ANTS} -d ${DIMENSION} -u 1 -w [ 0.025,0.975] -o ${EXTRACTION_WARP_OUTPUT_PREFIX} -r ${EXTRACTION_INITIAL_AFFINE} -z 1 --float ${USE_FLOAT_PRECISION} --verbose 1"
+          basecall="${ANTS} -d ${DIMENSION} -u 1 -w [ 0.025,0.975 ] -o ${EXTRACTION_WARP_OUTPUT_PREFIX} -r ${EXTRACTION_INITIAL_AFFINE} -z 1 --float ${USE_FLOAT_PRECISION} --verbose 1"
           if [[ -f ${EXTRACTION_REGISTRATION_MASK} ]];
             then
-              basecall="${basecall} -x [ ${EXTRACTION_REGISTRATION_MASK}]"
+              basecall="${basecall} -x [ ${EXTRACTION_REGISTRATION_MASK} ]"
             fi
-          stage1="-m MI[ ${EXTRACTION_TEMPLATE},${N4_CORRECTED_IMAGES[0]},${ANTS_LINEAR_METRIC_PARAMS}] -c ${ANTS_LINEAR_CONVERGENCE} -t Rigid[ 0.1] -f 8x4x2x1 -s 4x2x1x0"
-          stage2="-m MI[ ${EXTRACTION_TEMPLATE},${N4_CORRECTED_IMAGES[0]},${ANTS_LINEAR_METRIC_PARAMS}] -c ${ANTS_LINEAR_CONVERGENCE} -t Affine[ 0.1] -f 8x4x2x1 -s 4x2x1x0"
-          stage3="-m CC[ ${EXTRACTION_TEMPLATE},${N4_CORRECTED_IMAGES[0]},0.5,4] -m CC[ ${EXTRACTION_TEMPLATE_LAPLACIAN},${EXTRACTION_LAPLACIAN},0.5,4] -c [ 50x10x0,1e-9,15] -t ${ANTS_TRANSFORMATION} -f 4x2x1 -s 2x1x0"
+          stage1="-m MI[ ${EXTRACTION_TEMPLATE},${N4_CORRECTED_IMAGES[0]},${ANTS_LINEAR_METRIC_PARAMS} ] -c ${ANTS_LINEAR_CONVERGENCE} -t Rigid[ 0.1 ] -f 8x4x2x1 -s 4x2x1x0"
+          stage2="-m MI[ ${EXTRACTION_TEMPLATE},${N4_CORRECTED_IMAGES[0]},${ANTS_LINEAR_METRIC_PARAMS} ] -c ${ANTS_LINEAR_CONVERGENCE} -t Affine[ 0.1 ] -f 8x4x2x1 -s 4x2x1x0"
+          stage3="-m CC[ ${EXTRACTION_TEMPLATE},${N4_CORRECTED_IMAGES[0]},0.5,4 ] -m CC[ ${EXTRACTION_TEMPLATE_LAPLACIAN},${EXTRACTION_LAPLACIAN},0.5,4 ] -c [ 50x10x0,1e-9,15 ] -t ${ANTS_TRANSFORMATION} -f 4x2x1 -s 2x1x0"
 
           exe_brain_extraction_1="${basecall} ${stage1} ${stage2} ${stage3}"
 
@@ -513,7 +513,7 @@ if [[ ! -f ${EXTRACTION_MASK} || ! -f ${EXTRACTION_WM} ]];
 
         ## Step 2 ##
 
-        exe_brain_extraction_2="${WARP} -d ${DIMENSION} -i ${EXTRACTION_PRIOR} -o ${EXTRACTION_MASK_PRIOR_WARPED} -r ${ANATOMICAL_IMAGES[0]} -n Gaussian -t [ ${EXTRACTION_GENERIC_AFFINE},1] -t ${EXTRACTION_INVERSE_WARP} --float ${USE_FLOAT_PRECISION} --verbose 1"
+        exe_brain_extraction_2="${WARP} -d ${DIMENSION} -i ${EXTRACTION_PRIOR} -o ${EXTRACTION_MASK_PRIOR_WARPED} -r ${ANATOMICAL_IMAGES[0]} -n Gaussian -t [ ${EXTRACTION_GENERIC_AFFINE},1 ] -t ${EXTRACTION_INVERSE_WARP} --float ${USE_FLOAT_PRECISION} --verbose 1"
         logCmd $exe_brain_extraction_2
 
         ## superstep 1b ##

--- a/Scripts/antsBrainExtraction.sh
+++ b/Scripts/antsBrainExtraction.sh
@@ -115,10 +115,10 @@ PARAMETERS
 DEBUG_MODE=0
 
 function logCmd() {
-  cmd="$*"
+  cmd="$@"
   echo "BEGIN >>>>>>>>>>>>>>>>>>>>"
   echo $cmd
-  $cmd
+  ( "$@" )
 
   cmdExit=$?
 

--- a/Scripts/antsCookTemplatePriors.sh
+++ b/Scripts/antsCookTemplatePriors.sh
@@ -167,10 +167,10 @@ PARAMETERS
 DEBUG_MODE=0
 
 function logCmd() {
-  cmd="$*"
+  cmd="$@"
   echo "BEGIN >>>>>>>>>>>>>>>>>>>>"
   echo $cmd
-  $cmd
+  ( "$@" )
 
   cmdExit=$?
 

--- a/Scripts/antsCookTemplatePriors.sh
+++ b/Scripts/antsCookTemplatePriors.sh
@@ -331,7 +331,7 @@ FORMAT=${FORMAT%%d*}
 
 REPCHARACTER=''
 TOTAL_LENGTH=0
-if [ ${#FORMAT} -eq 2 ]
+if [[ ${#FORMAT} -eq 2 ]]
   then
     REPCHARACTER=${FORMAT:0:1}
     TOTAL_LENGTH=${FORMAT:1:1}

--- a/Scripts/antsCorticalThickness.sh
+++ b/Scripts/antsCorticalThickness.sh
@@ -121,7 +121,7 @@ Optional arguments:
      -v:  use b-spline smoothing                Use B-spline SyN for registrations and B-spline exponential mapping in DiReCT.
      -r:  cortical label image                  Cortical ROI labels to use as a prior for ATITH.
      -l:  label propagation                     Incorporate a distance prior one the posterior formulation.  Should be
-                                                of the form 'label[lambda,boundaryProbability]' where label is a value
+                                                of the form 'label[ lambda,boundaryProbability ]' where label is a value
                                                 of 1,2,3,... denoting label ID.  The label probability for anything
                                                 outside the current label
 
@@ -129,14 +129,14 @@ Optional arguments:
 
                                                 Intuitively, smaller lambda values will increase the spatial capture
                                                 range of the distance prior.  To apply to all label values, simply omit
-                                                specifying the label, i.e. -l [ lambda,boundaryProbability ].
+                                                specifying the label, i.e. '-l "[ lambda,boundaryProbability ]"'.
      -c                                         Add prior combination to combined gray and white matters.  For example,
                                                 when calling KK for normal subjects, we combine the deep gray matter
                                                 segmentation/posteriors with the white matter segmentation/posteriors.
                                                 An additional example would be performing cortical thickness in the presence
                                                 of white matter lesions.  We can accommodate this by specifying a lesion mask
                                                 posterior as an additional posterior (suppose label '7'), and then combine
-                                                this with white matter by specifying '-c WM[ 7 ]' or '-c 3[ 7 ]'.
+                                                this with white matter by specifying '-c "WM[ 7 ]"' or '-c "3[ 7 ]"'.
      -q:  Use quick registration parameters     If = 1, use antsRegistrationSyNQuick.sh as the basis for registration
                                                 during brain extraction, brain segmentation, and (optional) normalization
                                                 to a template.  Otherwise use antsRegistrationSyN.sh (default = 0).
@@ -255,10 +255,11 @@ DEBUG_MODE=0
 ACT_STAGE=0 # run all stages
 
 function logCmd() {
-  cmd="$*"
+  cmd="$@"
   echo "BEGIN >>>>>>>>>>>>>>>>>>>>"
   echo $cmd
-  $cmd
+  # Preserve quoted parameters by running "$@" instead of $cmd
+  ( "$@" )
 
   cmdExit=$?
 
@@ -613,7 +614,7 @@ CORTICAL_THICKNESS_GRAY_MATTER_OTHER_LABELS=()
 for(( j=0; j < ${#PRIOR_COMBINATIONS[@]}; j++ ))
   do
     echo ${PRIOR_COMBINATIONS[$j]}
-    COMBINATION=( $( echo ${PRIOR_COMBINATIONS[$j]} | tr "[]," "\n" ) )
+    COMBINATION=( $( echo ${PRIOR_COMBINATIONS[$j]} | tr -d ' ' | tr '[],' '\n' ) )
 
     echo ${COMBINATION[@]}
 
@@ -932,7 +933,7 @@ if [[ ! -s ${OUTPUT_PREFIX}ACTStage3Complete.txt ]] && \
 
     logCmd ${ANTSPATH}/antsAtroposN4.sh \
       -d ${DIMENSION} \
-      -b ${ATROPOS_SEGMENTATION_POSTERIOR_FORMULATION} \
+      -b "${ATROPOS_SEGMENTATION_POSTERIOR_FORMULATION}" \
       ${ATROPOS_ANATOMICAL_IMAGES_COMMAND_LINE} \
       ${ATROPOS_LABEL_PROPAGATION_COMMAND_LINE} \
       -x ${BRAIN_EXTRACTION_MASK} \
@@ -958,7 +959,7 @@ if [[ ! -s ${OUTPUT_PREFIX}ACTStage3Complete.txt ]] && \
     ## Don't de-noise a second time
     logCmd ${ANTSPATH}/antsAtroposN4.sh \
       -d ${DIMENSION} \
-      -b ${ATROPOS_SEGMENTATION_POSTERIOR_FORMULATION} \
+      -b "${ATROPOS_SEGMENTATION_POSTERIOR_FORMULATION}" \
       ${ATROPOS_ANATOMICAL_IMAGES_COMMAND_LINE} \
       ${ATROPOS_LABEL_PROPAGATION_COMMAND_LINE} \
       -x ${BRAIN_EXTRACTION_MASK} \

--- a/Scripts/antsCorticalThickness.sh
+++ b/Scripts/antsCorticalThickness.sh
@@ -113,7 +113,7 @@ Optional arguments:
      -w:  Atropos prior segmentation weight     Atropos spatial prior *probability* weight for the segmentation (default = 0.25)
      -n:  number of segmentation iterations     N4 -> Atropos -> N4 iterations during segmentation (default = 3)
      -b:  posterior formulation                 Atropos posterior formulation and whether or not to use mixture model proportions.
-                                                e.g 'Socrates[1]' (default) or 'Aristotle[1]'.  Choose the latter if you
+                                                e.g 'Socrates[ 1 ]' (default) or 'Aristotle[ 1 ]'.  Choose the latter if you
                                                 want use the distance priors (see also the -l option for label propagation
                                                 control).
      -j:  use floating-point precision          Use floating point precision in registrations (default = 0)
@@ -129,14 +129,14 @@ Optional arguments:
 
                                                 Intuitively, smaller lambda values will increase the spatial capture
                                                 range of the distance prior.  To apply to all label values, simply omit
-                                                specifying the label, i.e. -l [ lambda,boundaryProbability].
+                                                specifying the label, i.e. -l [ lambda,boundaryProbability ].
      -c                                         Add prior combination to combined gray and white matters.  For example,
                                                 when calling KK for normal subjects, we combine the deep gray matter
                                                 segmentation/posteriors with the white matter segmentation/posteriors.
                                                 An additional example would be performing cortical thickness in the presence
                                                 of white matter lesions.  We can accommodate this by specifying a lesion mask
                                                 posterior as an additional posterior (suppose label '7'), and then combine
-                                                this with white matter by specifying '-c WM[ 7]' or '-c 3[ 7]'.
+                                                this with white matter by specifying '-c WM[ 7 ]' or '-c 3[ 7 ]'.
      -q:  Use quick registration parameters     If = 1, use antsRegistrationSyNQuick.sh as the basis for registration
                                                 during brain extraction, brain segmentation, and (optional) normalization
                                                 to a template.  Otherwise use antsRegistrationSyN.sh (default = 0).
@@ -226,7 +226,7 @@ echoParameters() {
       registration template   = ${REGISTRATION_TEMPLATE}
 
     ANTs parameters:
-      metric                  = ${ANTS_METRIC}[fixedImage,movingImage,${ANTS_METRIC_PARAMS}]
+      metric                  = ${ANTS_METRIC}[ fixedImage,movingImage,${ANTS_METRIC_PARAMS} ]
       regularization          = ${ANTS_REGULARIZATION}
       transformation          = ${ANTS_TRANSFORMATION}
       max iterations          = ${ANTS_MAX_ITERATIONS}
@@ -328,39 +328,39 @@ ATROPOS_SEGMENTATION_PRIOR_WEIGHT=0.25
 
 ANTS=${ANTSPATH}/antsRegistration
 ANTS_MAX_ITERATIONS="100x100x70x20"
-ANTS_TRANSFORMATION="SyN[ 0.1,3,0]"
+ANTS_TRANSFORMATION="SyN[ 0.1,3,0 ]"
 ANTS_LINEAR_METRIC_PARAMS="1,32,Regular,0.25"
-ANTS_LINEAR_CONVERGENCE="[ 1000x500x250x100,1e-8,10]"
+ANTS_LINEAR_CONVERGENCE="[ 1000x500x250x100,1e-8,10 ]"
 ANTS_METRIC="CC"
 ANTS_METRIC_PARAMS="1,4"
 
 WARP=${ANTSPATH}/antsApplyTransforms
 
 N4=${ANTSPATH}/N4BiasFieldCorrection
-N4_CONVERGENCE_1="[ 50x50x50x50,0.0000001]"
-N4_CONVERGENCE_2="[ 50x50x50x50,0.0000001]"
+N4_CONVERGENCE_1="[ 50x50x50x50,0.0000001 ]"
+N4_CONVERGENCE_2="[ 50x50x50x50,0.0000001 ]"
 N4_SHRINK_FACTOR_1=4
 N4_SHRINK_FACTOR_2=2
-N4_BSPLINE_PARAMS="[ 200]"
+N4_BSPLINE_PARAMS="[ 200 ]"
 
 ATROPOS=${ANTSPATH}/Atropos
 
 ATROPOS_SEGMENTATION_INITIALIZATION="PriorProbabilityImages"
 ATROPOS_SEGMENTATION_LIKELIHOOD="Gaussian"
-ATROPOS_SEGMENTATION_CONVERGENCE="[ 5,0.0]"
-ATROPOS_SEGMENTATION_POSTERIOR_FORMULATION="Socrates[ 1]"
+ATROPOS_SEGMENTATION_CONVERGENCE="[ 5,0.0 ]"
+ATROPOS_SEGMENTATION_POSTERIOR_FORMULATION="Socrates[ 1 ]"
 ATROPOS_SEGMENTATION_NUMBER_OF_ITERATIONS=3
 ATROPOS_SEGMENTATION_INTERNAL_ITERATIONS=5 # to be backward compatible but i like 25
 ATROPOS_SEGMENTATION_LABEL_PROPAGATION=()
 
 DIRECT=${ANTSPATH}/KellyKapowski
-DIRECT_CONVERGENCE="[ 45,0.0,10]"
+DIRECT_CONVERGENCE="[ 45,0.0,10 ]"
 DIRECT_THICKNESS_PRIOR="10"
 DIRECT_GRAD_STEP_SIZE="0.025"
 DIRECT_SMOOTHING_PARAMETER="1.5"
 DIRECT_NUMBER_OF_DIFF_COMPOSITIONS="10"
 
-PRIOR_COMBINATIONS=( 'WM[4]' )
+PRIOR_COMBINATIONS=( 'WM[ 4 ]' )
 
 USE_FLOAT_PRECISION=0
 USE_BSPLINE_SMOOTHING=0
@@ -467,7 +467,7 @@ fi
 
 if [[ $USE_BSPLINE_SMOOTHING -ne 0 ]];
   then
-    ANTS_TRANSFORMATION="BSplineSyN[ 0.1,26,0,3]"
+    ANTS_TRANSFORMATION="BSplineSyN[ 0.1,26,0,3 ]"
     DIRECT_SMOOTHING_PARAMETER="5.75"
   fi
 
@@ -482,14 +482,14 @@ if [[ $DEBUG_MODE -gt 0 ]];
     # certain things are hard coded elsewhere, eg number of levels
 
     ANTS_MAX_ITERATIONS="40x40x20x0"
-    ANTS_LINEAR_CONVERGENCE="[ 100x100x50x0,1e-8,10]"
+    ANTS_LINEAR_CONVERGENCE="[ 100x100x50x0,1e-8,10 ]"
     ANTS_METRIC_PARAMS="1,2"
 
     # I think this is the number of times we run the whole N4 / Atropos thing, at the cost of about 10 minutes a time
     ATROPOS_SEGMENTATION_NUMBER_OF_ITERATIONS=1
     ATROPOS_SEGMENTATION_INTERNAL_ITERATIONS=5 # internal to atropos
 
-    DIRECT_CONVERGENCE="[ 5,0.0,10]"
+    DIRECT_CONVERGENCE="[ 5,0.0,10 ]"
 
     # Fix random seed to replicate exact results on each run
     USE_RANDOM_SEEDING=0
@@ -521,7 +521,7 @@ FORMAT=${FORMAT%%d*}
 
 REPCHARACTER=''
 TOTAL_LENGTH=0
-if [ ${#FORMAT} -eq 2 ]
+if [[ ${#FORMAT} -eq 2 ]]
   then
     REPCHARACTER=${FORMAT:0:1}
     TOTAL_LENGTH=${FORMAT:1:1}
@@ -830,17 +830,17 @@ if [[ ! -s ${OUTPUT_PREFIX}ACTStage2Complete.txt ]]  && \
                     basecall="${basecall} -p f"
                   fi
             else
-              basecall="${ANTS} -d ${DIMENSION} -u 1 -w [ 0.0,0.999] -o ${SEGMENTATION_WARP_OUTPUT_PREFIX} --float ${USE_FLOAT_PRECISION} --verbose 1"
+              basecall="${ANTS} -d ${DIMENSION} -u 1 -w [ 0.0,0.999 ] -o ${SEGMENTATION_WARP_OUTPUT_PREFIX} --float ${USE_FLOAT_PRECISION} --verbose 1"
               IMAGES="${EXTRACTED_SEGMENTATION_BRAIN},${EXTRACTED_BRAIN_TEMPLATE}"
               if [[ -f ${EXTRACTION_GENERIC_AFFINE} ]];
                 then
-                  basecall="${basecall} -r [ ${EXTRACTION_GENERIC_AFFINE},1]"
+                  basecall="${basecall} -r [ ${EXTRACTION_GENERIC_AFFINE},1 ]"
                 else
-                  basecall="${basecall} -r [ ${IMAGES},1]"
+                  basecall="${basecall} -r [ ${IMAGES},1 ]"
                 fi
-              basecall="${basecall} -x [ ${SEGMENTATION_MASK_DILATED}]"
-              stage1="-m MI[ ${IMAGES},${ANTS_LINEAR_METRIC_PARAMS}] -c ${ANTS_LINEAR_CONVERGENCE} -t Affine[ 0.1] -f 8x4x2x1 -s 4x2x1x0"
-              stage2="-m CC[ ${IMAGES},1,4] -c [ ${ANTS_MAX_ITERATIONS},1e-9,15] -t ${ANTS_TRANSFORMATION} -f 6x4x2x1 -s 3x2x1x0"
+              basecall="${basecall} -x [ ${SEGMENTATION_MASK_DILATED} ]"
+              stage1="-m MI[ ${IMAGES},${ANTS_LINEAR_METRIC_PARAMS} ] -c ${ANTS_LINEAR_CONVERGENCE} -t Affine[ 0.1 ] -f 8x4x2x1 -s 4x2x1x0"
+              stage2="-m CC[ ${IMAGES},1,4 ] -c [ ${ANTS_MAX_ITERATIONS},1e-9,15 ] -t ${ANTS_TRANSFORMATION} -f 6x4x2x1 -s 3x2x1x0"
 
               basecall="${basecall} ${stage1} ${stage2}"
             fi
@@ -1068,10 +1068,10 @@ if [[ -f ${REGISTRATION_TEMPLATE} ]] && [[ ! -f $REGISTRATION_LOG_JACOBIAN ]];
           fi
       else
         IMAGES="${REGISTRATION_TEMPLATE},${EXTRACTED_SEGMENTATION_BRAIN_N4_IMAGE}"
-        basecall="${ANTS} -d ${DIMENSION} -v 1 -u 1 -w [ 0.0,0.999] -o ${REGISTRATION_TEMPLATE_OUTPUT_PREFIX} -r [ ${IMAGES},1] --float ${USE_FLOAT_PRECISION}"
-        stage1="-m MI[ ${IMAGES},${ANTS_LINEAR_METRIC_PARAMS}] -c ${ANTS_LINEAR_CONVERGENCE} -t Rigid[ 0.1] -f 8x4x2x1 -s 3x2x1x0"
-        stage2="-m MI[ ${IMAGES},${ANTS_LINEAR_METRIC_PARAMS}] -c ${ANTS_LINEAR_CONVERGENCE} -t Affine[ 0.1] -f 8x4x2x1 -s 3x2x1x0"
-        stage3="-m CC[ ${IMAGES},1,4] -c [ ${ANTS_MAX_ITERATIONS},1e-9,15] -t ${ANTS_TRANSFORMATION} -f 6x4x2x1 -s 3x2x1x0"
+        basecall="${ANTS} -d ${DIMENSION} -v 1 -u 1 -w [ 0.0,0.999 ] -o ${REGISTRATION_TEMPLATE_OUTPUT_PREFIX} -r [ ${IMAGES},1 ] --float ${USE_FLOAT_PRECISION}"
+        stage1="-m MI[ ${IMAGES},${ANTS_LINEAR_METRIC_PARAMS} ] -c ${ANTS_LINEAR_CONVERGENCE} -t Rigid[ 0.1 ] -f 8x4x2x1 -s 3x2x1x0"
+        stage2="-m MI[ ${IMAGES},${ANTS_LINEAR_METRIC_PARAMS} ] -c ${ANTS_LINEAR_CONVERGENCE} -t Affine[ 0.1 ] -f 8x4x2x1 -s 3x2x1x0"
+        stage3="-m CC[ ${IMAGES},1,4 ] -c [ ${ANTS_MAX_ITERATIONS},1e-9,15 ] -t ${ANTS_TRANSFORMATION} -f 6x4x2x1 -s 3x2x1x0"
         basecall="${basecall} ${stage1} ${stage2} ${stage3}"
       fi
     exe_template_registration_1="${basecall}"
@@ -1104,7 +1104,7 @@ if [[ -f ${REGISTRATION_TEMPLATE} ]] && [[ ! -f $REGISTRATION_LOG_JACOBIAN ]];
       echo "The transform file ${REGISTRATION_SUBJECT_WARP} does not exist."
       exit 1
     fi
-    logCmd ${ANTSPATH}/antsApplyTransforms -d ${DIMENSION} -o Linear[ $REGISTRATION_SUBJECT_GENERIC_AFFINE,1] -t $REGISTRATION_TEMPLATE_GENERIC_AFFINE --verbose 1
+    logCmd ${ANTSPATH}/antsApplyTransforms -d ${DIMENSION} -o Linear[ $REGISTRATION_SUBJECT_GENERIC_AFFINE,1 ] -t $REGISTRATION_TEMPLATE_GENERIC_AFFINE --verbose 1
 
     time_end_template_registration=`date +%s`
     time_elapsed_template_registration=$((time_end_template_registration - time_start_template_registration))
@@ -1225,7 +1225,7 @@ if [[ ! -f ${CORTICAL_THICKNESS_IMAGE} ]];
 
     TMP_FILES=( $CORTICAL_THICKNESS_GM $CORTICAL_THICKNESS_WM $CORTICAL_THICKNESS_SEGMENTATION )
 
-    exe_direct="${DIRECT} -d ${DIMENSION} -s [ ${CORTICAL_THICKNESS_SEGMENTATION},${GRAY_MATTER_LABEL},${WHITE_MATTER_LABEL}] --verbose 1"
+    exe_direct="${DIRECT} -d ${DIMENSION} -s [ ${CORTICAL_THICKNESS_SEGMENTATION},${GRAY_MATTER_LABEL},${WHITE_MATTER_LABEL} ] --verbose 1"
     exe_direct="${exe_direct} -g ${CORTICAL_THICKNESS_GM} -w ${CORTICAL_THICKNESS_WM} -o ${CORTICAL_THICKNESS_IMAGE}"
     exe_direct="${exe_direct} -c ${DIRECT_CONVERGENCE} -r ${DIRECT_GRAD_STEP_SIZE}"
     exe_direct="${exe_direct} -m ${DIRECT_SMOOTHING_PARAMETER} -n ${DIRECT_NUMBER_OF_DIFF_COMPOSITIONS} -b ${USE_BSPLINE_SMOOTHING}"
@@ -1397,7 +1397,7 @@ if [[ ! -f ${CORTICAL_THICKNESS_MOSAIC} || ! -f ${BRAIN_SEGMENTATION_MOSAIC} ]];
 
     mosaic="${ANTSPATH}/CreateTiledMosaic -i ${HEAD_N4_IMAGE_RESAMPLED} -r ${CORTICAL_THICKNESS_IMAGE_RGB}"
     mosaic="${mosaic} -o ${CORTICAL_THICKNESS_MOSAIC} -a 1.0 -t -1x-1 -d z -p mask"
-    mosaic="${mosaic} -s [ 2,mask,mask] -x ${CORTICAL_THICKNESS_MASK}"
+    mosaic="${mosaic} -s [ 2,mask,mask ] -x ${CORTICAL_THICKNESS_MASK}"
     logCmd $mosaic
 
     # Segmentation
@@ -1412,7 +1412,7 @@ if [[ ! -f ${CORTICAL_THICKNESS_MOSAIC} || ! -f ${BRAIN_SEGMENTATION_MOSAIC} ]];
 
     mosaic="${ANTSPATH}/CreateTiledMosaic -i ${HEAD_N4_IMAGE_RESAMPLED} -r ${BRAIN_SEGMENTATION_IMAGE_RGB}"
     mosaic="${mosaic} -o ${BRAIN_SEGMENTATION_MOSAIC} -a 0.3 -t -1x-1 -d 2 -p mask"
-    mosaic="${mosaic} -s [ 2,mask,mask] -x ${BRAIN_EXTRACTION_MASK_RESAMPLED}"
+    mosaic="${mosaic} -s [ 2,mask,mask ] -x ${BRAIN_EXTRACTION_MASK_RESAMPLED}"
     logCmd $mosaic
 
 

--- a/Scripts/antsCorticalThickness.sh
+++ b/Scripts/antsCorticalThickness.sh
@@ -683,7 +683,7 @@ EXTRACTED_SEGMENTATION_BRAIN=${OUTPUT_PREFIX}BrainExtractionBrain.${OUTPUT_SUFFI
 EXTRACTION_GENERIC_AFFINE=${OUTPUT_PREFIX}BrainExtractionPrior0GenericAffine.mat
 EXTRACTED_BRAIN_TEMPLATE=${OUTPUT_PREFIX}ExtractedTemplateBrain.${OUTPUT_SUFFIX}
 if [[ ! -s ${OUTPUT_PREFIX}ACTStage1Complete.txt ]]; then
-if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 1  ]] ; then # BAStages bxt
+if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 1 ]] ; then # BAStages bxt
 if [[ ! -f ${BRAIN_EXTRACTION_MASK} ]];
   then
 
@@ -761,7 +761,7 @@ SEGMENTATION_CONVERGENCE_FILE=${BRAIN_SEGMENTATION_OUTPUT}Convergence.txt
 
 if [[ ! -s ${OUTPUT_PREFIX}ACTStage2Complete.txt ]]  && \
    [[   -s ${OUTPUT_PREFIX}ACTStage1Complete.txt ]]; then
-  if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 2  ]] ; then # BAStages reg
+  if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 2 ]] ; then # BAStages reg
     echo
     echo "--------------------------------------------------------------------------------------"
     echo " Brain segmentation using the following steps:"
@@ -908,7 +908,7 @@ if [[ ! -s ${OUTPUT_PREFIX}ACTStage2Complete.txt ]]  && \
 if [[ ! -s ${OUTPUT_PREFIX}ACTStage3Complete.txt ]] && \
    [[   -s ${OUTPUT_PREFIX}ACTStage2Complete.txt ]] && \
    [[   -s ${OUTPUT_PREFIX}ACTStage1Complete.txt ]] ; then
-  if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 3  ]] ; then # BAStages seg
+  if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 3 ]] ; then # BAStages seg
     time_start_brain_segmentation=`date +%s`
     ATROPOS_ANATOMICAL_IMAGES_COMMAND_LINE='';
     for (( j = 0; j < ${#ANATOMICAL_IMAGES[@]}; j++ ))
@@ -1155,7 +1155,7 @@ if [[ ! -s ${OUTPUT_PREFIX}ACTStage5Complete.txt ]] && \
    [[   -s ${OUTPUT_PREFIX}ACTStage3Complete.txt ]] && \
    [[   -s ${OUTPUT_PREFIX}ACTStage2Complete.txt ]] && \
    [[   -s ${OUTPUT_PREFIX}ACTStage1Complete.txt ]] ; then
-if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 5  ]] ; then # BAStages thk
+if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 5 ]] ; then # BAStages thk
 if [[ ! -f ${CORTICAL_THICKNESS_IMAGE} ]];
   then
 
@@ -1289,7 +1289,7 @@ if [[ ! -s ${OUTPUT_PREFIX}ACTStage6Complete.txt ]] && \
    [[   -s ${OUTPUT_PREFIX}ACTStage3Complete.txt ]] && \
    [[   -s ${OUTPUT_PREFIX}ACTStage2Complete.txt ]] && \
    [[   -s ${OUTPUT_PREFIX}ACTStage1Complete.txt ]] ; then
-if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 6  ]] ; then # BAStages qc
+if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 6 ]] ; then # BAStages qc
 echo "--------------------------------------------------------------------------------------"
 echo "Compute summary measurements"
 echo "--------------------------------------------------------------------------------------"
@@ -1438,7 +1438,7 @@ fi # check completion
 #
 ################################################################################
 
-if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -ge 5  ]] ; then
+if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -ge 5 ]] ; then
   logCmd checkOutputExists
 fi
 

--- a/Scripts/antsIntermodalityIntrasubject.sh
+++ b/Scripts/antsIntermodalityIntrasubject.sh
@@ -70,10 +70,10 @@ PARAMETERS
 
 # Echos a command to both stdout and stderr, then runs it
 function logCmd() {
-  cmd="$*"
+  cmd="$@"
   echo "BEGIN >>>>>>>>>>>>>>>>>>>>"
   echo $cmd
-  $cmd
+  ( "$@" )
   echo "END   <<<<<<<<<<<<<<<<<<<<"
   echo
   echo

--- a/Scripts/antsIntermodalityIntrasubject.sh
+++ b/Scripts/antsIntermodalityIntrasubject.sh
@@ -231,10 +231,10 @@ if [[ ! -d $OUTPUT_DIR ]];
 
 
 ANTS_MAX_ITERATIONS="50x50x0"
-ANTS_TRANSFORMATION="SyN[ 0.1,3,0]"
+ANTS_TRANSFORMATION="SyN[ 0.1,3,0 ]"
 ANTS_LINEAR_METRIC="MI"
 ANTS_LINEAR_METRIC_PARAMS="1,32,Regular,0.25"
-ANTS_LINEAR_CONVERGENCE="[ 1000x500x250x0,1e-7,5]"
+ANTS_LINEAR_CONVERGENCE="[ 1000x500x250x0,1e-7,5 ]"
 ANTS_METRIC="mattes"
 ANTS_METRIC_PARAMS="1,32"
 ANTS_TRANS1=""
@@ -242,18 +242,18 @@ ANTS_TRANS2=""
 
 if [ ${TRANSFORM_TYPE} -eq 0 ];
 then
-    ANTS_TRANS1="Rigid[ 0.1]"
+    ANTS_TRANS1="Rigid[ 0.1 ]"
 elif [ ${TRANSFORM_TYPE} -eq 1 ];
 then
-   ANTS_TRANS1="Affine[ 0.1]"
+   ANTS_TRANS1="Affine[ 0.1 ]"
 elif [ ${TRANSFORM_TYPE} -eq 2 ];
 then
-    ANTS_TRANS1="Rigid[ 0.1]"
-    ANTS_TRANS2="SyN[ 0.1,3,0]"
+    ANTS_TRANS1="Rigid[ 0.1 ]"
+    ANTS_TRANS2="SyN[ 0.1,3,0 ]"
 elif [ ${TRANSFORM_TYPE} -eq 3 ];
 then
-   ANTS_TRANS1="Affine[ 0.1]"
-   ANTS_TRANS2="SyN[ 0.1,3,0]"
+   ANTS_TRANS1="Affine[ 0.1 ]"
+   ANTS_TRANS2="SyN[ 0.1,3,0 ]"
 fi
 
 echoParameters >&2
@@ -282,9 +282,9 @@ stage1="-m ${ANTS_LINEAR_METRIC}[${ANATOMICAL_BRAIN},${BRAIN},${ANTS_LINEAR_METR
 
 stage2=""
 if [[ ${TRANSFORM_TYPE} -gt 1 ]] ; then
-    stage2="-m ${ANTS_METRIC}[${ANATOMICAL_BRAIN},${BRAIN},${ANTS_METRIC_PARAMS}] -c [ ${ANTS_MAX_ITERATIONS},1e-7,5] -t ${ANTS_TRANS2} -f 4x2x1 -s 2x1x0mm -u 1"
+    stage2="-m ${ANTS_METRIC}[${ANATOMICAL_BRAIN},${BRAIN},${ANTS_METRIC_PARAMS}] -c [ ${ANTS_MAX_ITERATIONS},1e-7,5 ] -t ${ANTS_TRANS2} -f 4x2x1 -s 2x1x0mm -u 1"
 fi
-globalparams=" -z 1 --winsorize-image-intensities [ 0.005, 0.995] "
+globalparams=" -z 1 --winsorize-image-intensities [ 0.005, 0.995 ] "
 
 cmd="${ANTSPATH}/antsRegistration -d $DIMENSION $stage1 $stage2 $globalparams -o ${OUTPUT_PREFIX}"
 echo $cmd
@@ -340,7 +340,7 @@ fi
 if [[ -f $TEMPLATE_MASK ]]; then
     ${ANTSPATH}/antsApplyTransforms -d $DIMENSION -i $TEMPLATE_MASK -o ${OUTPUT_PREFIX}brainmask.nii.gz \
 	-r $BRAIN  -n NearestNeighbor \
-	-t [ ${OUTPUT_PREFIX}0GenericAffine.mat, 1]       \
+	-t [ ${OUTPUT_PREFIX}0GenericAffine.mat, 1 ]       \
 	$iwarp
 fi
 
@@ -348,7 +348,7 @@ fi
 if [[ -f $TEMPLATE_LABELS ]]; then
     ${ANTSPATH}/antsApplyTransforms -d $DIMENSION -i $TEMPLATE_LABELS -o ${OUTPUT_PREFIX}labels.nii.gz \
 	-r $BRAIN  -n NearestNeighbor \
-	-t [ ${OUTPUT_PREFIX}0GenericAffine.mat, 1]       \
+	-t [ ${OUTPUT_PREFIX}0GenericAffine.mat, 1 ]       \
 	$iwarp           \
 	-t   ${TEMPLATE_TRANSFORM}1Warp.nii.gz \
 	-t   ${TEMPLATE_TRANSFORM}0GenericAffine.mat

--- a/Scripts/antsIntermodalityIntrasubject.sh
+++ b/Scripts/antsIntermodalityIntrasubject.sh
@@ -278,11 +278,11 @@ time_start=`date +%s`
 #
 ################################################################################
 
-stage1="-m ${ANTS_LINEAR_METRIC}[${ANATOMICAL_BRAIN},${BRAIN},${ANTS_LINEAR_METRIC_PARAMS}] -c ${ANTS_LINEAR_CONVERGENCE} -t ${ANTS_TRANS1} -f 8x4x2x1 -s 4x2x1x0 -u 1"
+stage1="-m ${ANTS_LINEAR_METRIC}[ ${ANATOMICAL_BRAIN},${BRAIN},${ANTS_LINEAR_METRIC_PARAMS} ] -c ${ANTS_LINEAR_CONVERGENCE} -t ${ANTS_TRANS1} -f 8x4x2x1 -s 4x2x1x0 -u 1"
 
 stage2=""
 if [[ ${TRANSFORM_TYPE} -gt 1 ]] ; then
-    stage2="-m ${ANTS_METRIC}[${ANATOMICAL_BRAIN},${BRAIN},${ANTS_METRIC_PARAMS}] -c [ ${ANTS_MAX_ITERATIONS},1e-7,5 ] -t ${ANTS_TRANS2} -f 4x2x1 -s 2x1x0mm -u 1"
+    stage2="-m ${ANTS_METRIC}[ ${ANATOMICAL_BRAIN},${BRAIN},${ANTS_METRIC_PARAMS} ] -c [ ${ANTS_MAX_ITERATIONS},1e-7,5 ] -t ${ANTS_TRANS2} -f 4x2x1 -s 2x1x0mm -u 1"
 fi
 globalparams=" -z 1 --winsorize-image-intensities [ 0.005, 0.995 ] "
 

--- a/Scripts/antsIntroduction.sh
+++ b/Scripts/antsIntroduction.sh
@@ -444,8 +444,8 @@ then
 # Mapping Parameters for the LDDMM style SyN --- the params are SyN[ GradientStepLength,NTimeDiscretizationPoints,IntegrationTimeStep]
 # increasing IntegrationTimeStep increases accuracy in the diffeomorphism integration and takes more computation time.
 # NTimeDiscretizationPoints is set to 2 here
-TRANSFORMATION=SyN[ 1,2,0.05]
-REGULARIZATION=Gauss[ 3,0.]
+TRANSFORMATION="SyN[ 1,2,0.05 ]"
+REGULARIZATION="Gauss[ 3,0. ]"
 
 elif [ "${TRANSFORMATIONTYPE}" == "SY" ]
 then
@@ -454,7 +454,7 @@ then
 # NTimeDiscretizationPoints is the number of spatial indices in the time dimension (the 4th dim when doing 3D registration)
 # increasing NTimeDiscretizationPoints increases flexibility and takes more computation time.
 # the --geodesic option enables either 1 asymmetric gradient estimation or 2 symmetric gradient estimation (the default here )
-TRANSFORMATION=" SyN[1,2,0.05 ] --geodesic 2 "
+TRANSFORMATION=" SyN[ 1,2,0.05 ] --geodesic 2 "
 REGULARIZATION="Gauss[ 3,0. ]"
 
 elif [ "${TRANSFORMATIONTYPE}" == "LDDMM" ]

--- a/Scripts/antsIntroduction.sh
+++ b/Scripts/antsIntroduction.sh
@@ -434,9 +434,9 @@ then
 # Mapping Parameters
 TRANSFORMATION=Elast[ 1]
 REGULARIZATION=Gauss[ 3,0.5]
-# Gauss[3,x] is usually the best option.    x is usually 0 for SyN --- if you want to reduce flexibility/increase mapping smoothness, the set x > 0.
+# Gauss[3,x ] is usually the best option.    x is usually 0 for SyN --- if you want to reduce flexibility/increase mapping smoothness, the set x > 0.
 # We did a large scale evaluation of SyN gradient parameters in normal brains and found 0.25 => 0.5 to perform best when
-# combined with default Gauss[3,0] regularization.    You would increase the gradient step in some cases, though, to make
+# combined with default Gauss[3,0 ] regularization.    You would increase the gradient step in some cases, though, to make
 # the registration converge faster --- though oscillations occur if the step is too high and other instability might happen too.
 
 elif [ "${TRANSFORMATIONTYPE}" == "S2"  ]
@@ -454,7 +454,7 @@ then
 # NTimeDiscretizationPoints is the number of spatial indices in the time dimension (the 4th dim when doing 3D registration)
 # increasing NTimeDiscretizationPoints increases flexibility and takes more computation time.
 # the --geodesic option enables either 1 asymmetric gradient estimation or 2 symmetric gradient estimation (the default here )
-TRANSFORMATION=" SyN[1,2,0.05] --geodesic 2 "
+TRANSFORMATION=" SyN[1,2,0.05 ] --geodesic 2 "
 REGULARIZATION=Gauss[ 3,0.]
 
 elif [ "${TRANSFORMATIONTYPE}" == "LDDMM"  ]
@@ -464,7 +464,7 @@ then
 # NTimeDiscretizationPoints is the number of spatial indices in the time dimension (the 4th dim when doing 3D registration)
 # increasing NTimeDiscretizationPoints increases flexibility and takes more computation time.
 # the --geodesic option enables either 1 asymmetric gradient estimation or 2 symmetric gradient estimation (the default here )
-TRANSFORMATION=" SyN[1,2,0.05] --geodesic 1 "
+TRANSFORMATION=" SyN[1,2,0.05 ] --geodesic 1 "
 REGULARIZATION=Gauss[ 3,0.]
 
 elif [ "${TRANSFORMATIONTYPE}" == "GR" ]
@@ -601,7 +601,7 @@ then
 # Apply N4BiasFieldCorrection
 #Uncomment/comment below to switch between N3 and N4 bias field correction binaries
 #exe="${ANTSPATH}/N3BiasFieldCorrection $DIM $MOVING ${OUTPUTNAME}.nii.gz 4"
-exe="${ANTSPATH}/N4BiasFieldCorrection -d $DIM -i $MOVING -o ${OUTPUTNAME}.nii.gz -b [ 200] -s 3 -c [ 50x50x30x20,1e-6]"
+exe="${ANTSPATH}/N4BiasFieldCorrection -d $DIM -i $MOVING -o ${OUTPUTNAME}.nii.gz -b [ 200 ] -s 3 -c [ 50x50x30x20,1e-6 ]"
 echo
 echo "--------------------------------------------------------------------------------------"
 echo "N4BiasFieldCorrection command:"
@@ -668,7 +668,7 @@ then
 # Apply N4BiasFieldCorrection
 #Uncomment/comment below to switch between N3 and N4 bias field correction binaries
 #exe="${ANTSPATH}/N3BiasFieldCorrection $DIM $MOVING ${OUTPUTNAME}.nii.gz 4"
-exe="${ANTSPATH}/N4BiasFieldCorrection -d $DIM -i $MOVING -o ${OUTPUTNAME}.nii.gz -b [ 200] -s 3 -c [ 50x50x30x20,1e-6]"
+exe="${ANTSPATH}/N4BiasFieldCorrection -d $DIM -i $MOVING -o ${OUTPUTNAME}.nii.gz -b [ 200 ] -s 3 -c [ 50x50x30x20,1e-6 ]"
 echo
 echo "--------------------------------------------------------------------------------------"
 echo "N4BiasFieldCorrection command:"
@@ -677,7 +677,7 @@ echo "--------------------------------------------------------------------------
 $exe
 echo "execN4=$exe" >> ${MOVINGBASE}.cfg
 
-exe=" ${ANTSPATH}/ANTS $DIM -m MI[ ${FIXED},${MOVING},1,32] -o ${OUTPUTNAME}.nii.gz -i 0 --use-Histogram-Matching --number-of-affine-iterations $AFFINEITERATIONS --MI-option 32x16000 ${RIGIDTRANSF} "
+exe=" ${ANTSPATH}/ANTS $DIM -m MI[ ${FIXED},${MOVING},1,32 ] -o ${OUTPUTNAME}.nii.gz -i 0 --use-Histogram-Matching --number-of-affine-iterations $AFFINEITERATIONS --MI-option 32x16000 ${RIGIDTRANSF} "
 echo
 echo "--------------------------------------------------------------------------------------"
 echo "ANTS command:"

--- a/Scripts/antsIntroduction.sh
+++ b/Scripts/antsIntroduction.sh
@@ -432,14 +432,14 @@ RIGIDTRANSF=" --rigid-affine true "
 elif [ "${TRANSFORMATIONTYPE}" == "EL" ]
 then
 # Mapping Parameters
-TRANSFORMATION=Elast[ 1]
-REGULARIZATION=Gauss[ 3,0.5]
+TRANSFORMATION="Elast[ 1 ]"
+REGULARIZATION="Gauss[ 3,0.5 ]"
 # Gauss[3,x ] is usually the best option.    x is usually 0 for SyN --- if you want to reduce flexibility/increase mapping smoothness, the set x > 0.
 # We did a large scale evaluation of SyN gradient parameters in normal brains and found 0.25 => 0.5 to perform best when
 # combined with default Gauss[3,0 ] regularization.    You would increase the gradient step in some cases, though, to make
 # the registration converge faster --- though oscillations occur if the step is too high and other instability might happen too.
 
-elif [ "${TRANSFORMATIONTYPE}" == "S2"  ]
+elif [ "${TRANSFORMATIONTYPE}" == "S2" ]
 then
 # Mapping Parameters for the LDDMM style SyN --- the params are SyN[ GradientStepLength,NTimeDiscretizationPoints,IntegrationTimeStep]
 # increasing IntegrationTimeStep increases accuracy in the diffeomorphism integration and takes more computation time.
@@ -447,7 +447,7 @@ then
 TRANSFORMATION=SyN[ 1,2,0.05]
 REGULARIZATION=Gauss[ 3,0.]
 
-elif [ "${TRANSFORMATIONTYPE}" == "SY"  ]
+elif [ "${TRANSFORMATIONTYPE}" == "SY" ]
 then
 # Mapping Parameters for the LDDMM style SyN --- the params are SyN[ GradientStepLength,NTimeDiscretizationPoints,IntegrationTimeStep]
 # increasing IntegrationTimeStep increases accuracy in the diffeomorphism integration and takes more computation time.
@@ -455,42 +455,42 @@ then
 # increasing NTimeDiscretizationPoints increases flexibility and takes more computation time.
 # the --geodesic option enables either 1 asymmetric gradient estimation or 2 symmetric gradient estimation (the default here )
 TRANSFORMATION=" SyN[1,2,0.05 ] --geodesic 2 "
-REGULARIZATION=Gauss[ 3,0.]
+REGULARIZATION="Gauss[ 3,0. ]"
 
-elif [ "${TRANSFORMATIONTYPE}" == "LDDMM"  ]
+elif [ "${TRANSFORMATIONTYPE}" == "LDDMM" ]
 then
 # Mapping Parameters for the LDDMM style SyN --- the params are SyN[ GradientStepLength,NTimeDiscretizationPoints,IntegrationTimeStep]
 # increasing IntegrationTimeStep increases accuracy in the diffeomorphism integration and takes more computation time.
 # NTimeDiscretizationPoints is the number of spatial indices in the time dimension (the 4th dim when doing 3D registration)
 # increasing NTimeDiscretizationPoints increases flexibility and takes more computation time.
 # the --geodesic option enables either 1 asymmetric gradient estimation or 2 symmetric gradient estimation (the default here )
-TRANSFORMATION=" SyN[1,2,0.05 ] --geodesic 1 "
-REGULARIZATION=Gauss[ 3,0.]
+TRANSFORMATION=" SyN[ 1,2,0.05 ] --geodesic 1 "
+REGULARIZATION="Gauss[ 3,0. ]"
 
 elif [ "${TRANSFORMATIONTYPE}" == "GR" ]
 then
 # Mapping Parameters for the greedy gradient descent (fast) version of SyN -- only needs GradientStepLength
-TRANSFORMATION=SyN[ 0.25]
-REGULARIZATION=Gauss[ 3,0]
+TRANSFORMATION="SyN[ 0.25 ]"
+REGULARIZATION="Gauss[ 3,0 ]"
 
 elif [ "${TRANSFORMATIONTYPE}" == "GR_Constrained" ]
 then
 # Mapping Parameters for the greedy gradient descent (fast) version of SyN -- only needs GradientStepLength
-TRANSFORMATION=SyN[ 0.25]
-REGULARIZATION=Gauss[ 3,0.5]
+TRANSFORMATION="SyN[ 0.25 ]"
+REGULARIZATION="Gauss[ 3,0.5 ]"
 
 elif [ "${TRANSFORMATIONTYPE}" == "EX" ]
 then
 # Mapping Parameters
-TRANSFORMATION=Exp[ 0.5,10]
-REGULARIZATION=Gauss[ 3,0.5]
+TRANSFORMATION="Exp[ 0.5,10 ]"
+REGULARIZATION="Gauss[ 3,0.5 ]"
 
 elif [ "${TRANSFORMATIONTYPE}" == "DD" ]
 then
 # Mapping Parameters for diffemorphic demons style optimization Exp[GradientStepLength,NTimePointsInIntegration]
 #  NTimePointsInIntegration controls the number of compositions in the transformation update , see the DD paper
-TRANSFORMATION=GreedyExp[ 0.5,10]
-REGULARIZATION=Gauss[ 3,0.5]
+TRANSFORMATION="GreedyExp[ 0.5,10 ]"
+REGULARIZATION="Gauss[ 3,0.5 ]"
 
 else
 echo "Invalid transformation metric. Use RI, RA, EL, SY, S2, GR , DD or EX or type bash `basename $0` -h."
@@ -502,25 +502,25 @@ if [ "${METRICTYPE}" == "PR" ]
 then
 # Mapping Parameters
 METRIC="PR[ "
-METRICPARAMS=1,4]
+METRICPARAMS="1,4 ]"
 
-elif [ "${METRICTYPE}" == "CC"  ]
+elif [ "${METRICTYPE}" == "CC" ]
 then
 # Mapping Parameters
 METRIC="CC[ "
-METRICPARAMS=1,5]
+METRICPARAMS="1,5 ]"
 
 elif [ "${METRICTYPE}" == "MI" ]
 then
 # Mapping Parameters
 METRIC="MI[ "
-METRICPARAMS=1,32]
+METRICPARAMS="1,32 ]"
 
 elif [ "${METRICTYPE}" == "MSQ" ]
 then
 # Mapping Parameters
 METRIC="MSQ[ "
-METRICPARAMS=1,0]
+METRICPARAMS="1,0 ]"
 
 else
 echo "Invalid similarity metric. Use CC, MI, MSQ or PR or type bash`basename $0` -h."
@@ -533,7 +533,7 @@ reportMappingParameters
 
 MOVINGBASE=` echo ${MOVING} | cut -d '.' -f 1 `
 
-if [ -f ${MOVINGBASE}.cfg  ] ;
+if [ -f ${MOVINGBASE}.cfg ] ;
 then
 rm -f ${MOVINGBASE}.cfg
 fi

--- a/Scripts/antsJointLabelFusion.sh
+++ b/Scripts/antsJointLabelFusion.sh
@@ -684,9 +684,9 @@ if [[ $DOQSUB -eq 0 ]];
 
         if [[ -z "${OUTPUT_POSTERIORS_FORMAT}" ]];
           then
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz ]"
           else
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT}]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT} ]"
           fi
 
         if [[ ${TARGET_MASK_IMAGE} == 'otsu' ]];
@@ -786,7 +786,7 @@ if [[ $DOQSUB -eq 1 ]];
 
         if [[ -z "${OUTPUT_POSTERIORS_FORMAT}" ]];
           then
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz ]"
           else
             jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT}]"
           fi
@@ -882,9 +882,9 @@ if [[ $DOQSUB -eq 4 ]];
 
         if [[ -z "${OUTPUT_POSTERIORS_FORMAT}" ]];
           then
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz ]"
           else
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT}]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT} ]"
           fi
 
         if [[ ${TARGET_MASK_IMAGE} == 'otsu' ]];
@@ -970,7 +970,7 @@ if [[ $DOQSUB -eq 2 ]];
 
         if [[ -z "${OUTPUT_POSTERIORS_FORMAT}" ]];
           then
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz ]"
           else
             jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT}]"
           fi
@@ -1070,7 +1070,7 @@ if [[ $DOQSUB -eq 3 ]];
 
         if [[ -z "${OUTPUT_POSTERIORS_FORMAT}" ]];
           then
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz ]"
           else
             jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT}]"
           fi
@@ -1173,9 +1173,9 @@ if [[ $DOQSUB -eq 5 ]];
 
         if [[ -z "${OUTPUT_POSTERIORS_FORMAT}" ]];
           then
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz ]"
           else
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT}]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT} ]"
           fi
 
         if [[ ${TARGET_MASK_IMAGE} == 'otsu' ]];

--- a/Scripts/antsJointLabelFusion2.sh
+++ b/Scripts/antsJointLabelFusion2.sh
@@ -833,10 +833,10 @@ for (( i = 0; i < ${#ATLAS_IMAGES[@]}; i++ ))
 
         INIT_OUTPUT_PREFIX=${OUTPUT_PREFIX}${BASENAME}_${i}_Init
 
-        registrationCallInit="${ANTSPATH}/antsRegistration -d 3 -v 1 -o $INIT_OUTPUT_PREFIX -r [ ${ATLAS_IMAGES[$i]},${TARGET_IMAGE},0]"
-        registrationCallInit="$registrationCallInit -t Rigid[ 0.15] -m MI[ ${ATLAS_IMAGES[$i]},${TARGET_IMAGE},1,32,Regular,0.25] -c [ 100x40x10,1e-6,10] -f 6x4x3 -s 3x2x1"
-        registrationCallInit="$registrationCallInit -t Similarity[ 0.15] -m MI[ ${ATLAS_IMAGES[$i]},${TARGET_IMAGE},1,32,Regular,0.25] -c [ 100x40x10,1e-6,10] -f 6x4x3 -s 3x2x1"
-        registrationCallInit="$registrationCallInit -t Affine[ 0.15] -m MI[ ${ATLAS_IMAGES[$i]},${TARGET_IMAGE},1,32,Regular,0.25] -c [ 100x40x10,1e-6,10] -f 6x4x3 -s 3x2x1  >> $logFile"
+        registrationCallInit="${ANTSPATH}/antsRegistration -d 3 -v 1 -o $INIT_OUTPUT_PREFIX -r [ ${ATLAS_IMAGES[$i]},${TARGET_IMAGE},0 ]"
+        registrationCallInit="$registrationCallInit -t Rigid[ 0.15 ] -m MI[ ${ATLAS_IMAGES[$i]},${TARGET_IMAGE},1,32,Regular,0.25 ] -c [ 100x40x10,1e-6,10 ] -f 6x4x3 -s 3x2x1"
+        registrationCallInit="$registrationCallInit -t Similarity[ 0.15 ] -m MI[ ${ATLAS_IMAGES[$i]},${TARGET_IMAGE},1,32,Regular,0.25 ] -c [ 100x40x10,1e-6,10 ] -f 6x4x3 -s 3x2x1"
+        registrationCallInit="$registrationCallInit -t Affine[ 0.15 ] -m MI[ ${ATLAS_IMAGES[$i]},${TARGET_IMAGE},1,32,Regular,0.25 ] -c [ 100x40x10,1e-6,10 ] -f 6x4x3 -s 3x2x1  >> $logFile"
 
         echo "$registrationCallInit" >> $qscript
 
@@ -865,17 +865,17 @@ for (( i = 0; i < ${#ATLAS_IMAGES[@]}; i++ ))
             PIECEWISE_OUTPUT_PREFIX=${OUTPUT_PREFIX}${BASENAME}_${i}_PiecewiseLabel${PIECEWISE_LABELS[$j]}_
 
             registrationCallPiecewise="${ANTSPATH}/antsRegistration -d 3 -v 1 -z 0 -o $PIECEWISE_OUTPUT_PREFIX -r ${INIT_OUTPUT_PREFIX}0GenericAffine.mat -x ${PIECEWISE_DILATED_MASKS[$j]}"
-            registrationCallPiecewise="$registrationCallPiecewise -t Rigid[ 0.15] -m MI[ ${ATLAS_IMAGES[$i]},${TARGET_IMAGE},1,32,Regular,0.25] -c [ 100x100x50,1e-6,10] -f 6x4x3 -s 3x2x1"
-            registrationCallPiecewise="$registrationCallPiecewise -t Similarity[ 0.15] -m MI[ ${ATLAS_IMAGES[$i]},${TARGET_IMAGE},1,32,Regular,0.25] -c [ 100x100x50,1e-6,10] -f 6x4x3 -s 3x2x1"
-            registrationCallPiecewise="$registrationCallPiecewise -t Affine[ 0.15] -m MI[ ${ATLAS_IMAGES[$i]},${TARGET_IMAGE},1,32,Regular,0.25] -c [ 100x100x50,1e-6,10] -f 6x4x3 -s 3x2x1"
-            registrationCallPiecewise="$registrationCallPiecewise -t BSplineSyN[ 0.15,40,0] -m MI[ ${ATLAS_IMAGES[$i]},${TARGET_IMAGE},1,32,Regular,0.25] -c [ 100x40x0,1e-6,10] -f 6x4x1 -s 3x2x0  >> $logFile"
+            registrationCallPiecewise="$registrationCallPiecewise -t Rigid[ 0.15 ] -m MI[ ${ATLAS_IMAGES[$i]},${TARGET_IMAGE},1,32,Regular,0.25 ] -c [ 100x100x50,1e-6,10 ] -f 6x4x3 -s 3x2x1"
+            registrationCallPiecewise="$registrationCallPiecewise -t Similarity[ 0.15 ] -m MI[ ${ATLAS_IMAGES[$i]},${TARGET_IMAGE},1,32,Regular,0.25 ] -c [ 100x100x50,1e-6,10 ] -f 6x4x3 -s 3x2x1"
+            registrationCallPiecewise="$registrationCallPiecewise -t Affine[ 0.15 ] -m MI[ ${ATLAS_IMAGES[$i]},${TARGET_IMAGE},1,32,Regular,0.25 ] -c [ 100x100x50,1e-6,10 ] -f 6x4x3 -s 3x2x1"
+            registrationCallPiecewise="$registrationCallPiecewise -t BSplineSyN[ 0.15,40,0 ] -m MI[ ${ATLAS_IMAGES[$i]},${TARGET_IMAGE},1,32,Regular,0.25 ] -c [ 100x40x0,1e-6,10 ] -f 6x4x1 -s 3x2x0  >> $logFile"
 
             echo "$registrationCallPiecewise" >> $qscript
 
             composeCallPiecewise="$WARP \
                                  -d ${DIM} \
                                  -v 1 \
-                                 -o [ ${PIECEWISE_OUTPUT_PREFIX}TotalWarp.nii.gz,1] \
+                                 -o [ ${PIECEWISE_OUTPUT_PREFIX}TotalWarp.nii.gz,1 ] \
                                  -r ${ATLAS_IMAGES[$i]} \
                                  -t ${PIECEWISE_OUTPUT_PREFIX}4Warp.nii.gz \
                                  -t ${PIECEWISE_OUTPUT_PREFIX}3Affine.mat \
@@ -918,7 +918,7 @@ for (( i = 0; i < ${#ATLAS_IMAGES[@]}; i++ ))
         # Compose all the piecewise warps
 
         composeCall="${WARP} -d ${DIM} -v 1 \
-                         -o [ ${OUTPUT_PREFIX}${BASENAME}_${i}_TotalWarp.nii.gz,1] \
+                         -o [ ${OUTPUT_PREFIX}${BASENAME}_${i}_TotalWarp.nii.gz,1 ] \
                          -r ${SUBSET_CONFIDENCE_MASK} \
                          ${PIECEWISE_TRANSFORM_WARPS} >> $logFile"
         echo "$composeCall" >> $qscript
@@ -933,13 +933,13 @@ for (( i = 0; i < ${#ATLAS_IMAGES[@]}; i++ ))
         # Resample to the full size
 
         xfrmForwardCall="${WARP} -d ${DIM} -v 1 \
-                         -o [ ${OUTPUT_PREFIX}${BASENAME}_${i}_TotalWarp.nii.gz,1] \
+                         -o [ ${OUTPUT_PREFIX}${BASENAME}_${i}_TotalWarp.nii.gz,1 ] \
                          -r ${ATLAS_IMAGES[$i]} \
                          -t ${OUTPUT_PREFIX}${BASENAME}_${i}_TotalWarp.nii.gz >> $logFile"
         echo "$xfrmForwardCall" >> $qscript
 
         xfrmInverseCall="${WARP} -d ${DIM} -v 1 \
-                         -o [ ${OUTPUT_PREFIX}${BASENAME}_${i}_TotalInverseWarp.nii.gz,1] \
+                         -o [ ${OUTPUT_PREFIX}${BASENAME}_${i}_TotalInverseWarp.nii.gz,1 ] \
                          -r ${ATLAS_IMAGES[$i]} \
                          -t ${OUTPUT_PREFIX}${BASENAME}_${i}_TotalInverseWarp.nii.gz >> $logFile"
         echo "$xfrmInverseCall" >> $qscript
@@ -947,7 +947,7 @@ for (( i = 0; i < ${#ATLAS_IMAGES[@]}; i++ ))
         # Now do a more refined registration
 
         registrationCallRefined="${ANTSPATH}/antsRegistration -d 3 -v 1 -z 0 -o ${OUTPUT_PREFIX}${BASENAME}_${i}_ -r ${OUTPUT_PREFIX}${BASENAME}_${i}_TotalWarp.nii.gz -r ${INIT_OUTPUT_PREFIX}0GenericAffine.mat -x ${CONFIDENCE_DILATED_MASK}"
-        registrationCallRefined="$registrationCallRefined -t BSplineSyN[ 0.15,40,0] -m CC[ ${ATLAS_IMAGES[$i]},${TARGET_IMAGE},1,2] -c [ 100x40x0,1e-6,10] -f 6x4x1 -s 2x1x0 >> $logFile"
+        registrationCallRefined="$registrationCallRefined -t BSplineSyN[ 0.15,40,0 ] -m CC[ ${ATLAS_IMAGES[$i]},${TARGET_IMAGE},1,2 ] -c [ 100x40x0,1e-6,10 ] -f 6x4x1 -s 2x1x0 >> $logFile"
 
         echo "$registrationCallRefined" >> $qscript
 
@@ -958,7 +958,7 @@ for (( i = 0; i < ${#ATLAS_IMAGES[@]}; i++ ))
                               -r ${TARGET_IMAGE} \
                               -o ${OUTPUT_PREFIX}${BASENAME}_${i}_Warped.nii.gz \
                               -n Linear \
-                              -t [ ${INIT_OUTPUT_PREFIX}0GenericAffine.mat,1] \
+                              -t [ ${INIT_OUTPUT_PREFIX}0GenericAffine.mat,1 ] \
                               -t ${OUTPUT_PREFIX}${BASENAME}_${i}_TotalInverseWarp.nii.gz \
                               -t ${OUTPUT_PREFIX}${BASENAME}_${i}_2InverseWarp.nii.gz >> ${OUTPUT_PREFIX}${BASENAME}_${i}_log.txt"
         echo "$atlasXfrmCall" >> $qscript
@@ -970,7 +970,7 @@ for (( i = 0; i < ${#ATLAS_IMAGES[@]}; i++ ))
                               -r ${TARGET_IMAGE} \
                               -o ${OUTPUT_PREFIX}${BASENAME}_${i}_WarpedLabels.nii.gz \
                               -n GenericLabel \
-                              -t [ ${INIT_OUTPUT_PREFIX}0GenericAffine.mat,1] \
+                              -t [ ${INIT_OUTPUT_PREFIX}0GenericAffine.mat,1 ] \
                               -t ${OUTPUT_PREFIX}${BASENAME}_${i}_TotalInverseWarp.nii.gz \
                               -t ${OUTPUT_PREFIX}${BASENAME}_${i}_2InverseWarp.nii.gz >> ${OUTPUT_PREFIX}${BASENAME}_${i}_log.txt"
         echo "$labelXfrmCall" >> $qscript
@@ -1083,9 +1083,9 @@ if [[ $DOQSUB -eq 0 ]];
 
         if [[ -z "${OUTPUT_POSTERIORS_FORMAT}" ]];
           then
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz ]"
           else
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT}]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT} ]"
           fi
 
         if [[ ${TARGET_MASK_IMAGE} == 'otsu' ]];
@@ -1185,7 +1185,7 @@ if [[ $DOQSUB -eq 1 ]];
 
         if [[ -z "${OUTPUT_POSTERIORS_FORMAT}" ]];
           then
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz ]"
           else
             jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT}]"
           fi
@@ -1286,7 +1286,7 @@ if [[ $DOQSUB -eq 4 ]];
 
         if [[ -z "${OUTPUT_POSTERIORS_FORMAT}" ]];
           then
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz ]"
           else
             jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT}]"
           fi
@@ -1374,7 +1374,7 @@ if [[ $DOQSUB -eq 2 ]];
 
         if [[ -z "${OUTPUT_POSTERIORS_FORMAT}" ]];
           then
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz ]"
           else
             jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT}]"
           fi
@@ -1474,7 +1474,7 @@ if [[ $DOQSUB -eq 3 ]];
 
         if [[ -z "${OUTPUT_POSTERIORS_FORMAT}" ]];
           then
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz ]"
           else
             jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT}]"
           fi
@@ -1577,9 +1577,9 @@ if [[ $DOQSUB -eq 5 ]];
 
         if [[ -z "${OUTPUT_POSTERIORS_FORMAT}" ]];
           then
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz ]"
           else
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT}]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT} ]"
           fi
 
         if [[ ${TARGET_MASK_IMAGE} == 'otsu' ]];

--- a/Scripts/antsLongitudinalCorticalThickness.sh
+++ b/Scripts/antsLongitudinalCorticalThickness.sh
@@ -371,7 +371,7 @@ FORMAT=${FORMAT%%d*}
 
 REPCHARACTER=''
 TOTAL_LENGTH=0
-if [ ${#FORMAT} -eq 2 ]
+if [[ ${#FORMAT} -eq 2 ]]
   then
     REPCHARACTER=${FORMAT:0:1}
     TOTAL_LENGTH=${FORMAT:1:1}
@@ -675,7 +675,7 @@ if [[ ! -f $SINGLE_SUBJECT_TEMPLATE ]];
          -n 1 \
          -r 1 \
          -l 1 \
-         -m CC[ 4] \
+         -m CC[ 4 ] \
          -t SyN \
          -y ${AFFINE_UPDATE_FULL} \
          ${TEMPLATE_Z_IMAGES} \
@@ -1026,7 +1026,7 @@ for (( i=0; i < ${#ANATOMICAL_IMAGES[@]}; i+=$NUMBER_OF_MODALITIES ))
             logCmd ${ANTSPATH}/antsApplyTransforms \
               -d ${DIMENSION} \
               -r ${REGISTRATION_TEMPLATE} \
-              -o [ ${OUTPUT_LOCAL_PREFIX}SubjectToGroupTemplateWarp.nii.gz,1] \
+              -o [ ${OUTPUT_LOCAL_PREFIX}SubjectToGroupTemplateWarp.nii.gz,1 ] \
               -t ${SINGLE_SUBJECT_ANTSCT_PREFIX}SubjectToTemplate1Warp.nii.gz \
               -t ${SINGLE_SUBJECT_ANTSCT_PREFIX}SubjectToTemplate0GenericAffine.mat \
               -t ${OUTPUT_LOCAL_PREFIX}SubjectToTemplate1Warp.nii.gz \
@@ -1038,7 +1038,7 @@ for (( i=0; i < ${#ANATOMICAL_IMAGES[@]}; i+=$NUMBER_OF_MODALITIES ))
             logCmd ${ANTSPATH}/antsApplyTransforms \
               -d ${DIMENSION} \
               -r ${ANATOMICAL_REFERENCE_IMAGE} \
-              -o [ ${OUTPUT_LOCAL_PREFIX}GroupTemplateToSubjectWarp.nii.gz,1] \
+              -o [ ${OUTPUT_LOCAL_PREFIX}GroupTemplateToSubjectWarp.nii.gz,1 ] \
               -t ${OUTPUT_LOCAL_PREFIX}TemplateToSubject1GenericAffine.mat \
               -t ${OUTPUT_LOCAL_PREFIX}TemplateToSubject0Warp.nii.gz \
               -t ${SINGLE_SUBJECT_ANTSCT_PREFIX}TemplateToSubject1GenericAffine.mat \

--- a/Scripts/antsLongitudinalCorticalThickness.sh
+++ b/Scripts/antsLongitudinalCorticalThickness.sh
@@ -185,10 +185,10 @@ PARAMETERS
 DEBUG_MODE=0
 
 function logCmd() {
-  cmd="$*"
+  cmd="$@"
   echo "BEGIN >>>>>>>>>>>>>>>>>>>>"
   echo $cmd
-  $cmd
+  ( "$@" )
 
   cmdExit=$?
 

--- a/Scripts/antsLongitudinalJointLabelFusion.sh
+++ b/Scripts/antsLongitudinalJointLabelFusion.sh
@@ -690,7 +690,7 @@ if [[ $DOQSUB -eq 0 ]];
 
         if [[ -z "${OUTPUT_POSTERIORS_FORMAT}" ]];
           then
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz ]"
           else
             jlfCall="${jlfCall}  -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT}]"
           fi
@@ -768,7 +768,7 @@ if [[ $DOQSUB -eq 0 ]];
             exit 1
           fi
 
-        jlfTimeCall="${ANTSPATH}/antsJointFusion -d ${DIM} -t $tImg -x $tMask -o [ ${OUTPUT_PREFIX}${j}_Labels.nii.gz,${OUTPUT_PREFIX}${j}_Intensity.nii.gz] --verbose 1 "
+        jlfTimeCall="${ANTSPATH}/antsJointFusion -d ${DIM} -t $tImg -x $tMask -o [ ${OUTPUT_PREFIX}${j}_Labels.nii.gz,${OUTPUT_PREFIX}${j}_Intensity.nii.gz ] --verbose 1 "
 
         for (( i = 0; i < ${#ATLAS_IMAGES[@]}; i++ ))
           do
@@ -882,7 +882,7 @@ if [[ $DOQSUB -eq 1 ]];
 
         if [[ -z "${OUTPUT_POSTERIORS_FORMAT}" ]];
           then
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz ]"
           else
             jlfCall="${jlfCall}  -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT}]"
           fi
@@ -1054,7 +1054,7 @@ if [[ $DOQSUB -eq 4 ]];
 
         if [[ -z "${OUTPUT_POSTERIORS_FORMAT}" ]];
           then
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz ]"
           else
             jlfCall="${jlfCall}  -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT}]"
           fi
@@ -1130,7 +1130,7 @@ if [[ $DOQSUB -eq 2 ]];
 
         if [[ -z "${OUTPUT_POSTERIORS_FORMAT}" ]];
           then
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz ]"
           else
             jlfCall="${jlfCall}  -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT}]"
           fi
@@ -1218,7 +1218,7 @@ if [[ $DOQSUB -eq 3 ]];
 
         if [[ -z "${OUTPUT_POSTERIORS_FORMAT}" ]];
           then
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz ]"
           else
             jlfCall="${jlfCall}  -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT}]"
           fi
@@ -1309,7 +1309,7 @@ if [[ $DOQSUB -eq 5 ]];
 
         if [[ -z "${OUTPUT_POSTERIORS_FORMAT}" ]];
           then
-            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz]"
+            jlfCall="${jlfCall} -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz ]"
           else
             jlfCall="${jlfCall}  -o [ ${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT}]"
           fi

--- a/Scripts/antsMultivariateTemplateConstruction.sh
+++ b/Scripts/antsMultivariateTemplateConstruction.sh
@@ -638,7 +638,7 @@ if [[ ${NINFILES} -eq 0 ]];
              # if there are more than 32 volumes in the time-series (in case they are smaller
 
              nfmribins=16
-            if [[ ${range} -gt 31  ]];
+            if [[ ${range} -gt 31 ]];
                 then
                 BINSIZE=$((${range} / ${nfmribins}))
                 j=1 # initialize counter j
@@ -680,7 +680,7 @@ if [[ ${NINFILES} -eq 0 ]];
                     let j++
                 done
             fi
-        elif [[ ${range} -gt ${nfmribins} && ${range} -lt 32  ]];
+        elif [[ ${range} -gt ${nfmribins} && ${range} -lt 32 ]];
             then
             for ((i = 0; i < ${nfmribins} ; i++))
                 do
@@ -1033,14 +1033,14 @@ if [[ "${TRANSFORMATIONTYPE}" == "EL" ]];
     # We did a large scale evaluation of SyN gradient parameters in normal brains and found 0.25 => 0.5 to perform best when
     # combined with default Gauss[3,0 ] regularization.    You would increase the gradient step in some cases, though, to make
     # the registration converge faster --- though oscillations occur if the step is too high and other instability might happen too.
-elif [[ "${TRANSFORMATIONTYPE}" == "S2"  ]];
+elif [[ "${TRANSFORMATIONTYPE}" == "S2" ]];
     then
     # Mapping Parameters for the LDDMM style SyN --- the params are SyN[ GradientStepLength,NTimeDiscretizationPoints,IntegrationTimeStep]
     # increasing IntegrationTimeStep increases accuracy in the diffeomorphism integration and takes more computation time.
     # NTimeDiscretizationPoints is set to 2 here
     TRANSFORMATION="SyN[ 1,2,0.05 ]"
     REGULARIZATION="Gauss[ 3,0. ]"
-elif [[ "${TRANSFORMATIONTYPE}" == "SY"  ]];
+elif [[ "${TRANSFORMATIONTYPE}" == "SY" ]];
     then
     # Mapping Parameters for the LDDMM style SyN --- the params are SyN[ GradientStepLength,NTimeDiscretizationPoints,IntegrationTimeStep]
     # increasing IntegrationTimeStep increases accuracy in the diffeomorphism integration and takes more computation time.
@@ -1049,7 +1049,7 @@ elif [[ "${TRANSFORMATIONTYPE}" == "SY"  ]];
     # the --geodesic option enables either 1 asymmetric gradient estimation or 2 symmetric gradient estimation (the default here )
     TRANSFORMATION="SyN[ 1,2,0.05 ] --geodesic 2"
     REGULARIZATION="Gauss[ 3,0. ]"
-elif [[ "${TRANSFORMATIONTYPE}" == "LDDMM"  ]];
+elif [[ "${TRANSFORMATIONTYPE}" == "LDDMM" ]];
    then
    # Mapping Parameters for the LDDMM style SyN --- the params are SyN[ GradientStepLength,NTimeDiscretizationPoints,IntegrationTimeStep]
    # increasing IntegrationTimeStep increases accuracy in the diffeomorphism integration and takes more computation time.

--- a/Scripts/antsMultivariateTemplateConstruction.sh
+++ b/Scripts/antsMultivariateTemplateConstruction.sh
@@ -599,7 +599,7 @@ if [[ ${NINFILES} -eq 0 ]];
             done
          done < $IMAGESFILE
     else
-        range=`${ANTSPATH}/ImageMath $TDIM abs nvols ${IMAGESETVARIABLE} | tail -1 | cut -d "," -f 4 | cut -d " " -f 2 | cut -d "]" -f 1 `
+        range=`${ANTSPATH}/ImageMath $TDIM abs nvols ${IMAGESETVARIABLE} | tail -1 | cut -d "," -f 4 | cut -d " " -f 2 | cut -d " ]" -f 1 `
         if [[ ${range} -eq 1 && ${TDIM} -ne 4 ]];
             then
             echo "Please provide at least 2 filenames for the template."
@@ -792,7 +792,7 @@ if [[ "$RIGID" -eq 1 ]];
             do
             k=0
             let k=$i+$j
-            IMAGEMETRICSET="$IMAGEMETRICSET -m MI[ ${TEMPLATES[$j]},${IMAGESETARRAY[$k]},${MODALITYWEIGHTS[$j]},32]"
+            IMAGEMETRICSET="$IMAGEMETRICSET -m MI[ ${TEMPLATES[$j]},${IMAGESETARRAY[$k]},${MODALITYWEIGHTS[$j]},32 ]"
         done
 
         qscript="${outdir}/job_${count}_qsub.sh"
@@ -1027,19 +1027,19 @@ REGULARIZATION=''
 if [[ "${TRANSFORMATIONTYPE}" == "EL" ]];
     then
     # Mapping Parameters
-    TRANSFORMATION=Elast[ 1]
-    REGULARIZATION=Gauss[ 3,0.5]
-    # Gauss[3,x] is usually the best option.    x is usually 0 for SyN --- if you want to reduce flexibility/increase mapping smoothness, the set x > 0.
+    TRANSFORMATION="Elast[ 1 ]"
+    REGULARIZATION="Gauss[ 3,0.5 ]"
+    # Gauss[3,x ] is usually the best option.    x is usually 0 for SyN --- if you want to reduce flexibility/increase mapping smoothness, the set x > 0.
     # We did a large scale evaluation of SyN gradient parameters in normal brains and found 0.25 => 0.5 to perform best when
-    # combined with default Gauss[3,0] regularization.    You would increase the gradient step in some cases, though, to make
+    # combined with default Gauss[3,0 ] regularization.    You would increase the gradient step in some cases, though, to make
     # the registration converge faster --- though oscillations occur if the step is too high and other instability might happen too.
 elif [[ "${TRANSFORMATIONTYPE}" == "S2"  ]];
     then
     # Mapping Parameters for the LDDMM style SyN --- the params are SyN[ GradientStepLength,NTimeDiscretizationPoints,IntegrationTimeStep]
     # increasing IntegrationTimeStep increases accuracy in the diffeomorphism integration and takes more computation time.
     # NTimeDiscretizationPoints is set to 2 here
-    TRANSFORMATION=SyN[ 1,2,0.05]
-    REGULARIZATION=Gauss[ 3,0.]
+    TRANSFORMATION="SyN[ 1,2,0.05 ]"
+    REGULARIZATION="Gauss[ 3,0. ]"
 elif [[ "${TRANSFORMATIONTYPE}" == "SY"  ]];
     then
     # Mapping Parameters for the LDDMM style SyN --- the params are SyN[ GradientStepLength,NTimeDiscretizationPoints,IntegrationTimeStep]
@@ -1047,8 +1047,8 @@ elif [[ "${TRANSFORMATIONTYPE}" == "SY"  ]];
     # NTimeDiscretizationPoints is the number of spatial indices in the time dimension (the 4th dim when doing 3D registration)
     # increasing NTimeDiscretizationPoints increases flexibility and takes more computation time.
     # the --geodesic option enables either 1 asymmetric gradient estimation or 2 symmetric gradient estimation (the default here )
-    TRANSFORMATION=" SyN[1,2,0.05] --geodesic 2 "
-    REGULARIZATION=Gauss[ 3,0.]
+    TRANSFORMATION="SyN[ 1,2,0.05 ] --geodesic 2"
+    REGULARIZATION="Gauss[ 3,0. ]"
 elif [[ "${TRANSFORMATIONTYPE}" == "LDDMM"  ]];
    then
    # Mapping Parameters for the LDDMM style SyN --- the params are SyN[ GradientStepLength,NTimeDiscretizationPoints,IntegrationTimeStep]
@@ -1056,30 +1056,30 @@ elif [[ "${TRANSFORMATIONTYPE}" == "LDDMM"  ]];
    # NTimeDiscretizationPoints is the number of spatial indices in the time dimension (the 4th dim when doing 3D registration)
    # increasing NTimeDiscretizationPoints increases flexibility and takes more computation time.
    # the --geodesic option enables either 1 asymmetric gradient estimation or 2 symmetric gradient estimation (the default here )
-   TRANSFORMATION=" SyN[1,2,0.05] --geodesic 1 "
-   REGULARIZATION=Gauss[ 3,0.]
+   TRANSFORMATION="SyN[1,2,0.05 ] --geodesic 1"
+   REGULARIZATION="Gauss[ 3,0. ]"
 elif [[ "${TRANSFORMATIONTYPE}" == "GR" ]];
     then
     # Mapping Parameters for the greedy gradient descent (fast) version of SyN -- only needs GradientStepLength
-    TRANSFORMATION=SyN[ 0.25]
-    REGULARIZATION=Gauss[ 3,0]
+    TRANSFORMATION="SyN[ 0.25 ]"
+    REGULARIZATION="Gauss[ 3,0 ]"
 elif [[ "${TRANSFORMATIONTYPE}" == "GR_Constrained" ]];
     then
     # Mapping Parameters for the greedy gradient descent (fast) version of SyN -- only needs GradientStepLength
-    TRANSFORMATION=SyN[ 0.25]
-    REGULARIZATION=Gauss[ 3,0.5]
+    TRANSFORMATION="SyN[ 0.25 ]"
+    REGULARIZATION="Gauss[ 3,0.5 ]"
 
 elif [[ "${TRANSFORMATIONTYPE}" == "EX" ]];
     then
     # Mapping Parameters
-    TRANSFORMATION=Exp[ 0.5,10]
-    REGULARIZATION=Gauss[ 3,0.5]
+    TRANSFORMATION="Exp[ 0.5,10 ]"
+    REGULARIZATION="Gauss[ 3,0.5 ]"
 elif [[ "${TRANSFORMATIONTYPE}" == "DD" ]];
     then
     # Mapping Parameters for diffemorphic demons style optimization Exp[GradientStepLength,NTimePointsInIntegration]
     #  NTimePointsInIntegration controls the number of compositions in the transformation update , see the DD paper
-    TRANSFORMATION=GreedyExp[ 0.5,10]
-    REGULARIZATION=Gauss[ 3,0.5]
+    TRANSFORMATION="GreedyExp[ 0.5,10 ]"
+    REGULARIZATION="Gauss[ 3,0.5 ]"
 else
     echo "Invalid transformation metric. Use EL, SY, S2, GR , DD or EX or type bash `basename $0` -h."
     exit 1
@@ -1133,22 +1133,22 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
                 then
                 # Mapping Parameters
                 METRIC="PR[ "
-                METRICPARAMS="${MODALITYWEIGHTS[$k]},4]"
-            elif [[ "${METRICTYPE[$k]}" == "CC"  ]];
+                METRICPARAMS="${MODALITYWEIGHTS[$k]},4 ]"
+            elif [[ "${METRICTYPE[$k]}" == "CC" ]];
                 then
                 # Mapping Parameters
                 METRIC="CC[ "
-                METRICPARAMS="${MODALITYWEIGHTS[$k]},5]"
+                METRICPARAMS="${MODALITYWEIGHTS[$k]},5 ]"
             elif [[ "${METRICTYPE[$k]}" == "MI" ]];
                 then
                 # Mapping Parameters
                 METRIC="MI[ "
-                METRICPARAMS="${MODALITYWEIGHTS[$k]},32]"
+                METRICPARAMS="${MODALITYWEIGHTS[$k]},32 ]"
             elif [[ "${METRICTYPE[$k]}" == "MSQ" ]];
                 then
                 # Mapping Parameters
                 METRIC="MSQ[ "
-                METRICPARAMS="${MODALITYWEIGHTS[$k]},0]"
+                METRICPARAMS="${MODALITYWEIGHTS[$k]},0 ]"
             else
                 echo "Invalid similarity metric. Use CC, MI, MSQ or PR or type bash `basename $0` -h."
                 exit 1
@@ -1174,8 +1174,8 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
             if [[ $N4CORRECT -eq 1 ]];
               then
                 REPAIRED="${outdir}/${OUTFN}Repaired.nii.gz"
-                exe=" $exe $N4 -d ${DIM} -b [ 200] -c [ 50x50x40x30,0.00000001] -i ${IMAGESETARRAY[$l]} -o ${REPAIRED} -r 0 -s 2\n"
-                pexe=" $pexe $N4 -d ${DIM} -b [ 200] -c [ 50x50x40x30,0.00000001] -i ${IMAGESETARRAY[$l]} -o ${REPAIRED} -r 0 -s 2  >> ${outdir}/job_${count}_metriclog.txt\n"
+                exe=" $exe $N4 -d ${DIM} -b [ 200 ] -c [ 50x50x40x30,0.00000001 ] -i ${IMAGESETARRAY[$l]} -o ${REPAIRED} -r 0 -s 2\n"
+                pexe=" $pexe $N4 -d ${DIM} -b [ 200 ] -c [ 50x50x40x30,0.00000001 ] -i ${IMAGESETARRAY[$l]} -o ${REPAIRED} -r 0 -s 2  >> ${outdir}/job_${count}_metriclog.txt\n"
                 IMAGEMETRICSET="$IMAGEMETRICSET -m ${METRIC}${TEMPLATES[$k]},${REPAIRED},${METRICPARAMS}"
                 warpexe=" $warpexe ${WARP} ${DIM} ${REPAIRED} ${DEFORMED} -R ${TEMPLATES[$k]} ${outdir}/${OUTWARPFN}Warp.nii.gz ${outdir}/${OUTWARPFN}Affine.txt\n"
                 warppexe=" $warppexe ${WARP} ${DIM} ${REPAIRED} ${DEFORMED} -R ${TEMPLATES[$k]} ${outdir}/${OUTWARPFN}Warp.nii.gz ${outdir}/${OUTWARPFN}Affine.txt >> ${outdir}/job_${count}_metriclog.txt\n"

--- a/Scripts/antsMultivariateTemplateConstruction2.sh
+++ b/Scripts/antsMultivariateTemplateConstruction2.sh
@@ -325,7 +325,7 @@ function shapeupdatetotemplate() {
     echo "--------------------------------------------------------------------------------------"
 
     imagelist=(`ls ${outputname}template${whichtemplate}*WarpedToTemplate.nii.gz`)
-    if [[ ${#imagelist[@]} -eq 0  ]] ; then
+    if [[ ${#imagelist[@]} -eq 0 ]] ; then
       echo ERROR shapeupdatedtotemplate - imagelist length is 0
       exit 1
     fi
@@ -852,7 +852,7 @@ elif [[ ${NINFILES} -eq 1 ]];
              # if there are more than 32 volumes in the time-series (in case they are smaller
 
              nfmribins=16
-            if [[ ${range} -gt 31  ]];
+            if [[ ${range} -gt 31 ]];
               then
                 BINSIZE=$((${range} / ${nfmribins}))
                 j=1 # initialize counter j
@@ -894,7 +894,7 @@ elif [[ ${NINFILES} -eq 1 ]];
                     let j++
                 done
             fi
-        elif [[ ${range} -gt ${nfmribins} && ${range} -lt 32  ]];
+        elif [[ ${range} -gt ${nfmribins} && ${range} -lt 32 ]];
             then
             for ((i = 0; i < ${nfmribins} ; i++))
                 do

--- a/Scripts/antsMultivariateTemplateConstruction2.sh
+++ b/Scripts/antsMultivariateTemplateConstruction2.sh
@@ -158,7 +158,7 @@ Optional arguments:
             MSQ = mean square difference
             DEMONS = demon's metric
           A similarity metric per modality can be specified.  If the CC metric is chosen,
-          one can also specify the radius in brackets, e.g. '-m CC[ 4]'.
+          one can also specify the radius in brackets, e.g. '-m CC[ 4 ]'.
 
      -t:  Type of transformation model used for registration (default = SyN):  Options are
             SyN = Greedy SyN
@@ -364,28 +364,28 @@ function shapeupdatetotemplate() {
         echo " shapeupdatetotemplate---average the affine transforms (template <-> subject)"
         echo "                      ---transform the inverse field by the resulting average affine transform"
         echo "   ${ANTSPATH}/${AVERAGE_AFFINE_PROGRAM} ${dim} ${templatename}0GenericAffine.mat ${outputname}*GenericAffine.mat"
-        echo "   ${WARP} -d ${dim} -e vector -i ${templatename}0warp.nii.gz -o ${templatename}0warp.nii.gz -t [ ${templatename}0GenericAffine.mat,1] -r ${template} --verbose 1"
+        echo "   ${WARP} -d ${dim} -e vector -i ${templatename}0warp.nii.gz -o ${templatename}0warp.nii.gz -t [ ${templatename}0GenericAffine.mat,1 ] -r ${template} --verbose 1"
         echo "--------------------------------------------------------------------------------------"
 
         ${ANTSPATH}/${AVERAGE_AFFINE_PROGRAM} ${dim} ${templatename}0GenericAffine.mat ${outputname}*GenericAffine.mat
 
         if [[ $NWARPS -ne 0 ]];
           then
-            ${WARP} -d ${dim} -e vector -i ${templatename}0warp.nii.gz -o ${templatename}0warp.nii.gz -t [ ${templatename}0GenericAffine.mat,1] -r ${template} --verbose 1
+            ${WARP} -d ${dim} -e vector -i ${templatename}0warp.nii.gz -o ${templatename}0warp.nii.gz -t [ ${templatename}0GenericAffine.mat,1 ] -r ${template} --verbose 1
             ${ANTSPATH}/MeasureMinMaxMean ${dim} ${templatename}0warp.nii.gz ${templatename}warplog.txt 1
           fi
       fi
 
     echo "--------------------------------------------------------------------------------------"
     echo " shapeupdatetotemplate---warp each template by the resulting transforms"
-    echo "   ${WARP} -d ${dim} --float $USEFLOAT --verbose 1 -i ${template} -o ${template} -t [ ${templatename}0GenericAffine.mat,1] -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -r ${template}"
+    echo "   ${WARP} -d ${dim} --float $USEFLOAT --verbose 1 -i ${template} -o ${template} -t [ ${templatename}0GenericAffine.mat,1 ] -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -r ${template}"
     echo "--------------------------------------------------------------------------------------"
 
-    if [ -f "${templatename}0warp.nii.gz" ];
+    if [[ -f "${templatename}0warp.nii.gz" ]];
       then
-        ${WARP} -d ${dim} --float $USEFLOAT --verbose 1 -i ${template} -o ${template} -t [ ${templatename}0GenericAffine.mat,1] -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -r ${template}
+        ${WARP} -d ${dim} --float $USEFLOAT --verbose 1 -i ${template} -o ${template} -t [ ${templatename}0GenericAffine.mat,1 ] -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -r ${template}
       else
-        ${WARP} -d ${dim} --float $USEFLOAT --verbose 1 -i ${template} -o ${template} -t [ ${templatename}0GenericAffine.mat,1] -r ${template}
+        ${WARP} -d ${dim} --float $USEFLOAT --verbose 1 -i ${template} -o ${template} -t [ ${templatename}0GenericAffine.mat,1 ] -r ${template}
       fi
 
 }
@@ -642,7 +642,7 @@ if [[ ! -d $OUTPUT_DIR ]];
 if [[ $DOQSUB -eq 1 || $DOQSUB -eq 4 ]];
   then
     qq=`which  qsub`
-    if [[  ${#qq} -lt 1 ]];
+    if [[ ${#qq} -lt 1 ]];
       then
         echo "do you have qsub?  if not, then choose another c option ... if so, then check where the qsub alias points ..."
         exit
@@ -699,14 +699,16 @@ if [[ ! -n "$MODALITYWEIGHTSTRING" ]];
 
 
 TRANSFORMATION=''
-
+# Allow SyN[step] or SyN[ step ]
+# Users should use the latter to avoid glob problems, but but don't want force that
+#
 if [[ $TRANSFORMATIONTYPE == "BSplineSyN"* ]];
   then
     if [[ $TRANSFORMATIONTYPE == "BSplineSyN["*"]" ]]
       then
         TRANSFORMATION=${TRANSFORMATIONTYPE}
       else
-        TRANSFORMATION=BSplineSyN[ 0.1,26,0,3]
+        TRANSFORMATION="BSplineSyN[ 0.1,26,0,3 ]"
     fi
 elif [[ $TRANSFORMATIONTYPE == "SyN"* ]];
   then
@@ -714,7 +716,7 @@ elif [[ $TRANSFORMATIONTYPE == "SyN"* ]];
       then
         TRANSFORMATION=${TRANSFORMATIONTYPE}
       else
-        TRANSFORMATION=SyN[ 0.1,3,0]
+        TRANSFORMATION="SyN[ 0.1,3,0 ]"
     fi
 elif [[ $TRANSFORMATIONTYPE == "TimeVaryingVelocityField"* ]];
   then
@@ -722,7 +724,7 @@ elif [[ $TRANSFORMATIONTYPE == "TimeVaryingVelocityField"* ]];
       then
         TRANSFORMATION=${TRANSFORMATIONTYPE}
       else
-        TRANSFORMATION=TimeVaryingVelocityField[ 0.5,4,3,0,0,0]
+        TRANSFORMATION="TimeVaryingVelocityField[ 0.5,4,3,0,0,0 ]"
     fi
 elif [[ $TRANSFORMATIONTYPE == "TimeVaryingBSplineVelocityField"* ]];
   then
@@ -730,7 +732,7 @@ elif [[ $TRANSFORMATIONTYPE == "TimeVaryingBSplineVelocityField"* ]];
       then
         TRANSFORMATION=${TRANSFORMATIONTYPE}
       else
-        TRANSFORMATION=TimeVaryingVelocityField[ 0.5,12x12x12x2,4,3]
+        TRANSFORMATION="TimeVaryingVelocityField[ 0.5,12x12x12x2,4,3 ]"
     fi
 elif [[ $TRANSFORMATIONTYPE == "Affine"* ]];
   then
@@ -740,7 +742,7 @@ elif [[ $TRANSFORMATIONTYPE == "Affine"* ]];
       then
         TRANSFORMATION=${TRANSFORMATIONTYPE}
       else
-        TRANSFORMATION=Affine[ 0.1]
+        TRANSFORMATION="Affine[ 0.1 ]"
     fi
 elif [[ $TRANSFORMATIONTYPE == "Rigid"* ]];
   then
@@ -750,7 +752,7 @@ elif [[ $TRANSFORMATIONTYPE == "Rigid"* ]];
       then
         TRANSFORMATION=${TRANSFORMATIONTYPE}
       else
-        TRANSFORMATION=Rigid[ 0.1]
+        TRANSFORMATION="Rigid[ 0.1 ]"
     fi
 else
   echo "Invalid transformation. See `basename $0` -h for help menu."
@@ -811,7 +813,7 @@ elif [[ ${NINFILES} -eq 1 ]];
             done
          done < $IMAGESFILE
     else
-        range=`${ANTSPATH}/ImageMath $TDIM abs nvols ${IMAGESETVARIABLE} | tail -1 | cut -d "," -f 4 | cut -d " " -f 2 | cut -d "]" -f 1 `
+        range=`${ANTSPATH}/ImageMath $TDIM abs nvols ${IMAGESETVARIABLE} | tail -1 | cut -d "," -f 4 | cut -d " " -f 2 | cut -d " ]" -f 1 `
         if [[ ${range} -eq 1 && ${TDIM} -ne 4 ]];
           then
             echo "Please provide at least 2 filenames for the template."
@@ -976,7 +978,7 @@ for (( i = 0; i < $NUMBEROFMODALITIES; i++ ))
 
     if [[ ! -s ${TEMPLATES[$i]} ]];
       then
-        echo "Your initial template : $TEMPLATES[$i] was not created.  This indicates trouble!  You may want to check correctness of your input parameters. exiting."
+        echo "Your initial template : $TEMPLATES[$i ] was not created.  This indicates trouble!  You may want to check correctness of your input parameters. exiting."
         exit 1
       fi
 done
@@ -1003,18 +1005,18 @@ if [[ "$RIGID" -eq 1 ]];
     for (( i = 0; i < ${#IMAGESETARRAY[@]}; i+=$NUMBEROFMODALITIES ))
       do
 
-        basecall="${ANTS} -d ${DIM} --float $USEFLOAT --verbose 1 -u 1 -w [ 0.01,0.99] -z 1 -r [ ${TEMPLATES[0]},${IMAGESETARRAY[$i]},1]"
+        basecall="${ANTS} -d ${DIM} --float $USEFLOAT --verbose 1 -u 1 -w [ 0.01,0.99 ] -z 1 -r [ ${TEMPLATES[0]},${IMAGESETARRAY[$i]},1 ]"
 
         IMAGEMETRICSET=""
         for (( j = 0; j < $NUMBEROFMODALITIES; j++ ))
           do
             k=0
             let k=$i+$j
-            IMAGEMETRICSET="$IMAGEMETRICSET -m MI[ ${TEMPLATES[$j]},${IMAGESETARRAY[$k]},${MODALITYWEIGHTS[$j]},32,Regular,0.25]"
+            IMAGEMETRICSET="$IMAGEMETRICSET -m MI[ ${TEMPLATES[$j]},${IMAGESETARRAY[$k]},${MODALITYWEIGHTS[$j]},32,Regular,0.25 ]"
           done
 
-        stage1="-t Rigid[ 0.1] ${IMAGEMETRICSET} -c [ 1000x500x250x0,1e-6,10] -f 6x4x2x1 -s 3x2x1x0 -o ${outdir}/rigid${i}_"
-        #stage1="-t Rigid[ 0.1] ${IMAGEMETRICSET} -c [ 10x10x10x10,1e-8,10] -f 8x4x2x1 -s 4x2x1x0 -o ${outdir}/rigid${i}_"
+        stage1="-t Rigid[ 0.1 ] ${IMAGEMETRICSET} -c [ 1000x500x250x0,1e-6,10 ] -f 6x4x2x1 -s 3x2x1x0 -o ${outdir}/rigid${i}_"
+        #stage1="-t Rigid[ 0.1 ] ${IMAGEMETRICSET} -c [ 10x10x10x10,1e-8,10 ] -f 8x4x2x1 -s 4x2x1x0 -o ${outdir}/rigid${i}_"
         exe="${basecall} ${stage1}"
 
         qscript="${outdir}/job_${count}_qsub.sh"
@@ -1274,7 +1276,7 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
 
     for (( j = 0; j < ${#IMAGESETARRAY[@]}; j+=$NUMBEROFMODALITIES ))
       do
-        basecall="${ANTS} -d ${DIM} --float $USEFLOAT --verbose 1 -u 1 -w [ 0.01,0.99] -z 1"
+        basecall="${ANTS} -d ${DIM} --float $USEFLOAT --verbose 1 -u 1 -w [ 0.01,0.99 ] -z 1"
 
         IMAGEMETRICLINEARSET=''
         IMAGEMETRICSET=''
@@ -1292,8 +1294,8 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
               then
                 # Mapping Parameters
                 METRIC="Demons[ "
-                METRICPARAMS="${MODALITYWEIGHTS[$k]},4]"
-            elif [[ "${METRICTYPE[$k]}" == CC*  ]];
+                METRICPARAMS="${MODALITYWEIGHTS[$k]},4 ]"
+            elif [[ "${METRICTYPE[$k]}" == CC* ]];
               then
                 METRIC="CC[ "
                 RADIUS=4
@@ -1302,17 +1304,17 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
                     RADIUS=${METRICTYPE[$k]%]*}
                     RADIUS=${RADIUS##*[}
                   fi
-                METRICPARAMS="${MODALITYWEIGHTS[$k]},${RADIUS}]"
+                METRICPARAMS="${MODALITYWEIGHTS[$k]},${RADIUS} ]"
             elif [[ "${METRICTYPE[$k]}" == "MI" ]];
               then
                 # Mapping Parameters
                 METRIC="MI[ "
-                METRICPARAMS="${MODALITYWEIGHTS[$k]},32]"
+                METRICPARAMS="${MODALITYWEIGHTS[$k]},32 ]"
             elif [[ "${METRICTYPE[$k]}" == "MSQ" ]];
               then
                 # Mapping Parameters
                 METRIC="MeanSquares[ "
-                METRICPARAMS="${MODALITYWEIGHTS[$k]},0]"
+                METRICPARAMS="${MODALITYWEIGHTS[$k]},0 ]"
             else
               echo "Invalid similarity metric. Use CC, MI, MSQ, DEMONS or type bash `basename $0` -h."
               exit 1
@@ -1333,7 +1335,7 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
             OUTWARPFN=`basename ${OUTWARPFN}`
             OUTWARPFN="${OUTWARPFN}${j}"
 
-            if [ $NOWARP -eq 0 ];
+            if [[ $NOWARP -eq 0 ]];
               then
                 OUTPUTTRANSFORMS="-t ${outdir}/${OUTWARPFN}1Warp.nii.gz -t ${outdir}/${OUTWARPFN}0GenericAffine.mat"
               else
@@ -1343,17 +1345,17 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
             if [[ $N4CORRECT -eq 1 ]];
               then
                 REPAIRED="${outdir}/${OUTFN}Repaired.nii.gz"
-                exe=" $exe $N4 -d ${DIM} -b [ 200] -c [ 50x50x40x30,0.00000001] -i ${IMAGESETARRAY[$l]} -o ${REPAIRED} -r 0 -s 2 --verbose 1\n"
-                pexe=" $pexe $N4 -d ${DIM} -b [ 200] -c [ 50x50x40x30,0.00000001] -i ${IMAGESETARRAY[$l]} -o ${REPAIRED} -r 0 -s 2 --verbose 1  >> ${outdir}/job_${count}_metriclog.txt >> ${outdir}/job_${count}_metriclog.txt\n"
+                exe=" $exe $N4 -d ${DIM} -b [ 200 ] -c [ 50x50x40x30,0.00000001 ] -i ${IMAGESETARRAY[$l]} -o ${REPAIRED} -r 0 -s 2 --verbose 1\n"
+                pexe=" $pexe $N4 -d ${DIM} -b [ 200 ] -c [ 50x50x40x30,0.00000001 ] -i ${IMAGESETARRAY[$l]} -o ${REPAIRED} -r 0 -s 2 --verbose 1  >> ${outdir}/job_${count}_metriclog.txt >> ${outdir}/job_${count}_metriclog.txt\n"
 
                 IMAGEMETRICSET="$IMAGEMETRICSET -m ${METRIC}${TEMPLATES[$k]},${REPAIRED},${METRICPARAMS}"
-                IMAGEMETRICLINEARSET="$IMAGEMETRICLINEARSET -m MI[ ${TEMPLATES[$k]},${REPAIRED},${MODALITYWEIGHTS[$k]},32,Regular,0.25]"
+                IMAGEMETRICLINEARSET="$IMAGEMETRICLINEARSET -m MI[ ${TEMPLATES[$k]},${REPAIRED},${MODALITYWEIGHTS[$k]},32,Regular,0.25 ]"
 
                 warpexe=" $warpexe ${WARP} -d ${DIM} --float $USEFLOAT --verbose 1 -i ${REPAIRED} -o ${DEFORMED} -r ${TEMPLATES[$k]} ${OUTPUTTRANSFORMS}\n"
                 warppexe=" $warppexe ${WARP} -d ${DIM} --float $USEFLOAT --verbose 1 -i ${REPAIRED} -o ${DEFORMED} -r ${TEMPLATES[$k]} ${OUTPUTTRANSFORMS} >> ${outdir}/job_${count}_metriclog.txt\n"
               else
                 IMAGEMETRICSET="$IMAGEMETRICSET -m ${METRIC}${TEMPLATES[$k]},${IMAGESETARRAY[$l]},${METRICPARAMS}"
-                IMAGEMETRICLINEARSET="$IMAGEMETRICLINEARSET -m MI[ ${TEMPLATES[$k]},${IMAGESETARRAY[$l]},${MODALITYWEIGHTS[$k]},32,Regular,0.25]"
+                IMAGEMETRICLINEARSET="$IMAGEMETRICLINEARSET -m MI[ ${TEMPLATES[$k]},${IMAGESETARRAY[$l]},${MODALITYWEIGHTS[$k]},32,Regular,0.25 ]"
 
                 warpexe=" $warpexe ${WARP} -d ${DIM} --float $USEFLOAT --verbose 1 -i ${IMAGESETARRAY[$l]} -o ${DEFORMED} -r ${TEMPLATES[$k]} ${OUTPUTTRANSFORMS}\n"
                 warppexe=" $warppexe ${WARP} -d ${DIM} --float $USEFLOAT --verbose 1 -i ${IMAGESETARRAY[$l]} -o ${DEFORMED} -r ${TEMPLATES[$k]} ${OUTPUTTRANSFORMS} >> ${outdir}/job_${count}_metriclog.txt\n"
@@ -1365,14 +1367,14 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
         OUTWARPFN=${OUTPUTNAME}${IMGbase/%?(.nii.gz|.nii)}
         OUTWARPFN=`basename ${OUTWARPFN}${j}`
 
-        stage0="-r [ ${TEMPLATES[0]},${IMAGESETARRAY[$j]},1]"
-        stage1="-t Rigid[ 0.1] ${IMAGEMETRICLINEARSET} -c [ 1000x500x250x0,1e-6,10] -f 6x4x2x1 -s 4x2x1x0"
-        stage2="-t Affine[ 0.1] ${IMAGEMETRICLINEARSET} -c [ 1000x500x250x0,1e-6,10] -f 6x4x2x1 -s 4x2x1x0"
-        #stage1="-t Rigid[ 0.1] ${IMAGEMETRICLINEARSET} -c [ 10x10x10x10,1e-8,10] -f 8x4x2x1 -s 4x2x1x0"
-        #stage2="-t Affine[ 0.1] ${IMAGEMETRICLINEARSET} -c [ 10x10x10x10,1e-8,10] -f 8x4x2x1 -s 4x2x1x0"
-        stage3="-t ${TRANSFORMATION} ${IMAGEMETRICSET} -c [ ${MAXITERATIONS},1e-9,10] -f ${SHRINKFACTORS} -s ${SMOOTHINGFACTORS} -o ${outdir}/${OUTWARPFN}"
+        stage0="-r [ ${TEMPLATES[0]},${IMAGESETARRAY[$j]},1 ]"
+        stage1="-t Rigid[ 0.1 ] ${IMAGEMETRICLINEARSET} -c [ 1000x500x250x0,1e-6,10 ] -f 6x4x2x1 -s 4x2x1x0"
+        stage2="-t Affine[ 0.1 ] ${IMAGEMETRICLINEARSET} -c [ 1000x500x250x0,1e-6,10 ] -f 6x4x2x1 -s 4x2x1x0"
+        #stage1="-t Rigid[ 0.1 ] ${IMAGEMETRICLINEARSET} -c [ 10x10x10x10,1e-8,10 ] -f 8x4x2x1 -s 4x2x1x0"
+        #stage2="-t Affine[ 0.1 ] ${IMAGEMETRICLINEARSET} -c [ 10x10x10x10,1e-8,10 ] -f 8x4x2x1 -s 4x2x1x0"
+        stage3="-t ${TRANSFORMATION} ${IMAGEMETRICSET} -c [ ${MAXITERATIONS},1e-9,10 ] -f ${SHRINKFACTORS} -s ${SMOOTHINGFACTORS} -o ${outdir}/${OUTWARPFN}"
 
-        stageId="-t Rigid[ 0.1] ${IMAGEMETRICLINEARSET} -c [ 0,1e-8,10] -f 1 -s 0"
+        stageId="-t Rigid[ 0.1 ] ${IMAGEMETRICLINEARSET} -c [ 0,1e-8,10 ] -f 1 -s 0"
         exebase=$exe
         pexebase=$pexe
 

--- a/Scripts/antsNeuroimagingBattery
+++ b/Scripts/antsNeuroimagingBattery
@@ -338,13 +338,13 @@ for my $paslfile ( @$paslfiles ) {
       my $m0Moco1 = "${ANTSPATH}/antsMotionCorr -d 3 -a $m0file -o $meanM0";
       system($m0Moco1);
 
-      my $m0Moco2 = "${ANTSPATH}/antsMotionCorr -d 3 -o [ ${outdir}${dirname}${outname}${outid}m0, $M0, $meanM0 ] -u 1 -m mi[ $meanM0, $m0file, 1, 32, Regular, 0.1 ] -t Affine[0.2] -i 25 -e 1 -f 1 -s 0 -l 0";
+      my $m0Moco2 = "${ANTSPATH}/antsMotionCorr -d 3 -o [ ${outdir}${dirname}${outname}${outid}m0, $M0, $meanM0 ] -u 1 -m mi[ $meanM0, $m0file, 1, 32, Regular, 0.1 ] -t Affine[ 0.2 ] -i 25 -e 1 -f 1 -s 0 -l 0";
       print( "$m0Moco2\n");
       system( $m0Moco2 );
 
     #my $pasl = "${outdir}${dirname}${outname}${outid}pasl.nii.gz";
     #my $meanpasl = "${outdir}${dirname}${outname}${outid}meanpasl.nii.gz";
-    #my $paslMoco = "antsMotionCorr -d 3 -o [ ${outdir}${dirname}${outname}${outid}pasl, $pasl, $meanpasl ] -u 1 -m mi[ $meanM0, $paslfile, 1, 32, Regular, 0.1 ] -t Affine[0.2] -i 25 -e 1 -f 1 -s 0 -l 0";
+    #my $paslMoco = "antsMotionCorr -d 3 -o [ ${outdir}${dirname}${outname}${outid}pasl, $pasl, $meanpasl ] -u 1 -m mi[ $meanM0, $paslfile, 1, 32, Regular, 0.1 ] -t Affine[ 0.2 ] -i 25 -e 1 -f 1 -s 0 -l 0";
     #print("$paslMoco\n");
     #system($paslMoco);
 
@@ -440,7 +440,7 @@ for my $rsboldfile ( @$rsboldfiles ) {
   # Motion correction
   system("${ANTSPATH}/antsMotionCorr -d 3 -a $rsboldfile -o $meanbold");
   print("${ANTSPATH}/antsMotionCorr -d 3 -o [ ${obase}, $bold, $meanbold ] -u 1 -m mi[ $meanbold, $rsboldfile, 1, 32, Regular, 0.1 ] -t Affine[0.2] -i 25 -e 1 -f 1 -s 0 -l 0 -u 1 \n");
-  system("${ANTSPATH}/antsMotionCorr -d 3 -o [ ${obase}, $bold, $meanbold ] -m mi[ $meanbold, $rsboldfile, 1, 32, Regular, 0.1 ] -t Affine[0.2] -i 25 -e 1 -f 1 -s 0 -l 0 -u 1");
+  system("${ANTSPATH}/antsMotionCorr -d 3 -o [ ${obase}, $bold, $meanbold ] -m mi[ $meanbold, $rsboldfile, 1, 32, Regular, 0.1 ] -t Affine[ 0.2 ] -i 25 -e 1 -f 1 -s 0 -l 0 -u 1");
 
 
   system("${ANTSPATH}/ImageMath 3 $ref m $anat $mask" );

--- a/Scripts/antsRegistrationSpaceTime.sh
+++ b/Scripts/antsRegistrationSpaceTime.sh
@@ -371,7 +371,7 @@ ImageMath $DIMP1 $stacktemplate SetTimeSpacing $stacktemplate $timespacing
 if [[ $DIM == 2 ]] ; then rxt="1x1x0"; fi
 if [[ $DIM == 3 ]] ; then rxt="1x1x1x0"; fi
 antsMotionCorr  -d $DIM \
-  -o [ ${nm}aff, ${nm}aff.nii.gz,${nm}_affavg.nii.gz] \
+  -o [ ${nm}aff, ${nm}aff.nii.gz,${nm}_affavg.nii.gz ] \
   -m MI[ ${FIXEDIMAGES}, ${stack}, 1 , 20, Regular, 0.1 ] \
   -t rigid[ 0.1 ] -u 1 -e 1 -s 4x2x1x0 -f 6x4x2x1 \
   -i 100x100x0x0 \
@@ -384,12 +384,12 @@ ImageMath $DIMP1 ${nm}affInverseWarp.nii.gz SetTimeSpacingWarp ${nm}affInverseWa
 # if below does not work - have to drop the -r
 # and put the aff version into the metric
 antsRegistration -d $DIMP1 -r ${nm}affWarp.nii.gz  \
- -c [ 100x70x50x10,1e-6,10] \
+ -c [ 100x70x50x10,1e-6,10 ] \
  -f 6x4x2x1               \
  -s 3x2x1x0vox            \
  -m CC[ $stacktemplate, ${nm}stack.nii.gz, 1, 2 ] \
- -t SyN[ 0.15,3,0] --restrict-deformation $rxt \
- -o [ ${nm},${nm}diffeoWarped.nii.gz,${nm}diffeoInvWarped.nii.gz] -z 0
+ -t SyN[ 0.15,3,0 ] --restrict-deformation $rxt \
+ -o [ ${nm},${nm}diffeoWarped.nii.gz,${nm}diffeoInvWarped.nii.gz ] -z 0
  CreateJacobianDeterminantImage $DIMP1 ${nm}1Warp.nii.gz ${nm}0logjacobian.nii.gz 1 1
 ###############################
 #

--- a/Scripts/antsRegistrationSyN.sh
+++ b/Scripts/antsRegistrationSyN.sh
@@ -381,7 +381,7 @@ if [[ ${#MASKIMAGES[@]} -gt 0 ]];
   then
     for (( i = 0; i < ${#MASKIMAGES[@]}; i++ ))
       do
-        MASKCALL="${MASKCALL} -x [ ${MASKIMAGES[$i]}, NULL]"
+        MASKCALL="${MASKCALL} -x [ ${MASKIMAGES[$i]}, NULL ]"
       done
   fi
 
@@ -444,34 +444,34 @@ for (( i=0; i<${#SIZE[@]}; i++ ))
 #
 ##############################
 
-RIGIDCONVERGENCE="[ 1000x500x250x100,1e-6,10]"
+RIGIDCONVERGENCE="[ 1000x500x250x100,1e-6,10 ]"
 RIGIDSHRINKFACTORS="8x4x2x1"
 RIGIDSMOOTHINGSIGMAS="3x2x1x0vox"
 
-AFFINECONVERGENCE="[ 1000x500x250x100,1e-6,10]"
+AFFINECONVERGENCE="[ 1000x500x250x100,1e-6,10 ]"
 AFFINESHRINKFACTORS="8x4x2x1"
 AFFINESMOOTHINGSIGMAS="3x2x1x0vox"
 
-SYNCONVERGENCE="[ 100x70x50x20,1e-6,10]"
+SYNCONVERGENCE="[ 100x70x50x20,1e-6,10 ]"
 SYNSHRINKFACTORS="8x4x2x1"
 SYNSMOOTHINGSIGMAS="3x2x1x0vox"
 
 if [[ $ISLARGEIMAGE -eq 1 ]];
   then
-    RIGIDCONVERGENCE="[ 1000x500x250x100,1e-6,10]"
+    RIGIDCONVERGENCE="[ 1000x500x250x100,1e-6,10 ]"
     RIGIDSHRINKFACTORS="12x8x4x2"
     RIGIDSMOOTHINGSIGMAS="4x3x2x1vox"
 
-    AFFINECONVERGENCE="[ 1000x500x250x100,1e-6,10]"
+    AFFINECONVERGENCE="[ 1000x500x250x100,1e-6,10 ]"
     AFFINESHRINKFACTORS="12x8x4x2"
     AFFINESMOOTHINGSIGMAS="4x3x2x1vox"
 
-    SYNCONVERGENCE="[ 100x100x70x50x20,1e-6,10]"
+    SYNCONVERGENCE="[ 100x100x70x50x20,1e-6,10 ]"
     SYNSHRINKFACTORS="10x6x4x2x1"
     SYNSMOOTHINGSIGMAS="5x3x2x1x0vox"
   fi
 
-INITIALSTAGE="--initial-moving-transform [ ${FIXEDIMAGES[0]},${MOVINGIMAGES[0]},1]"
+INITIALSTAGE="--initial-moving-transform [ ${FIXEDIMAGES[0]},${MOVINGIMAGES[0]},1 ]"
 
 if [[ ${#INITIALTRANSFORMS[@]} -gt 0 ]];
   then
@@ -487,14 +487,14 @@ if [[ $TRANSFORMTYPE == 't' ]] ; then
   tx=Translation
 fi
 
-RIGIDSTAGE="--transform ${tx}[0.1] \
-            --metric MI[ ${FIXEDIMAGES[0]},${MOVINGIMAGES[0]},1,32,Regular,0.25] \
+RIGIDSTAGE="--transform ${tx}[0.1 ] \
+            --metric MI[ ${FIXEDIMAGES[0]},${MOVINGIMAGES[0]},1,32,Regular,0.25 ] \
             --convergence $RIGIDCONVERGENCE \
             --shrink-factors $RIGIDSHRINKFACTORS \
             --smoothing-sigmas $RIGIDSMOOTHINGSIGMAS"
 
-AFFINESTAGE="--transform Affine[ 0.1] \
-             --metric MI[ ${FIXEDIMAGES[0]},${MOVINGIMAGES[0]},1,32,Regular,0.25] \
+AFFINESTAGE="--transform Affine[ 0.1 ] \
+             --metric MI[ ${FIXEDIMAGES[0]},${MOVINGIMAGES[0]},1,32,Regular,0.25 ] \
              --convergence $AFFINECONVERGENCE \
              --shrink-factors $AFFINESHRINKFACTORS \
              --smoothing-sigmas $AFFINESMOOTHINGSIGMAS"
@@ -512,7 +512,7 @@ SYNSTAGE="${SYNMETRICS} \
 
 if [[ $TRANSFORMTYPE == 'sr' ]] || [[ $TRANSFORMTYPE == 'br' ]];
   then
-    SYNCONVERGENCE="[ 50x0,1e-6,10]"
+    SYNCONVERGENCE="[ 50x0,1e-6,10 ]"
     SYNSHRINKFACTORS="2x1"
     SYNSMOOTHINGSIGMAS="1x0vox"
           SYNSTAGE="${SYNMETRICS} \
@@ -523,13 +523,13 @@ if [[ $TRANSFORMTYPE == 'sr' ]] || [[ $TRANSFORMTYPE == 'br' ]];
 
 if [[ $TRANSFORMTYPE == 'b' ]] || [[ $TRANSFORMTYPE == 'br' ]] || [[ $TRANSFORMTYPE == 'bo' ]];
   then
-    SYNSTAGE="--transform BSplineSyN[ 0.1,${SPLINEDISTANCE},0,3] \
+    SYNSTAGE="--transform BSplineSyN[ 0.1,${SPLINEDISTANCE},0,3 ] \
              $SYNSTAGE"
   fi
 
 if [[ $TRANSFORMTYPE == 's' ]] || [[ $TRANSFORMTYPE == 'sr' ]] || [[ $TRANSFORMTYPE == 'so' ]];
   then
-    SYNSTAGE="--transform SyN[ 0.1,3,0] \
+    SYNSTAGE="--transform SyN[ 0.1,3,0 ] \
              $SYNSTAGE"
   fi
 
@@ -591,10 +591,10 @@ fi
 COMMAND="${ANTS} --verbose 1 $RANDOMOPT \
                  --dimensionality $DIM $PRECISION \
                  --collapse-output-transforms $COLLAPSEOUTPUTTRANSFORMS \
-                 --output [ $OUTPUTNAME,${OUTPUTNAME}Warped.nii.gz,${OUTPUTNAME}InverseWarped.nii.gz] \
+                 --output [ $OUTPUTNAME,${OUTPUTNAME}Warped.nii.gz,${OUTPUTNAME}InverseWarped.nii.gz ] \
                  --interpolation Linear \
                  --use-histogram-matching ${USEHISTOGRAMMATCHING} \
-                 --winsorize-image-intensities [ 0.005,0.995] \
+                 --winsorize-image-intensities [ 0.005,0.995 ] \
                  $MASKCALL \
                  $STAGES"
 

--- a/Scripts/antsRegistrationSyN.sh
+++ b/Scripts/antsRegistrationSyN.sh
@@ -487,7 +487,7 @@ if [[ $TRANSFORMTYPE == 't' ]] ; then
   tx=Translation
 fi
 
-RIGIDSTAGE="--transform ${tx}[0.1 ] \
+RIGIDSTAGE="--transform ${tx}[ 0.1 ] \
             --metric MI[ ${FIXEDIMAGES[0]},${MOVINGIMAGES[0]},1,32,Regular,0.25 ] \
             --convergence $RIGIDCONVERGENCE \
             --shrink-factors $RIGIDSHRINKFACTORS \
@@ -502,7 +502,7 @@ AFFINESTAGE="--transform Affine[ 0.1 ] \
 SYNMETRICS=''
 for(( i=0; i<${#FIXEDIMAGES[@]}; i++ ))
   do
-    SYNMETRICS="$SYNMETRICS --metric CC[ ${FIXEDIMAGES[$i]},${MOVINGIMAGES[$i]},1,${CCRADIUS}]"
+    SYNMETRICS="$SYNMETRICS --metric CC[ ${FIXEDIMAGES[$i]},${MOVINGIMAGES[$i]},1,${CCRADIUS} ]"
   done
 
 SYNSTAGE="${SYNMETRICS} \

--- a/Scripts/antsRegistrationSyNQuick.sh
+++ b/Scripts/antsRegistrationSyNQuick.sh
@@ -381,7 +381,7 @@ if [[ ${#MASKIMAGES[@]} -gt 0 ]];
   then
     for (( i = 0; i < ${#MASKIMAGES[@]}; i++ ))
       do
-        MASKCALL="${MASKCALL} -x [ ${MASKIMAGES[$i]}, NULL]"
+        MASKCALL="${MASKCALL} -x [ ${MASKIMAGES[$i]}, NULL ]"
       done
   fi
 
@@ -444,34 +444,34 @@ for (( i=0; i<${#SIZE[@]}; i++ ))
 #
 ##############################
 
-RIGIDCONVERGENCE="[ 1000x500x250x0,1e-6,10]"
+RIGIDCONVERGENCE="[ 1000x500x250x0,1e-6,10 ]"
 RIGIDSHRINKFACTORS="8x4x2x1"
 RIGIDSMOOTHINGSIGMAS="3x2x1x0vox"
 
-AFFINECONVERGENCE="[ 1000x500x250x0,1e-6,10]"
+AFFINECONVERGENCE="[ 1000x500x250x0,1e-6,10 ]"
 AFFINESHRINKFACTORS="8x4x2x1"
 AFFINESMOOTHINGSIGMAS="3x2x1x0vox"
 
-SYNCONVERGENCE="[ 100x70x50x0,1e-6,10]"
+SYNCONVERGENCE="[ 100x70x50x0,1e-6,10 ]"
 SYNSHRINKFACTORS="8x4x2x1"
 SYNSMOOTHINGSIGMAS="3x2x1x0vox"
 
 if [[ $ISLARGEIMAGE -eq 1 ]];
   then
-    RIGIDCONVERGENCE="[ 1000x500x250x0,1e-6,10]"
+    RIGIDCONVERGENCE="[ 1000x500x250x0,1e-6,10 ]"
     RIGIDSHRINKFACTORS="12x8x4x2"
     RIGIDSMOOTHINGSIGMAS="4x3x2x1vox"
 
-    AFFINECONVERGENCE="[ 1000x500x250x0,1e-6,10]"
+    AFFINECONVERGENCE="[ 1000x500x250x0,1e-6,10 ]"
     AFFINESHRINKFACTORS="12x8x4x2"
     AFFINESMOOTHINGSIGMAS="4x3x2x1vox"
 
-    SYNCONVERGENCE="[ 100x100x70x50x0,1e-6,10]"
+    SYNCONVERGENCE="[ 100x100x70x50x0,1e-6,10 ]"
     SYNSHRINKFACTORS="10x6x4x2x1"
     SYNSMOOTHINGSIGMAS="5x3x2x1x0vox"
   fi
 
-INITIALSTAGE="--initial-moving-transform [ ${FIXEDIMAGES[0]},${MOVINGIMAGES[0]},1]"
+INITIALSTAGE="--initial-moving-transform [ ${FIXEDIMAGES[0]},${MOVINGIMAGES[0]},1 ]"
 
 if [[ ${#INITIALTRANSFORMS[@]} -gt 0 ]];
   then
@@ -487,14 +487,14 @@ if [[ $TRANSFORMTYPE == 't' ]] ; then
   tx=Translation
 fi
 
-RIGIDSTAGE="--transform ${tx}[0.1] \
-            --metric MI[ ${FIXEDIMAGES[0]},${MOVINGIMAGES[0]},1,32,Regular,0.25] \
+RIGIDSTAGE="--transform ${tx}[0.1 ] \
+            --metric MI[ ${FIXEDIMAGES[0]},${MOVINGIMAGES[0]},1,32,Regular,0.25 ] \
             --convergence $RIGIDCONVERGENCE \
             --shrink-factors $RIGIDSHRINKFACTORS \
             --smoothing-sigmas $RIGIDSMOOTHINGSIGMAS"
 
-AFFINESTAGE="--transform Affine[ 0.1] \
-             --metric MI[ ${FIXEDIMAGES[0]},${MOVINGIMAGES[0]},1,32,Regular,0.25] \
+AFFINESTAGE="--transform Affine[ 0.1 ] \
+             --metric MI[ ${FIXEDIMAGES[0]},${MOVINGIMAGES[0]},1,32,Regular,0.25 ] \
              --convergence $AFFINECONVERGENCE \
              --shrink-factors $AFFINESHRINKFACTORS \
              --smoothing-sigmas $AFFINESMOOTHINGSIGMAS"
@@ -512,7 +512,7 @@ SYNSTAGE="${SYNMETRICS} \
 
 if [[ $TRANSFORMTYPE == 'sr' ]] || [[ $TRANSFORMTYPE == 'br' ]];
   then
-    SYNCONVERGENCE="[ 50x0,1e-6,10]"
+    SYNCONVERGENCE="[ 50x0,1e-6,10 ]"
     SYNSHRINKFACTORS="2x1"
     SYNSMOOTHINGSIGMAS="1x0vox"
           SYNSTAGE="${SYNMETRICS} \
@@ -523,13 +523,13 @@ if [[ $TRANSFORMTYPE == 'sr' ]] || [[ $TRANSFORMTYPE == 'br' ]];
 
 if [[ $TRANSFORMTYPE == 'b' ]] || [[ $TRANSFORMTYPE == 'br' ]] || [[ $TRANSFORMTYPE == 'bo' ]];
   then
-    SYNSTAGE="--transform BSplineSyN[ 0.1,${SPLINEDISTANCE},0,3] \
+    SYNSTAGE="--transform BSplineSyN[ 0.1,${SPLINEDISTANCE},0,3 ] \
              $SYNSTAGE"
   fi
 
 if [[ $TRANSFORMTYPE == 's' ]] || [[ $TRANSFORMTYPE == 'sr' ]] || [[ $TRANSFORMTYPE == 'so' ]];
   then
-    SYNSTAGE="--transform SyN[ 0.1,3,0] \
+    SYNSTAGE="--transform SyN[ 0.1,3,0 ] \
              $SYNSTAGE"
   fi
 
@@ -591,10 +591,10 @@ fi
 COMMAND="${ANTS} --verbose 1 $RANDOMOPT \
                  --dimensionality $DIM $PRECISION \
                  --collapse-output-transforms $COLLAPSEOUTPUTTRANSFORMS \
-                 --output [ $OUTPUTNAME,${OUTPUTNAME}Warped.nii.gz,${OUTPUTNAME}InverseWarped.nii.gz] \
+                 --output [ $OUTPUTNAME,${OUTPUTNAME}Warped.nii.gz,${OUTPUTNAME}InverseWarped.nii.gz ] \
                  --interpolation Linear \
                  --use-histogram-matching ${USEHISTOGRAMMATCHING} \
-                 --winsorize-image-intensities [ 0.005,0.995] \
+                 --winsorize-image-intensities [ 0.005,0.995 ] \
                  $MASKCALL \
                  $STAGES"
 

--- a/Scripts/antsRegistrationSyNQuick.sh
+++ b/Scripts/antsRegistrationSyNQuick.sh
@@ -487,7 +487,7 @@ if [[ $TRANSFORMTYPE == 't' ]] ; then
   tx=Translation
 fi
 
-RIGIDSTAGE="--transform ${tx}[0.1 ] \
+RIGIDSTAGE="--transform ${tx}[ 0.1 ] \
             --metric MI[ ${FIXEDIMAGES[0]},${MOVINGIMAGES[0]},1,32,Regular,0.25 ] \
             --convergence $RIGIDCONVERGENCE \
             --shrink-factors $RIGIDSHRINKFACTORS \

--- a/Scripts/antsaffine.sh
+++ b/Scripts/antsaffine.sh
@@ -75,7 +75,7 @@ echo  " ANTSPATH  is $ANTSPATH     "
  #below, some affine options
   #--MI-option 16x8000 #-a InitAffine.txt --continue-affine 0
 
-exe=" ${ANTSPATH}/ANTS $DIM -m  MI[ ${FIXED},${MOVING},1,32] -o ${OUTPUTNAME}   -i 0   --use-Histogram-Matching --number-of-affine-iterations 10000x10000x10000x10000x10000  $RIGID   "
+exe=" ${ANTSPATH}/ANTS $DIM -m  MI[ ${FIXED},${MOVING},1,32 ] -o ${OUTPUTNAME}   -i 0   --use-Histogram-Matching --number-of-affine-iterations 10000x10000x10000x10000x10000  $RIGID   "
 
  echo " $exe "
 

--- a/Scripts/antsaffine.sh
+++ b/Scripts/antsaffine.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
-if [ ${#ANTSPATH} -le 3 ] ; then
-  echo we guess at your ants path
-  export ANTSPATH=${ANTSPATH:="$HOME/bin/ants/"} # EDIT THIS
+
+if [[ -z ${ANTSPATH} ]] ; then
+  echo "Environment variable ANTSPATH must be defined"
+  exit 1
 fi
-if [ ! -s ${ANTSPATH}/ANTS ] ; then
-  echo we cant find the ANTS program -- does not seem to exist.  please \(re\)define \$ANTSPATH in your environment.
-  exit
+if [[ ! -f "${ANTSPATH}/ANTS" ]] ; then
+  echo "Cannot find the ANTS program. Please \(re\)define \$ANTSPATH in your environment."
+  exit 1
 fi
 
 NUMPARAMS=$#
 
-if [ $NUMPARAMS -lt 3  ]
+if [ $NUMPARAMS -lt 3 ]
 then
 echo " USAGE ::  "
 echo "  sh   antsaffine.sh  ImageDimension  fixed.ext  moving.ext  OPTIONAL-OUTPREFIX   PURELY-RIGID  "
@@ -59,7 +60,7 @@ fi
 
 OUTPUTNAME=` echo $MOVING | cut -d '.' -f 1 `
 
-if [ $NUMPARAMS -gt 3  ]
+if [ $NUMPARAMS -gt 3 ]
 then
   OUTPUTNAME=${4}
 fi

--- a/Scripts/antsdeformationmag.sh
+++ b/Scripts/antsdeformationmag.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 NUMPARAMS=$#
-if [ $NUMPARAMS -lt 4  ]
+if [ $NUMPARAMS -lt 4 ]
 then
 echo " USAGE ::  "
 echo " $0   inWarp WhichTypeOfMagnitude outputmagnitudeimage.nii  ANTSPATH "

--- a/Scripts/antswithdt.sh
+++ b/Scripts/antswithdt.sh
@@ -4,7 +4,7 @@ NUMPARAMS=$#
 
 MAXITERATIONS=30x90x20
 export ANTSPATH=${ANTSPATH:="$HOME/bin/ants/"}
-if [ $NUMPARAMS -lt 3  ]
+if [ $NUMPARAMS -lt 3 ]
 then
 echo " USAGE ::  "
 echo "  sh   ants.sh  ImageDimension  fixed.ext  moving.ext Subject/Moving-DT-To-Deform-To-Fixed-Image  OPTIONAL-Subject/Moving-BZero-To-DistortionCorrect-To-Moving-T1-Image "
@@ -65,7 +65,7 @@ OUTPUTNAME=${MOVING%.*}
 fi
 
 MOVINGDT=0
-if [ $NUMPARAMS -gt 3  ]
+if [ $NUMPARAMS -gt 3 ]
 then
  MOVINGDT=$4
 if [ ! -f $MOVINGDT ]
@@ -76,7 +76,7 @@ fi
 fi
 
 MOVINGBZ=0
-if [ $NUMPARAMS -gt 4  ]
+if [ $NUMPARAMS -gt 4 ]
 then
  MOVINGBZ=$5
 if [ ! -f $MOVINGBZ ]
@@ -97,13 +97,13 @@ fi
 
 
 # Mapping Parameters
-  TRANSFORMATION=SyN[ 0.25]
+  TRANSFORMATION="SyN[ 0.25 ]"
   ITERATLEVEL=(`echo $MAXITERATIONS | tr 'x' ' '`)
   NUMLEVELS=${#ITERATLEVEL[@]}
   echo $NUMLEVELS
-  REGULARIZATION=Gauss[ 3,0]
+  REGULARIZATION="Gauss[ 3,0 ]"
   METRIC="CC[ "
-  METRICPARAMS=1,2]
+  METRICPARAMS="1,2 ]"
 #echo " $METRICPARAMS  &  $METRIC "
 #exit
 
@@ -133,7 +133,7 @@ if [[ ! -s ${OUTPUTNAME}Affine.txt ]] ; then
   sh ${ANTSPATH}/ants.sh $DIM $FIXED $MOVING ${OUTPUTNAME}
 fi
 
-if  [[ -s ${MOVINGDT}  ]] &&  [[  -s ${OUTPUTNAME}Affine.txt ]] ; then
+if  [[ -s ${MOVINGDT} ]] &&  [[  -s ${OUTPUTNAME}Affine.txt ]] ; then
     DTDEF=${OUTPUTNAME}DTdeformed.nii.gz
     FIXEDSUB=${OUTPUTNAME}fixedsub.nii.gz
 #    ${ANTSPATH}/ResampleImageBySpacing 3 $FIXED $FIXEDSUB 2 2 2

--- a/Scripts/antswithdt.sh
+++ b/Scripts/antswithdt.sh
@@ -124,7 +124,7 @@ echo " "
 
 # first, do distortion correction of MOVINGDT to MOVING
 # use the B0 image
-${ANTSPATH}/ANTS 3 -m CC[ ${MOVINGBZ},${MOVING},1,2]  -o ${OUTPUTNAME}distcorr  -r Gauss[ 3,0] -t SyN[ 0.25]  -i 25x20x0  --number-of-affine-iterations 10000x10000x10000
+${ANTSPATH}/ANTS 3 -m CC[ ${MOVINGBZ},${MOVING},1,2 ]  -o ${OUTPUTNAME}distcorr  -r Gauss[ 3,0 ] -t SyN[ 0.25 ]  -i 25x20x0  --number-of-affine-iterations 10000x10000x10000
 
 ${ANTSPATH}/WarpImageMultiTransform 3 $MOVING   ${OUTPUTNAME}distcorr.nii.gz ${OUTPUTNAME}distcorrWarp.nii.gz ${OUTPUTNAME}distcorrAffine.txt  -R $MOVINGBZ
 #exit

--- a/Scripts/asymmetry.sh
+++ b/Scripts/asymmetry.sh
@@ -50,8 +50,8 @@ if [[ ! -s $A ]] || [[  ! -s $B ]]  ; then echo inputs: $A $B $prefix ; echo $us
 reg=antsRegistration
 uval=0
 affits=999x999x1550x200
-rig=" -t rigid[ 0.2 ]  -c [ $affits ,1.e-7,20]  -s 3x2x1x0 -f 8x4x2x1 -u $uval -l 0 "
-aff=" -t affine[ 0.2 ]  -c [ $affits ,1.e-7,20]  -s 3x2x1x0 -f 8x4x2x1 -u $uval -l 0 "
+rig=" -t rigid[ 0.2 ]  -c [ $affits ,1.e-7,20 ]  -s 3x2x1x0 -f 8x4x2x1 -u $uval -l 0 "
+aff=" -t affine[ 0.2 ]  -c [ $affits ,1.e-7,20 ]  -s 3x2x1x0 -f 8x4x2x1 -u $uval -l 0 "
 metparams=" 1 , 32, regular , 0.5 "
 synits=220x220x100x50  #BA 
 # synits=0x0x0x0  #BA 
@@ -71,7 +71,7 @@ $reg -d $dim -r ${prefix}_init.mat\
 $reg -d $dim -r ${prefix}_L0GenericAffine.mat \
     -m mattes[ $imgs , 1 , 32 ] \
     -t $dtx \
-    -c [ ${synits},1.e-8,10]  \
+    -c [ ${synits},1.e-8,10 ]  \
     -s 3x2x1x0 \
     -f 8x4x2x1 \
     -u $uval -b 0 -z 1 \
@@ -80,7 +80,7 @@ $reg -d $dim -r ${prefix}_L0GenericAffine.mat \
 $reg -d $dim   -r  ${prefix}_reflection.mat -r ${prefix}_L0GenericAffine.mat \
     -m mattes[ $imgs , 1 , 32 ] \
     -t $dtx \
-    -c [ ${synits},1.e-8,10]  \
+    -c [ ${synits},1.e-8,10 ]  \
     -s 3x2x1x0 \
     -f 8x4x2x1 \
     -u $uval -b 0 -z 1 \

--- a/Scripts/basic_ants_example.sh
+++ b/Scripts/basic_ants_example.sh
@@ -41,16 +41,16 @@ fi
 ITS=" -i 100x100x30 " # 3 optimization levels
 
 # different transformation models you can choose
-TSYNWITHTIME=" -t SyN[ 0.25,5,0.01] -r DMFFD[ 10x10,0,3] " # spatiotemporal (full) diffeomorphism
-GGREEDYSYN=" -t SyN[ 0.15]  -r Gauss[ 3,0] " # fast symmetric normalization gaussian regularization
-BGREEDYSYN=" -t SyN[ 0.15]  -r DMFFD[ 4x4,0,3] " # fast symmetric normalization dmffd regularization
-TELAST=" -t Elast[ 1] -r Gauss[ 0.5,3] "             # elastic
-TEXP=" -t Exp[ 0.001,100] -r DMFFD[ 3,0] "            # exponential
+TSYNWITHTIME=" -t SyN[ 0.25,5,0.01 ] -r DMFFD[ 10x10,0,3 ] " # spatiotemporal (full) diffeomorphism
+GGREEDYSYN=" -t SyN[ 0.15 ]  -r Gauss[ 3,0 ] " # fast symmetric normalization gaussian regularization
+BGREEDYSYN=" -t SyN[ 0.15 ]  -r DMFFD[ 4x4,0,3 ] " # fast symmetric normalization dmffd regularization
+TELAST=" -t Elast[ 1 ] -r Gauss[ 0.5,3 ] "             # elastic
+TEXP=" -t Exp[ 0.001,100 ] -r DMFFD[ 3,0 ] "            # exponential
 
 # different metric choices for the user
-INTMSQ=" -m MSQ[ ${II},${JJ},1,0] "
-INTMI=" -m MI[ ${II},${JJ},1,16] "
-INTCC=" -m CC[ ${II},${JJ},1,4] "
+INTMSQ=" -m MSQ[ ${II},${JJ},1,0 ] "
+INTMI=" -m MI[ ${II},${JJ},1,16 ] "
+INTCC=" -m CC[ ${II},${JJ},1,4 ] "
 #
 #
 # these are the forward and backward warps.
@@ -80,11 +80,11 @@ JJSEG=${OUTPUTNAME}B_seg.nii.gz
 #
 ${ANTSPATH}/ThresholdImage $DIM $II $IISEG 1 1.e9
 ${ANTSPATH}/ThresholdImage $DIM $JJ $JJSEG 1 1.e9
-AtroposParams=" -d $DIM -m [ 0.1,1x1] -c [ 5,0] -i kmeans[ 3] "
+AtroposParams=" -d $DIM -m [ 0.1,1x1 ] -c [ 5,0 ] -i kmeans[ 3 ] "
 ${ANTSPATH}/Atropos $AtroposParams -a $II -o $IISEG  -x $IISEG
 ${ANTSPATH}/Atropos $AtroposParams -a $JJ -o $JJSEG  -x $JJSEG
 # compute some segmentations and use them in labelguided mapping
-LABELGUIDED=" -m PSE[ ${II},${JJ},${IISEG},${JJSEG},0.75,0.1,25,0,10] "
+LABELGUIDED=" -m PSE[ ${II},${JJ},${IISEG},${JJSEG},0.75,0.1,25,0,10 ] "
 #
 ${ANTSPATH}/ANTS $DIM -o ${OUTPUTNAME} $ITS $TRAN $INT $LABELGUIDED
 ${ANTSPATH}/WarpImageMultiTransform $DIM ${II} ${OUTPUTNAME}IItoJJ.nii.gz -R ${JJ} $INVW
@@ -106,11 +106,11 @@ JJSEG=${OUTPUTNAME}B_seg.nii.gz
 #
 ${ANTSPATH}/ThresholdImage $DIM $II $IISEG 1 1.e9
 ${ANTSPATH}/ThresholdImage $DIM $JJ $JJSEG 1 1.e9
-AtroposParams=" -d $DIM -m [ 0.1,1x1] -c [ 5,0] -i kmeans[ 3] "
+AtroposParams=" -d $DIM -m [ 0.1,1x1 ] -c [ 5,0 ] -i kmeans[ 3 ] "
 ${ANTSPATH}/Atropos $AtroposParams -a $II -o $IISEG  -x $IISEG
 ${ANTSPATH}/Atropos $AtroposParams -a $JJ -o $JJSEG  -x $JJSEG
 # compute some segmentations and use them in labelguided mapping
-LABELGUIDED=" -m MSQ[ ${IISEG},${JJSEG},0.75] "
+LABELGUIDED=" -m MSQ[ ${IISEG},${JJSEG},0.75 ] "
 #
 ${ANTSPATH}/ANTS $DIM -o ${OUTPUTNAME} $ITS $TRAN $INT $LABELGUIDED
 ${ANTSPATH}/WarpImageMultiTransform $DIM ${II} ${OUTPUTNAME}IItoJJ.nii.gz -R ${JJ} $INVW

--- a/Scripts/buildtemplateparallel.sh
+++ b/Scripts/buildtemplateparallel.sh
@@ -568,7 +568,7 @@ function ANTSAverage3DAffine {
 function jobfnamepadding {
 
     files=`ls job*.sh`
-    BASENAME1=`echo $files[1] | cut -d 'b' -f 1`
+    BASENAME1=`echo $files[1 ] | cut -d 'b' -f 1`
 
     for file in ${files}
       do
@@ -797,7 +797,7 @@ if [ ${NINFILES} -eq 0 ]
 elif [[ ${NINFILES} -eq 1 ]]
     then
 
-    range=`${ANTSPATH}/ImageMath $TDIM abs nvols ${IMAGESETVARIABLE} | tail -1 | cut -d "," -f 4 | cut -d " " -f 2 | cut -d "]" -f 1 `
+    range=`${ANTSPATH}/ImageMath $TDIM abs nvols ${IMAGESETVARIABLE} | tail -1 | cut -d "," -f 4 | cut -d " " -f 2 | cut -d " ]" -f 1 `
 
     if [ ${range} -eq 1 ] && [ ${TDIM} -ne 4 ]
 	then
@@ -958,7 +958,7 @@ if [ "$RIGID" -eq 1 ] ;
 
       BASENAME=` echo ${IMG} | cut -d '.' -f 1 `
 
-      exe=" ${ANTSPATH}/ANTS $DIM -m MI[ ${TEMPLATE},${IMG},1,32] -o rigid_${IMG} -i 0 --use-Histogram-Matching --number-of-affine-iterations 10000x10000x10000x10000x10000 $RIGIDTYPE"
+      exe=" ${ANTSPATH}/ANTS $DIM -m MI[ ${TEMPLATE},${IMG},1,32 ] -o rigid_${IMG} -i 0 --use-Histogram-Matching --number-of-affine-iterations 10000x10000x10000x10000x10000 $RIGIDTYPE"
       exe2="${ANTSPATH}/WarpImageMultiTransform $DIM ${IMG} rigid_${IMG} rigid_${BASENAME}Affine${afftype} -R ${TEMPLATE}"
       pexe=" $exe >> job_${count}_metriclog.txt "
 

--- a/Scripts/buildtemplateparallel.sh
+++ b/Scripts/buildtemplateparallel.sh
@@ -51,7 +51,7 @@ SLURM=${ANTSPATH}/waitForSlurmJobs.pl
 fle_error=0
 for FLE in $ANTSSCRIPTNAME $PEXEC $SGE $XGRID $SLURM
   do
-  if [ ! -x $FLE  ] ;
+  if [ ! -x $FLE ] ;
       then
       echo
       echo "--------------------------------------------------------------------------------------"
@@ -403,9 +403,9 @@ function shapeupdatetotemplate {
     echo "--------------------------------------------------------------------------------------"
 
     # Averaging and inversion code --- both are 1st order estimates.
-#    if [ ${dim} -eq 2   ] ; then
+#    if [ ${dim} -eq 2  ] ; then
 #      ANTSAverage2DAffine ${templatename}Affine${afftype} ${outputname}*Affine${afftype}
-#    elif [ ${dim} -eq 3  ] ; then
+#    elif [ ${dim} -eq 3 ] ; then
 #      ANTSAverage3DAffine ${templatename}Affine${afftype} ${outputname}*Affine${afftype}
 #    fi
 
@@ -837,7 +837,7 @@ elif [[ ${NINFILES} -eq 1 ]]
         # if there are more than 32 volumes in the time-series (in case they are smaller
 	nfmribins=2
 	let
-	if [ ${range} -gt 31  ]  ; then
+	if [ ${range} -gt 31 ]  ; then
 		BINSIZE=$((${range} / ${nfmribins}))
 		j=1 # initialize counter j
 		for ((i = 0; i < ${nfmribins} ; i++))
@@ -881,7 +881,7 @@ elif [[ ${NINFILES} -eq 1 ]]
 			let j++
 		done
 
-	elif [ ${range} -gt ${nfmribins}  ] && [ ${range} -lt 32  ]
+	elif [ ${range} -gt ${nfmribins} ] && [ ${range} -lt 32 ]
 		then
 
 			for ((i = 0; i < ${nfmribins} ; i++))
@@ -900,7 +900,7 @@ elif [[ ${NINFILES} -eq 1 ]]
 				fi
 			done
 
-	elif [ ${range} -le ${nfmribins}  ]
+	elif [ ${range} -le ${nfmribins} ]
 		then
 
 		${ANTSPATH}/ImageMath selection/$TDIM vol0.nii.gz TimeSeriesSubset ${IMAGESETVARIABLE} ${range}

--- a/Scripts/buildtemplateparallel.sh
+++ b/Scripts/buildtemplateparallel.sh
@@ -29,7 +29,7 @@ SETPATH
 # export ANTSPATH=${ANTSPATH:="$HOME/bin/ants/"} # EDIT THIS
 
 #ANTSPATH=YOURANTSPATH
-if [  ${#ANTSPATH} -le 3 ]
+if [ ${#ANTSPATH} -le 3 ]
     then
     setPath >&2
 fi
@@ -568,7 +568,7 @@ function ANTSAverage3DAffine {
 function jobfnamepadding {
 
     files=`ls job*.sh`
-    BASENAME1=`echo $files[1 ] | cut -d 'b' -f 1`
+    BASENAME1=`echo $files[1] | cut -d 'b' -f 1`
 
     for file in ${files}
       do
@@ -759,7 +759,7 @@ fi
 
 if [[ $DOQSUB -eq 1 || $DOQSUB -eq 4 ]] ; then
   qq=`which  qsub`
-  if [  ${#qq} -lt 1 ] ; then
+  if [ ${#qq} -lt 1 ] ; then
     echo do you have qsub?  if not, then choose another c option ... if so, then check where the qsub alias points ...
     exit
   fi

--- a/Scripts/directlabels.sh
+++ b/Scripts/directlabels.sh
@@ -205,7 +205,7 @@ writeSubimages() {
 function jobfnamepadding {
 
     files=`ls ${TMPDIR}job*.sh`
-    BASENAME1=`echo $files[1] | cut -d 'b' -f 1`
+    BASENAME1=`echo $files[1 ] | cut -d 'b' -f 1`
 
     for file in ${files}
       do
@@ -396,7 +396,7 @@ for LABEL in ${LABELS[@]}
   gmLabelImage=${TMPDIR}gm_${LABEL}.nii.gz
   wmLabelImage=${TMPDIR}wm_${LABEL}.nii.gz
 
-  exe="${DIRECT} -d ${DIMENSION} -c [ $ITERATION_LIMIT,0.000001,10] -t ${LABEL_THICKNESSES[$count]} -r $GRADIENT_STEP -m $SMOOTHING_SIGMA -s $segLabelImage -o ${TMPDIR}direct_${LABEL}.nii.gz"
+  exe="${DIRECT} -d ${DIMENSION} -c [ $ITERATION_LIMIT,0.000001,10 ] -t ${LABEL_THICKNESSES[$count]} -r $GRADIENT_STEP -m $SMOOTHING_SIGMA -s $segLabelImage -o ${TMPDIR}direct_${LABEL}.nii.gz"
   if [[ -f "$gmLabelImage" ]]; then
     exe=${exe}" -g $gmLabelImage"
   fi

--- a/Scripts/directlabels.sh
+++ b/Scripts/directlabels.sh
@@ -205,7 +205,7 @@ writeSubimages() {
 function jobfnamepadding {
 
     files=`ls ${TMPDIR}job*.sh`
-    BASENAME1=`echo $files[1 ] | cut -d 'b' -f 1`
+    BASENAME1=`echo $files[1] | cut -d 'b' -f 1`
 
     for file in ${files}
       do
@@ -301,7 +301,7 @@ SGE=${ANTSPATH}/waitForSGEQJobs.pl
 
 for FLE in $PEXEC $SGE
   do
-  if [ ! -x $FLE  ] ;
+  if [ ! -x $FLE ] ;
       then
       echo
       echo "--------------------------------------------------------------------------------------"

--- a/Scripts/geodesicinterpolation.sh
+++ b/Scripts/geodesicinterpolation.sh
@@ -2,7 +2,7 @@
 NUMPARAMS=$#
 
 
-if [ $NUMPARAMS -lt 2  ]
+if [ $NUMPARAMS -lt 2 ]
 then
 echo " USAGE ::  "
 echo "  sh   geodesicinterpolation.sh image1  image2  N-interpolation-points  N-step-size Use-Affine-Initialization?  Mask-Image Auxiliary-Template "
@@ -25,11 +25,11 @@ TARGET=$2
 NUMSTEPS=10
 STEP=1
 OUTNAME=ANTSMORPH
-if [ $NUMPARAMS -gt 2  ]
+if [ $NUMPARAMS -gt 2 ]
 then
 NUMSTEPS=$3
 fi
-if [ $NUMPARAMS -gt 3  ]
+if [ $NUMPARAMS -gt 3 ]
 then
 STEP=$4
 fi

--- a/Scripts/guidedregistration.sh
+++ b/Scripts/guidedregistration.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ $# -lt 7  ]
+if [ $# -lt 7 ]
 then
 echo " USAGE \n  sh command.sh  fixed.nii fixedhipp.nii  moving.nii movinghipp.nii outputname  iterations DIM "
 echo " the template = fixed.nii   ,   the individual = moving.nii "

--- a/Scripts/guidedregistration.sh
+++ b/Scripts/guidedregistration.sh
@@ -63,7 +63,7 @@ INTENSITY=CC[ $FIX,${MOV},${INTWT},4]
 
 #  == Important Parameters end? ==
 
- ${ANTSPATH}ANTS $DIM -o $OUT  -i $ITS -t SyN[ 0.25]  -r Gauss[ 3,0] -m $INTENSITY   -m   $LM
+ ${ANTSPATH}ANTS $DIM -o $OUT  -i $ITS -t SyN[ 0.25 ]  -r Gauss[ 3,0 ] -m $INTENSITY   -m   $LM
 
  ${ANTSPATH}WarpImageMultiTransform $DIM $MOV ${OUT}toTemplate.nii.gz ${OUT}Warp.nii.gz ${OUT}Affine.txt  -R $FIX
 

--- a/Scripts/landmarkmatch.sh
+++ b/Scripts/landmarkmatch.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [ $# -lt 6  ]
+if [ $# -lt 6 ]
 then
 echo " USAGE \n  sh $0  fixed.nii fixedhipp.nii  moving.nii movinghipp.nii  ITERATIONS LandmarkWeight "
 echo " you should set LandmarkWeight yourself --- the intensity weight is 1.  so the landmark weight should be in that range (e.g. 0.5 => 1 ) "
@@ -71,14 +71,14 @@ PARZSIG=10
 LM=PSE[ ${FIX},${MOV},${FIXHMOD},${MOVHMOD},${LMWT},${PERCENTtoUSE},${PARZSIG},0,${KNN}]
 echo $LM
 
-if [ $# -gt 6  ]
+if [ $# -gt 6 ]
 then
 OUT=$7
 fi
 
 STEPL=0.25
 INTENSITY=PR[ $FIX,${MOV},${INTWT},4]
-if [ $LMWT -le 0  ]
+if [ $LMWT -le 0 ]
 then
 exe="${ANTSPATH}ANTS 3  -o $OUT  -i $ITS -t SyN[ ${STEPL}]  -r Gauss[ 3,0 ]   -m $INTENSITY   "
 else

--- a/Scripts/landmarkmatch.sh
+++ b/Scripts/landmarkmatch.sh
@@ -80,9 +80,9 @@ STEPL=0.25
 INTENSITY=PR[ $FIX,${MOV},${INTWT},4]
 if [ $LMWT -le 0  ]
 then
-exe="${ANTSPATH}ANTS 3  -o $OUT  -i $ITS -t SyN[ ${STEPL}]  -r Gauss[ 3,0]   -m $INTENSITY   "
+exe="${ANTSPATH}ANTS 3  -o $OUT  -i $ITS -t SyN[ ${STEPL}]  -r Gauss[ 3,0 ]   -m $INTENSITY   "
 else
-exe="${ANTSPATH}ANTS 3  -o $OUT  -i $ITS -t SyN[ ${STEPL}]  -r Gauss[ 3,0]   -m   $LM  -m $INTENSITY    "
+exe="${ANTSPATH}ANTS 3  -o $OUT  -i $ITS -t SyN[ ${STEPL}]  -r Gauss[ 3,0 ]   -m   $LM  -m $INTENSITY    "
 fi
 echo " $exe "
 

--- a/Scripts/lohmann.sh
+++ b/Scripts/lohmann.sh
@@ -3,7 +3,7 @@
 NUMPARAMS=$#
 MAXITERATIONS=30x90x20
 
-if [ $NUMPARAMS -lt 2  ]
+if [ $NUMPARAMS -lt 2 ]
 then
 echo " USAGE ::  "
 echo "  sh   $0 ImageDimension  image.ext   "

--- a/Scripts/lohmann.sh
+++ b/Scripts/lohmann.sh
@@ -49,7 +49,7 @@ ${ANTSPATH}/ThresholdImage $DIM  ${OUTPUTNAME}repaired.nii.gz ${OUTPUTNAME}mask.
 
 WM=${OUTPUTNAME}seg.nii.gz
 if [[ ! -s $WM ]] ; then
-  ${ANTSPATH}/Apocrita $DIM -x ${OUTPUTNAME}mask.nii.gz  -m [ 0.5,1,0,0] -o [ ${OUTPUTNAME}seg.nii.gz] -i Otsu[ ${OUTPUTNAME}repaired.nii.gz,3] -h 0
+  ${ANTSPATH}/Apocrita $DIM -x ${OUTPUTNAME}mask.nii.gz  -m [ 0.5,1,0,0 ] -o [ ${OUTPUTNAME}seg.nii.gz ] -i Otsu[ ${OUTPUTNAME}repaired.nii.gz,3 ] -h 0
   ${ANTSPATH}/ThresholdImage $DIM $WM $WM 3 3
   ${ANTSPATH}/ImageMath $DIM $WM GetLargestComponent $WM
 fi

--- a/Scripts/newAntsExample.sh
+++ b/Scripts/newAntsExample.sh
@@ -29,20 +29,20 @@ else
 fi
 echo affine $m $f outname is $nm am using setting $mysetting
 nm=${D}${nm1}_fixed_${nm2}_moving_setting_is_${mysetting}   # construct output prefix
-$reg -d $dim -r [ $f, $m ,1]  \
+$reg -d $dim -r [ $f, $m ,1 ]  \
                         -m mattes[  $f, $m , 1 , 32, regular, $percentage ] \
                          -t translation[ 0.1 ] \
-                         -c [ $its,1.e-8,20]  \
+                         -c [ $its,1.e-8,20 ]  \
                         -s 4x2x1vox  \
                         -f 6x4x2 -l 1 \
                         -m mattes[  $f, $m , 1 , 32, regular, $percentage ] \
                          -t rigid[ 0.1 ] \
-                         -c [ $its,1.e-8,20]  \
+                         -c [ $its,1.e-8,20 ]  \
                         -s 4x2x1vox  \
                         -f 3x2x1 -l 1 \
                         -m mattes[  $f, $m , 1 , 32, regular, $percentage ] \
                          -t affine[ 0.1 ] \
-                         -c [ $its,1.e-8,20]  \
+                         -c [ $its,1.e-8,20 ]  \
                         -s 4x2x1vox  \
                         -f 3x2x1 -l 1 \
                         -m mattes[  $f, $m , 0.5 , 32 ] \

--- a/Scripts/phantomstudy.sh
+++ b/Scripts/phantomstudy.sh
@@ -8,9 +8,9 @@ for x in  phantomAwmgm.jpg phantomBwmgm.jpg phantomCwmgm.jpg phantomDwmgm.jpg ph
 do
     count=`expr $count + 1`					# Increment the counter
    echo " count is $count  and file is $x "
-    ${ANTSPATH}/ANTS 2 -m PR[ phantomtemplate.jpg,$x,1,4]   -i 20x161x161x161  -o TEST{$count}  -t SyN[ 2] -r Gauss[ 3,0.]
+    ${ANTSPATH}/ANTS 2 -m PR[ phantomtemplate.jpg,$x,1,4 ]   -i 20x161x161x161  -o TEST{$count}  -t SyN[ 2 ] -r Gauss[ 3,0.]
 #
-#  -t SyN[ 1,2,0.05] -r Gauss[ 3,0.25]
+#  -t SyN[ 1,2,0.05 ] -r Gauss[ 3,0.25]
     ${ANTSPATH}/WarpImageMultiTransform 2  $x  TEST{$count}registered.nii  TEST{$count}Warp.nii TEST{$count}Affine.txt
 done
 

--- a/Scripts/shapeupdatetotemplate.sh
+++ b/Scripts/shapeupdatetotemplate.sh
@@ -210,28 +210,28 @@ function shapeupdatetotemplate() {
         echo " shapeupdatetotemplate---average the affine transforms (template <-> subject)"
         echo "                      ---transform the inverse field by the resulting average affine transform"
         echo "   ${AVERAGE_AFFINE_PROGRAM} ${dim} ${templatename}0GenericAffine.mat ${outputname}*GenericAffine.mat"
-        echo "   ${WARP} -d ${dim} -e vector -i ${templatename}0warp.nii.gz -o ${templatename}0warp.nii.gz -t [ ${templatename}0GenericAffine.mat,1] -r ${template}"
+        echo "   ${WARP} -d ${dim} -e vector -i ${templatename}0warp.nii.gz -o ${templatename}0warp.nii.gz -t [ ${templatename}0GenericAffine.mat,1 ] -r ${template}"
         echo "--------------------------------------------------------------------------------------"
 
         ${AVERAGE_AFFINE_PROGRAM} ${dim} ${templatename}0GenericAffine.mat ${outputname}*GenericAffine.mat
 
         if [[ $NWARPS -ne 0 ]];
           then
-            ${WARP} -d ${dim} -e vector -i ${templatename}0warp.nii.gz -o ${templatename}0warp.nii.gz -t [ ${templatename}0GenericAffine.mat,1] -r ${template}
+            ${WARP} -d ${dim} -e vector -i ${templatename}0warp.nii.gz -o ${templatename}0warp.nii.gz -t [ ${templatename}0GenericAffine.mat,1 ] -r ${template}
             ${ANTSPATH}/MeasureMinMaxMean ${dim} ${templatename}0warp.nii.gz ${templatename}warplog.txt 1
           fi
       fi
 
     echo "--------------------------------------------------------------------------------------"
     echo " shapeupdatetotemplate---warp each template by the resulting transforms"
-    echo "   ${WARP} -d ${dim} --float $USEFLOAT -i ${template} -o ${template} -t [ ${templatename}0GenericAffine.mat,1] -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -r ${template}"
+    echo "   ${WARP} -d ${dim} --float $USEFLOAT -i ${template} -o ${template} -t [ ${templatename}0GenericAffine.mat,1 ] -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -r ${template}"
     echo "--------------------------------------------------------------------------------------"
 
     if [ -f "${templatename}0warp.nii.gz" ];
       then
-        ${WARP} -d ${dim} --float $USEFLOAT -i ${template} -o ${template} -t [ ${templatename}0GenericAffine.mat,1] -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -r ${template}
+        ${WARP} -d ${dim} --float $USEFLOAT -i ${template} -o ${template} -t [ ${templatename}0GenericAffine.mat,1 ] -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -t ${templatename}0warp.nii.gz -r ${template}
       else
-        ${WARP} -d ${dim} --float $USEFLOAT -i ${template} -o ${template} -t [ ${templatename}0GenericAffine.mat,1] -r ${template}
+        ${WARP} -d ${dim} --float $USEFLOAT -i ${template} -o ${template} -t [ ${templatename}0GenericAffine.mat,1 ] -r ${template}
       fi
 
 }

--- a/Scripts/shapeupdatetotemplate.sh
+++ b/Scripts/shapeupdatetotemplate.sh
@@ -171,7 +171,7 @@ function shapeupdatetotemplate() {
     #echo "    ${ANTSPATH}/ImageSetStatistics $dim ${whichtemplate}WarpedToTemplateList.txt ${template} 0"
     echo "--------------------------------------------------------------------------------------"
     imagelist=(`ls ${outputname}template${whichtemplate}*WarpedToTemplate.nii.gz`)
-    if [[ ${#imagelist[@]} -eq 0  ]] ; then
+    if [[ ${#imagelist[@]} -eq 0 ]] ; then
       echo ERROR shapeupdatedtotemplate - imagelist length is 0
       exit 1
     fi

--- a/Scripts/sliceBySliceOperation.sh
+++ b/Scripts/sliceBySliceOperation.sh
@@ -146,7 +146,7 @@ if [[ ${#SIZE[@]} -ne 3 ]];
 
 if [[ ${WHICH_DIRECTION} -gt 2 || ${WHICH_DIRECTION} -lt 0 ]];
   then
-    echo "Error: Direction must be an integer in [0,2]"
+    echo "Error: Direction must be an integer in [0,2 ]"
     exit
   fi
 

--- a/Scripts/unbiased_pairwise_registration.sh
+++ b/Scripts/unbiased_pairwise_registration.sh
@@ -71,7 +71,7 @@ if [[ ${#prefix} -lt 3 ]] ; then echo must provide output prefix $prefix ; echo 
 if [[ ! -s $A ]] || [[  ! -s $B ]]  ; then echo inputs: $A $B $prefix ; echo $usage ; exit 1 ; fi
 reg=antsRegistration
 uval=0
-aff=" -t affine[ 0.25 ]  -c [ 1009x200x20,1.e-8,20]  -s 4x2x0 -f 4x2x1 "
+aff=" -t affine[ 0.25 ]  -c [ 1009x200x20,1.e-8,20 ]  -s 4x2x0 -f 4x2x1 "
 synits=20x20x10
 ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=2
 export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS
@@ -106,7 +106,7 @@ $reg -d $dim -r  [ ${prefix}_mid.nii.gz, $A, 1 ] \
                         -m mattes[  ${prefix}_mid.nii.gz, $A, 1 , 32, random , 0.25 ] $aff \
                        -o [ ${nmA},${nmA}_aff.nii.gz]
 # compute the map from B to midpoint(B,A) --- "fair" interpolation
-$reg -d $dim  -r [ ${nmA}_aff.nii.gz, $B, 1] \
+$reg -d $dim  -r [ ${nmA}_aff.nii.gz, $B, 1 ] \
                         -m mattes[  ${nmA}_aff.nii.gz, $B, 1 , 32, random , 0.25 ] $aff \
                        -o [ ${nmB},${nmB}_aff.nii.gz]
 midaaff=${nmA}0GenericAffine.mat
@@ -116,7 +116,7 @@ echo now do deformable expecting $initB and $initA to exist
 $reg -d $dim  --initial-fixed-transform $midaaff  --initial-moving-transform $midbaff \
                          -m mattes[  $A, $B , 1 , 32 ] \
                          -t syn[ 0.25, 3, 0.0 ] \
-                         -c [ ${synits},1.e-8,10]  \
+                         -c [ ${synits},1.e-8,10 ]  \
                         -s 2x1x0 \
                         -f 4x2x1 \
                        -o [ ${nm},${nm}_diff_symm.nii.gz]

--- a/Scripts/unbiased_pairwise_registration_with_aux_images.sh
+++ b/Scripts/unbiased_pairwise_registration_with_aux_images.sh
@@ -137,7 +137,7 @@ $reg -d $dim -r [ $A, $B, 1 ]   \
                         -m mattes[  $A, $B , $metparams ] $aff -z 1 \
                        -o [ ${initA}]
 $reg -d $dim -r [ $B, $A, 1 ] \
-                        -m mattes[  $B, $A , $metparams  ] $aff -z 1 \
+                        -m mattes[  $B, $A , $metparams ] $aff -z 1 \
                        -o [ ${initB}]
 # get the identity map
 ComposeMultiTransform $dim ${initA}_id.mat -R ${initA}0GenericAffine.mat  ${initA}0GenericAffine.mat -i ${initA}0GenericAffine.mat
@@ -153,7 +153,7 @@ ImageMath $dim  ${prefix}_mid.nii.gz PadImage $A 10
 antsApplyTransforms -d $dim -i $B -o ${prefix}_mid.nii.gz -t  ${prefix}_mid.mat  -r  $A
 # compute the map from A to midpoint(B,A) --- "fair" interpolation
 $reg -d $dim  \
-                        -m mattes[  ${prefix}_mid.nii.gz, $A, $metparams  ] $aff \
+                        -m mattes[  ${prefix}_mid.nii.gz, $A, $metparams ] $aff \
                        -o [ ${nmA},${nmA}_aff.nii.gz]
 # compute the map from B to midpoint(B,A) --- "fair" interpolation
 $reg -d $dim  \
@@ -166,7 +166,7 @@ N3BiasFieldCorrection $dim ${nm}_n3_a.nii.gz ${nm}_n3_a.nii.gz 2
 N3BiasFieldCorrection $dim $B ${nm}_n3_b.nii.gz 4 
 N3BiasFieldCorrection $dim ${nm}_n3_b.nii.gz ${nm}_n3_b.nii.gz 2 
   echo now do deformable expecting $initB and $initA to exist
-  if [[ -s $initAmat  ]] && [[ -s $initBmat ]] ; then
+  if [[ -s $initAmat ]] && [[ -s $initBmat ]] ; then
     $reg -d $dim  --initial-fixed-transform $initAmat  --initial-moving-transform $initBmat \
                          -m mattes[  ${nm}_n3_a.nii.gz, ${nm}_n3_b.nii.gz , 1 , 32 ] \
                          -t syn[ 0.25, 3, 0.5 ] \
@@ -194,7 +194,7 @@ antsApplyTransforms -d $dim -i ${nm}_avg.nii.gz -o ${nm}_avg.nii.gz -t ${nm}temp
 rm ${nm}tempWarp.nii.gz 
 
 # recompute the mappings 
-  if [[ -s $initAmat  ]] && [[ -s $initBmat ]] ; then
+  if [[ -s $initAmat ]] && [[ -s $initBmat ]] ; then
     $reg -d $dim  --initial-moving-transform $initBmat \
                          -m mattes[  ${nm}_avg.nii.gz, ${nm}_n3_b.nii.gz , 1 , 32 ] \
                          -t syn[ 0.25, 3, 0.5 ] \
@@ -249,7 +249,7 @@ if [[ -s $template ]] && [[ ! -s  ${nm}_gt_0GenericAffine.mat ]] ; then
 fi 
 echo done with brain extraction 
 
-if [[ -s $G ]] && [[ -s $N ]] && [[ ! -s ${nm}_fadiff.nii.gz  ]] ; then 
+if [[ -s $G ]] && [[ -s $N ]] && [[ ! -s ${nm}_fadiff.nii.gz ]] ; then 
 # map brain mask to subject space T1
 trans=" -t [ $initAmat, 1 ] -t [ ${nm}_gt_0GenericAffine.mat, 1 ] -t  ${nm}_gt_1InverseWarp.nii.gz "
 antsApplyTransforms -d $dim -i $templatebm -o  ${nm}_bm_A.nii.gz -n NearestNeighbor -r $A $trans
@@ -267,7 +267,7 @@ MultiplyImages $dim  ${nm}_bm_B.nii.gz $B  ${nm}_B_brain.nii.gz
   N3BiasFieldCorrection $dim ${nm}_n3_b.nii.gz ${nm}_n3_b.nii.gz 2
   N3BiasFieldCorrection $dim ${nm}_n3_b.nii.gz ${nm}_n3_b.nii.gz 2
   echo now do deformable expecting $initB and $initA to exist
-  if [[ -s $initAmat  ]] && [[ -s $initBmat ]] ; then
+  if [[ -s $initAmat ]] && [[ -s $initBmat ]] ; then
     $reg -d $dim  --initial-fixed-transform $initAmat  --initial-moving-transform $initBmat \
                          -m mattes[  ${nm}_n3_a.nii.gz, ${nm}_n3_b.nii.gz , 1 , 32 ] \
                          -t syn[ 0.25, 3, 0.5 ] \
@@ -283,7 +283,7 @@ MultiplyImages $dim  ${nm}_bm_B.nii.gz $B  ${nm}_B_brain.nii.gz
   antsApplyTransforms -d $dim -i $B -o ${nm}_diff.nii.gz -t [ $initAmat, 1 ] -t ${nm}1Warp.nii.gz -t  $initBmat -r $A
   ANTSJacobian $dim ${nm}1Warp.nii.gz ${nm} 1 no 0
 fi
-if [[ -s $G ]] && [[ -s $N ]] && [[ ! -s ${nm}_fadiff.nii.gz  ]] ; then
+if [[ -s $G ]] && [[ -s $N ]] && [[ ! -s ${nm}_fadiff.nii.gz ]] ; then
   echo deal with auxiliary images ... here DTI
   ffa=${nm}_ffa.nii.gz
   mfa=${nm}_mfa.nii.gz
@@ -340,9 +340,9 @@ echo done with aux images --- now get final jacobians
 
  
 
-if [[ -s $H ]] && [[ -s $K ]] && [[ ! -s ${nm}_cbfdiff.nii.gz  ]] ; then 
+if [[ -s $H ]] && [[ -s $K ]] && [[ ! -s ${nm}_cbfdiff.nii.gz ]] ; then 
   echo deal with auxiliary images ... here a scalar image pair 
-# if [[ -s $H ]] && [[ -s $K ]] && [[ ! -s ${nm}_cbfdiff.nii.gz  ]] ; then
+# if [[ -s $H ]] && [[ -s $K ]] && [[ ! -s ${nm}_cbfdiff.nii.gz ]] ; then
 #  echo deal with auxiliary images ... here DTI
   fcbf=${nm}_fcbf.nii.gz
   mcbf=${nm}_mcbf.nii.gz

--- a/Scripts/unbiased_pairwise_registration_with_aux_images.sh
+++ b/Scripts/unbiased_pairwise_registration_with_aux_images.sh
@@ -96,7 +96,7 @@ if [[ ! -s $A ]] || [[  ! -s $B ]]  ; then echo inputs: $A $B $prefix ; echo $us
 reg=antsRegistration
 uval=0
 affits=999x550x20
-aff=" -t affine[ 0.2 ]  -c [ $affits ,1.e-7,20]  -s 3x2x0 -f 4x2x1 -u $uval -l 0 "
+aff=" -t affine[ 0.2 ]  -c [ $affits ,1.e-7,20 ]  -s 3x2x0 -f 4x2x1 -u $uval -l 0 "
 metparams=" 1 , 32, random , 0.25 "
 synits=100x50  #BA 
 ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=2
@@ -170,7 +170,7 @@ N3BiasFieldCorrection $dim ${nm}_n3_b.nii.gz ${nm}_n3_b.nii.gz 2
     $reg -d $dim  --initial-fixed-transform $initAmat  --initial-moving-transform $initBmat \
                          -m mattes[  ${nm}_n3_a.nii.gz, ${nm}_n3_b.nii.gz , 1 , 32 ] \
                          -t syn[ 0.25, 3, 0.5 ] \
-                         -c [ ${synits},1.e-8,10]  \
+                         -c [ ${synits},1.e-8,10 ]  \
                         -s 1x0 \
                         -f 2x1 \
                        -u $uval -b 0 -z 1 \
@@ -178,7 +178,7 @@ N3BiasFieldCorrection $dim ${nm}_n3_b.nii.gz ${nm}_n3_b.nii.gz 2
 #    $reg -d $dim  --initial-fixed-transform $initBmat  --initial-moving-transform $initAmat \
 #                         -m mattes[  ${nm}_n3_a.nii.gz, ${nm}_n3_b.nii.gz , 1 , 32 ] \
 #                         -t syn[ 0.25, 3, 0.5 ] \
-#                         -c [ ${synits},1.e-8,10]  \
+#                         -c [ ${synits},1.e-8,10 ]  \
 #                        -s 1x0 \
 #                        -f 2x1 \
 #                       -u $uval -b 0 -z 1 \
@@ -198,7 +198,7 @@ rm ${nm}tempWarp.nii.gz
     $reg -d $dim  --initial-moving-transform $initBmat \
                          -m mattes[  ${nm}_avg.nii.gz, ${nm}_n3_b.nii.gz , 1 , 32 ] \
                          -t syn[ 0.25, 3, 0.5 ] \
-                         -c [ ${synits},1.e-8,10]  \
+                         -c [ ${synits},1.e-8,10 ]  \
                         -s 1x0 \
                         -f 2x1 \
                        -u $uval -b 0 -z 1 \
@@ -206,7 +206,7 @@ rm ${nm}tempWarp.nii.gz
     $reg -d $dim  --initial-moving-transform $initAmat \
                          -m mattes[  ${nm}_avg.nii.gz, ${nm}_n3_a.nii.gz , 1 , 32 ] \
                          -t syn[ 0.25, 3, 0.5 ] \
-                         -c [ ${synits},1.e-8,10]  \
+                         -c [ ${synits},1.e-8,10 ]  \
                         -s 1x0 \
                         -f 2x1 \
                        -u $uval -b 0 -z 1 \
@@ -229,20 +229,20 @@ if [[ -s $template ]] && [[ ! -s  ${nm}_gt_0GenericAffine.mat ]] ; then
   $reg -d $dim  -r $initafffn  \
                         -m mattes[  $imgs , 1 , 32, regular, 0.25 ] \
                          -t affine[ 0.1 ] \
-                         -c [ $affits ,1.e-7,20]  \
+                         -c [ $affits ,1.e-7,20 ]  \
                         -s 4x2x1vox  \
                         -f 4x2x1 -l 1 \
                         -m cc[  $imgs , 1 , 4 ] \
                          -t syn[ .2, 3, 0.0 ] \
-                         -c [ 100x50x20,1.e-8,20]  \
+                         -c [ 100x50x20,1.e-8,20 ]  \
                         -s 2x1x0vox  \
                         -f 4x2x1 -l 1 -u 0 -z 1 \
                        -o [ ${nm}_gt_,${nm}_gt.nii.gz]
 
   # map brain mask to subject space T1
-  trans=" -t [ $initAmat, 1 ] -t ${nm}_A1InverseWarp.nii.gz -t [ ${nm}_gt_0GenericAffine.mat, 1] -t  ${nm}_gt_1InverseWarp.nii.gz "
+  trans=" -t [ $initAmat, 1 ] -t ${nm}_A1InverseWarp.nii.gz -t [ ${nm}_gt_0GenericAffine.mat, 1 ] -t  ${nm}_gt_1InverseWarp.nii.gz "
   antsApplyTransforms -d $dim -i $templatebm -o  ${nm}_bm_A.nii.gz -n NearestNeighbor -r $A $trans
-  trans=" -t [ $initBmat, 1 ] -t ${nm}_B1InverseWarp.nii.gz -t [ ${nm}_gt_0GenericAffine.mat, 1] -t  ${nm}_gt_1InverseWarp.nii.gz "
+  trans=" -t [ $initBmat, 1 ] -t ${nm}_B1InverseWarp.nii.gz -t [ ${nm}_gt_0GenericAffine.mat, 1 ] -t  ${nm}_gt_1InverseWarp.nii.gz "
   antsApplyTransforms -d $dim -i $templatebm -o  ${nm}_bm_B.nii.gz -n NearestNeighbor -r $B $trans
   MultiplyImages $dim  ${nm}_bm_A.nii.gz $A  ${nm}_A_brain.nii.gz
   MultiplyImages $dim  ${nm}_bm_B.nii.gz $B  ${nm}_B_brain.nii.gz
@@ -251,9 +251,9 @@ echo done with brain extraction
 
 if [[ -s $G ]] && [[ -s $N ]] && [[ ! -s ${nm}_fadiff.nii.gz  ]] ; then 
 # map brain mask to subject space T1
-trans=" -t [ $initAmat, 1 ] -t [ ${nm}_gt_0GenericAffine.mat, 1] -t  ${nm}_gt_1InverseWarp.nii.gz "
+trans=" -t [ $initAmat, 1 ] -t [ ${nm}_gt_0GenericAffine.mat, 1 ] -t  ${nm}_gt_1InverseWarp.nii.gz "
 antsApplyTransforms -d $dim -i $templatebm -o  ${nm}_bm_A.nii.gz -n NearestNeighbor -r $A $trans
-trans=" -t [ $initBmat, 1 ] -t ${nm}1InverseWarp.nii.gz -t [ ${nm}_gt_0GenericAffine.mat, 1] -t  ${nm}_gt_1InverseWarp.nii.gz "
+trans=" -t [ $initBmat, 1 ] -t ${nm}1InverseWarp.nii.gz -t [ ${nm}_gt_0GenericAffine.mat, 1 ] -t  ${nm}_gt_1InverseWarp.nii.gz "
 antsApplyTransforms -d $dim -i $templatebm -o  ${nm}_bm_B.nii.gz -n NearestNeighbor -r $B $trans
 MultiplyImages $dim  ${nm}_bm_A.nii.gz $A  ${nm}_A_brain.nii.gz
 MultiplyImages $dim  ${nm}_bm_B.nii.gz $B  ${nm}_B_brain.nii.gz
@@ -271,7 +271,7 @@ MultiplyImages $dim  ${nm}_bm_B.nii.gz $B  ${nm}_B_brain.nii.gz
     $reg -d $dim  --initial-fixed-transform $initAmat  --initial-moving-transform $initBmat \
                          -m mattes[  ${nm}_n3_a.nii.gz, ${nm}_n3_b.nii.gz , 1 , 32 ] \
                          -t syn[ 0.25, 3, 0.5 ] \
-                         -c [ ${synits},1.e-8,10]  \
+                         -c [ ${synits},1.e-8,10 ]  \
                         -s 1x0 \
                         -f 2x1 \
                        -u $uval -b 0 -z 1 \
@@ -294,38 +294,38 @@ if [[ -s $G ]] && [[ -s $N ]] && [[ ! -s ${nm}_fadiff.nii.gz  ]] ; then
   $reg -d $dim  \
                         -m mattes[  $imgs , 1 , 32, regular, 0.2 ] \
                          -t rigid[ 0.1 ] \
-                         -c [ 1000x1000x5,1.e-7,20]  \
-                        -s 4x2x1mm  -x [ ${nm}_bm_A.nii.gz]  \
+                         -c [ 1000x1000x5,1.e-7,20 ]  \
+                        -s 4x2x1mm  -x [ ${nm}_bm_A.nii.gz ]  \
                         -f 4x2x1 -l 1 -u 1 -z 1 \
                          -m mattes[  $imgs , 1 , 32, regular, 0.2 ] \
                          -t affine[ 0.1 ] \
-                         -c [ 1000x25,1.e-7,20]  \
-                        -s 2x1mm  -x [ ${nm}_bm_A.nii.gz]  \
+                         -c [ 1000x25,1.e-7,20 ]  \
+                        -s 2x1mm  -x [ ${nm}_bm_A.nii.gz ]  \
                         -f 2x1 -l 1 -u 1 -z 1 \
                          -m mattes[  $imgs , 1 , 32 ] \
                          -m cc[  $imgs , 1 , 2 ] \
                          -t SyN[ 0.2, 3, 0.5 ] \
-                         -c [ $synits,1.e-7,20]  \
-                        -s 4x2x1mm -x [ ${nm}_bm_A.nii.gz] \
+                         -c [ $synits,1.e-7,20 ]  \
+                        -s 4x2x1mm -x [ ${nm}_bm_A.nii.gz ] \
                         -f 4x2x1 -l 1 -u 1 -z 1 \
                        -o [ ${nm}_ffa,${nm}_ffa_distcorr.nii.gz]
   imgs=" ${nm}_B_brain.nii.gz, $mfa "
   $reg -d $dim  \
                          -m mattes[  $imgs , 1 , 32, regular, 0.2 ] \
                          -t rigid[ 0.1 ] \
-                         -c [ 1000x1000x5,1.e-7,20]  \
-                        -s 4x2x1mm  -x [ ${nm}_bm_A.nii.gz]  \
+                         -c [ 1000x1000x5,1.e-7,20 ]  \
+                        -s 4x2x1mm  -x [ ${nm}_bm_A.nii.gz ]  \
                         -f 4x2x1 -l 1 -u 1 -z 1 \
                         -m mattes[  $imgs , 1 , 32, regular, 0.2 ] \
                          -t affine[ 0.1 ] \
-                         -c [ 1000x25,1.e-7,20]  \
-                        -s 2x1mm  -x [ ${nm}_bm_B.nii.gz]  \
+                         -c [ 1000x25,1.e-7,20 ]  \
+                        -s 2x1mm  -x [ ${nm}_bm_B.nii.gz ]  \
                         -f 2x1 -l 1 -u 1 -z 1 \
                          -m mattes[  $imgs , 1 , 32 ] \
                          -m cc[  $imgs , 1 , 2 ] \
                          -t SyN[ 0.2, 3, 0.5 ] \
-                         -c [ $synits,1.e-7,20]  \
-                        -s 4x2x1mm  -x [ ${nm}_bm_B.nii.gz] \
+                         -c [ $synits,1.e-7,20 ]  \
+                        -s 4x2x1mm  -x [ ${nm}_bm_B.nii.gz ] \
                         -f 4x2x1 -l 1 -u 1 -z 1 \
                         -o [ ${nm}_mfa,${nm}_mfa_distcorr.nii.gz]
 #
@@ -353,38 +353,38 @@ if [[ -s $H ]] && [[ -s $K ]] && [[ ! -s ${nm}_cbfdiff.nii.gz  ]] ; then
   $reg -d $dim  \
                         -m mattes[  $imgs , 1 , 32, regular, 0.2 ] \
                          -t rigid[ 0.1 ] \
-                         -c [ 1000x1000x5,1.e-7,20]  \
-                        -s 4x2x1mm  -x [ ${nm}_bm_A.nii.gz]  \
+                         -c [ 1000x1000x5,1.e-7,20 ]  \
+                        -s 4x2x1mm  -x [ ${nm}_bm_A.nii.gz ]  \
                         -f 4x2x1 -l 1 -u 1 -z 1 \
                          -m mattes[  $imgs , 1 , 32, regular, 0.2 ] \
                          -t affine[ 0.1 ] \
-                         -c [ 1000x25,1.e-7,20]  \
-                        -s 2x1mm  -x [ ${nm}_bm_A.nii.gz]  \
+                         -c [ 1000x25,1.e-7,20 ]  \
+                        -s 2x1mm  -x [ ${nm}_bm_A.nii.gz ]  \
                         -f 2x1 -l 1 -u 1 -z 1 \
                          -m mattes[  $imgs , 1 , 32 ] \
                          -m cc[  $imgs , 1 , 2 ] \
                          -t SyN[ 0.2, 3, 0.5 ] \
-                         -c [ $synits,1.e-7,20]  \
-                        -s 4x2x1mm -x [ ${nm}_bm_A.nii.gz] \
+                         -c [ $synits,1.e-7,20 ]  \
+                        -s 4x2x1mm -x [ ${nm}_bm_A.nii.gz ] \
                         -f 4x2x1 -l 1 -u 1 -z 1 \
                        -o [ ${nm}_fcbf,${nm}_fcbf_distcorr.nii.gz]
   imgs=" ${nm}_B_brain.nii.gz, $mcbf "
   $reg -d $dim  \
                          -m mattes[  $imgs , 1 , 32, regular, 0.2 ] \
                          -t rigid[ 0.1 ] \
-                         -c [ 1000x1000x5,1.e-7,20]  \
-                        -s 4x2x1mm  -x [ ${nm}_bm_A.nii.gz]  \
+                         -c [ 1000x1000x5,1.e-7,20 ]  \
+                        -s 4x2x1mm  -x [ ${nm}_bm_A.nii.gz ]  \
                         -f 4x2x1 -l 1 -u 1 -z 1 \
                         -m mattes[  $imgs , 1 , 32, regular, 0.2 ] \
                          -t affine[ 0.1 ] \
-                         -c [ 1000x25,1.e-7,20]  \
-                        -s 2x1mm  -x [ ${nm}_bm_B.nii.gz]  \
+                         -c [ 1000x25,1.e-7,20 ]  \
+                        -s 2x1mm  -x [ ${nm}_bm_B.nii.gz ]  \
                         -f 2x1 -l 1 -u 1 -z 1 \
                          -m mattes[  $imgs , 1 , 32 ] \
                          -m cc[  $imgs , 1 , 2 ] \
                          -t SyN[ 0.2, 3, 0.5 ] \
-                         -c [ $synits,1.e-7,20]  \
-                        -s 4x2x1mm  -x [ ${nm}_bm_B.nii.gz] \
+                         -c [ $synits,1.e-7,20 ]  \
+                        -s 4x2x1mm  -x [ ${nm}_bm_B.nii.gz ] \
                         -f 4x2x1 -l 1 -u 1 -z 1 \
                         -o [ ${nm}_mcbf,${nm}_mcbf_distcorr.nii.gz]
 #

--- a/Scripts/weightedaverage.sh
+++ b/Scripts/weightedaverage.sh
@@ -7,7 +7,7 @@ for x in `ls -tr  $1 `
 do
     count=`expr $count + 1`					# Increment the counter
    echo " count is $count  and file is $x at it $i "
-      ANTS 2 -m PR[ template.nii,$x,1,8,-0.9]   -t SyN[ 3] -r Gauss[ 3,1.5] -o ROBU{$count}   -i 22x21x10  --MI-option 16x8000 #-a InitAffine.txt --continue-affine 0
+      ANTS 2 -m PR[ template.nii,$x,1,8,-0.9 ]   -t SyN[ 3 ] -r Gauss[ 3,1.5 ] -o ROBU{$count}   -i 22x21x10  --MI-option 16x8000 #-a InitAffine.txt --continue-affine 0
       WarpImageMultiTransform 2  $x    ROBU{$count}{$i}registered.nii ROBU{$count}Warp.nii ROBU{$count}Affine.txt
 ComposeMultiTransform 2   ROBU{$count}Warp.nii  -R template.nii ROBU{$count}Warp.nii ROBU{$count}Affine.txt
      ComposeMaps 2 ROBU{$count}Warp.nii ROBU{$count}Affine.txt ROBU{$count}Warp.nii  2


### PR DESCRIPTION
Args with spaces inside the brackets work with ANTs executables, but need to be quoted if passed to scripts.

I changed the logCmd function in various scripts to use "$@" rather than "$*" because that preserves quoted args better by not combining "$@" into a string. One problem I could not solve was that the printed log of commands will not contain the necessary quotes, so if you do eg 

```
  logCmd antsAtroposN4.sh ... -b "Socrates[ 1 ]"
```
the argument is passed to the script correctly but the quotes don't get printed to stdout, so you'd have to add the quotes before running the command manually.