### PR TITLE
PERF: Allow overwriting ABI/Optimization & Warning flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10.2...3.14.2)
+cmake_policy(VERSION 3.10.2...3.14.2)
 
 if(CMAKE_CXX_STANDARD EQUAL "98" )
    message(FATAL_ERROR "CMAKE_CXX_STANDARD:STRING=98 is not supported in ITK version 5 and greater.")


### PR DESCRIPTION
Provide a mechanism for changing the default warning
and ABI/OPTIMIZATION flags.

The default ABI/Optimization flag settings are
set to:
    -mtune=native # Tune the code for the computer used compile
                  # ITK, but allow running on generic cpu
                  # archetectures
    -march=corei7-avx # Use ABI settings to support corei7-avx
                      # (circa 2013 ABI feature sets)

The defaults can easily be overriden from the cmake comand line with:
  -DANTs_C_OPTIMIZATION_FLAGS:STRING="-march=native"
  -DANTs_CXX_OPTIMIZATION_FLAGS:STRING="-march=native"
  -DANTs_C_WARNING_FLAGS:STRING="-Wall -Werror"
  -DANTs_CXX_WARNING_FLAGS:STRING="-Wall -Werror"