### PR TITLE
COMP: Remove self assignment warning

### DIFF
--- a/Examples/ANTSIntegrateVectorField.cxx
+++ b/Examples/ANTSIntegrateVectorField.cxx
@@ -325,7 +325,7 @@ int IntegrateVectorField(int argc, char *argv[])
     timesign = -1.0;
     }
   typedef   DisplacementFieldType                                                        TimeVaryingVelocityFieldType;
-  typedef typename DisplacementFieldType::PointType                                      DPointType;
+  //UNUSED: typedef typename DisplacementFieldType::PointType                                      DPointType;
   typedef itk::VectorLinearInterpolateImageFunction<TimeVaryingVelocityFieldType, float> DefaultInterpolatorType;
   typename DefaultInterpolatorType::Pointer vinterp =  DefaultInterpolatorType::New();
   typedef itk::LinearInterpolateImageFunction<ImageType, float> ScalarInterpolatorType;

--- a/Examples/MeasureImageSimilarity.cxx
+++ b/Examples/MeasureImageSimilarity.cxx
@@ -229,7 +229,7 @@ int MeasureImageSimilarity( itk::ants::CommandLineParser *parser )
           }
         typedef itk::MattesMutualInformationImageToImageMetricv4<ImageType, ImageType, ImageType, TComputeType> MutualInformationMetricType;
         typename MutualInformationMetricType::Pointer mutualInformationMetric = MutualInformationMetricType::New();
-        mutualInformationMetric = mutualInformationMetric;
+        //mutualInformationMetric = mutualInformationMetric;
         mutualInformationMetric->SetNumberOfHistogramBins( binOption );
         mutualInformationMetric->SetUseMovingImageGradientFilter( gradientfilter );
         mutualInformationMetric->SetUseFixedImageGradientFilter( gradientfilter );
@@ -249,7 +249,7 @@ int MeasureImageSimilarity( itk::ants::CommandLineParser *parser )
         typedef itk::JointHistogramMutualInformationImageToImageMetricv4<ImageType, ImageType, ImageType,
                                                                         TComputeType> MutualInformationMetricType;
         typename MutualInformationMetricType::Pointer mutualInformationMetric = MutualInformationMetricType::New();
-        mutualInformationMetric = mutualInformationMetric;
+        //mutualInformationMetric = mutualInformationMetric;
         mutualInformationMetric->SetNumberOfHistogramBins( binOption );
         mutualInformationMetric->SetUseMovingImageGradientFilter( gradientfilter );
         mutualInformationMetric->SetUseFixedImageGradientFilter( gradientfilter );
@@ -268,8 +268,7 @@ int MeasureImageSimilarity( itk::ants::CommandLineParser *parser )
 
         typedef itk::MeanSquaresImageToImageMetricv4<ImageType, ImageType, ImageType, TComputeType> MeanSquaresMetricType;
         typename MeanSquaresMetricType::Pointer meanSquaresMetric = MeanSquaresMetricType::New();
-        meanSquaresMetric = meanSquaresMetric;
-
+        //meanSquaresMetric = meanSquaresMetric;
         imageMetric = meanSquaresMetric;
         }
         break;

--- a/Examples/antsAI.cxx
+++ b/Examples/antsAI.cxx
@@ -1155,7 +1155,7 @@ int antsAI( itk::ants::CommandLineParser *parser )
       }
     typedef itk::MattesMutualInformationImageToImageMetricv4<ImageType, ImageType, ImageType, RealType> MutualInformationMetricType;
     typename MutualInformationMetricType::Pointer mutualInformationMetric = MutualInformationMetricType::New();
-    mutualInformationMetric = mutualInformationMetric;
+    //mutualInformationMetric = mutualInformationMetric;
     mutualInformationMetric->SetNumberOfHistogramBins( numberOfBins );
     mutualInformationMetric->SetUseMovingImageGradientFilter( true );
     mutualInformationMetric->SetUseFixedImageGradientFilter( true );
@@ -1171,7 +1171,7 @@ int antsAI( itk::ants::CommandLineParser *parser )
     typedef itk::JointHistogramMutualInformationImageToImageMetricv4<ImageType, ImageType, ImageType,
                                                                      RealType> MutualInformationMetricType;
     typename MutualInformationMetricType::Pointer mutualInformationMetric = MutualInformationMetricType::New();
-    mutualInformationMetric = mutualInformationMetric;
+    //mutualInformationMetric = mutualInformationMetric;
     mutualInformationMetric->SetNumberOfHistogramBins( numberOfBins );
     mutualInformationMetric->SetUseMovingImageGradientFilter( true );
     mutualInformationMetric->SetUseFixedImageGradientFilter( true );

--- a/Examples/antsMotionCorr.cxx
+++ b/Examples/antsMotionCorr.cxx
@@ -943,7 +943,7 @@ int ants_motion( itk::ants::CommandLineParser *parser )
         typedef itk::MattesMutualInformationImageToImageMetricv4<FixedImageType,
                                                                  FixedImageType> MutualInformationMetricType;
         typename MutualInformationMetricType::Pointer mutualInformationMetric = MutualInformationMetricType::New();
-        mutualInformationMetric = mutualInformationMetric;
+        //mutualInformationMetric = mutualInformationMetric;
         mutualInformationMetric->SetNumberOfHistogramBins( binOption );
         mutualInformationMetric->SetUseMovingImageGradientFilter( false );
         mutualInformationMetric->SetUseFixedImageGradientFilter( false );
@@ -957,7 +957,7 @@ int ants_motion( itk::ants::CommandLineParser *parser )
           }
         typedef itk::MeanSquaresImageToImageMetricv4<FixedImageType, FixedImageType> DemonsMetricType;
         typename DemonsMetricType::Pointer demonsMetric = DemonsMetricType::New();
-        demonsMetric = demonsMetric;
+        //demonsMetric = demonsMetric;
         metric = demonsMetric;
         }
       else if( std::strcmp( whichMetric.c_str(), "gc" ) == 0 )

--- a/Examples/antsSliceRegularizedRegistration.cxx
+++ b/Examples/antsSliceRegularizedRegistration.cxx
@@ -684,7 +684,7 @@ int ants_slice_regularized_registration( itk::ants::CommandLineParser *parser )
         typedef itk::MattesMutualInformationImageToImageMetricv4<FixedImageType,
                                                                  FixedImageType> MutualInformationMetricType;
         typename MutualInformationMetricType::Pointer mutualInformationMetric = MutualInformationMetricType::New();
-        mutualInformationMetric = mutualInformationMetric;
+        //mutualInformationMetric = mutualInformationMetric;
         mutualInformationMetric->SetNumberOfHistogramBins( binOption );
         mutualInformationMetric->SetUseMovingImageGradientFilter( false );
         mutualInformationMetric->SetUseFixedImageGradientFilter( false );
@@ -694,7 +694,7 @@ int ants_slice_regularized_registration( itk::ants::CommandLineParser *parser )
         {
         typedef itk::MeanSquaresImageToImageMetricv4<FixedImageType, FixedImageType> MSQMetricType;
         typename MSQMetricType::Pointer demonsMetric = MSQMetricType::New();
-        demonsMetric = demonsMetric;
+        //demonsMetric = demonsMetric;
         metric = demonsMetric;
         }
       else if( std::strcmp( whichMetric.c_str(), "gc" ) == 0 )

--- a/Examples/itkantsRegistrationHelper.hxx
+++ b/Examples/itkantsRegistrationHelper.hxx
@@ -951,7 +951,7 @@ RegistrationHelper<TComputeType, VImageDimension>
                          << stageMetricList[currentMetricNumber].m_Weighting << ")" << std::endl;
           typedef itk::MattesMutualInformationImageToImageMetricv4<ImageType, ImageType, ImageType, TComputeType> MutualInformationMetricType;
           typename MutualInformationMetricType::Pointer mutualInformationMetric = MutualInformationMetricType::New();
-          mutualInformationMetric = mutualInformationMetric;
+          // mutualInformationMetric = mutualInformationMetric;
           mutualInformationMetric->SetNumberOfHistogramBins( binOption );
           mutualInformationMetric->SetUseMovingImageGradientFilter( gradientfilter );
           mutualInformationMetric->SetUseFixedImageGradientFilter( gradientfilter );
@@ -969,7 +969,7 @@ RegistrationHelper<TComputeType, VImageDimension>
           typedef itk::JointHistogramMutualInformationImageToImageMetricv4<ImageType, ImageType, ImageType,
                                                                            TComputeType> MutualInformationMetricType;
           typename MutualInformationMetricType::Pointer mutualInformationMetric = MutualInformationMetricType::New();
-          mutualInformationMetric = mutualInformationMetric;
+          //mutualInformationMetric = mutualInformationMetric;
           mutualInformationMetric->SetNumberOfHistogramBins( binOption );
           mutualInformationMetric->SetUseMovingImageGradientFilter( gradientfilter );
           mutualInformationMetric->SetUseFixedImageGradientFilter( gradientfilter );
@@ -986,7 +986,7 @@ RegistrationHelper<TComputeType, VImageDimension>
 
           typedef itk::MeanSquaresImageToImageMetricv4<ImageType, ImageType, ImageType, TComputeType> MeanSquaresMetricType;
           typename MeanSquaresMetricType::Pointer meanSquaresMetric = MeanSquaresMetricType::New();
-          meanSquaresMetric = meanSquaresMetric;
+          //meanSquaresMetric = meanSquaresMetric;
 
           imageMetric = meanSquaresMetric;
           }


### PR DESCRIPTION
ANTs/Examples/itkantsRegistrationHelper.hxx:954:35: warning:
      explicitly assigning value of variable of type 'typename
      MutualInformationMetricType::Pointer' to itself [-Wself-assign-overloaded]
          mutualInformationMetric = mutualInformationMetric;
          ~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~