### PR TITLE
COMP: Allow building with ITK_LEGACY_REMOVE turned on

### DIFF
--- a/ImageRegistration/itkANTSImageRegistrationOptimizer.h
+++ b/ImageRegistration/itkANTSImageRegistrationOptimizer.h
@@ -35,7 +35,7 @@
 #include "itkFiniteDifferenceFunction.h"
 #include "itkFixedArray.h"
 #include "itkANTSSimilarityMetric.h"
-#include "itkVectorExpandImageFilter.h"
+#include "itkExpandImageFilter.h"
 #include "itkPDEDeformableRegistrationFilter.h"
 #include "itkWarpImageFilter.h"
 #include "itkWarpImageMultiTransformFilter.h"
@@ -369,7 +369,7 @@ public:
         }
       }
     VectorType pad;  pad.Fill(0);
-    typedef VectorExpandImageFilter<TimeVaryingVelocityFieldType, TimeVaryingVelocityFieldType> ExpanderType;
+    typedef ExpandImageFilter<TimeVaryingVelocityFieldType, TimeVaryingVelocityFieldType> ExpanderType;
     typename ExpanderType::Pointer m_FieldExpander = ExpanderType::New();
     m_FieldExpander->SetInput(this->m_TimeVaryingVelocity);
     m_FieldExpander->SetExpandFactors( expandFactors );
@@ -397,7 +397,7 @@ public:
 
     VectorType pad;
     pad.Fill(0);
-    typedef VectorExpandImageFilter<DisplacementFieldType, DisplacementFieldType> ExpanderType;
+    typedef ExpandImageFilter<DisplacementFieldType, DisplacementFieldType> ExpanderType;
     typename ExpanderType::Pointer m_FieldExpander = ExpanderType::New();
     m_FieldExpander->SetInput(field);
     m_FieldExpander->SetExpandFactors( expandFactors );

--- a/SuperBuild/External_ITKv5.cmake
+++ b/SuperBuild/External_ITKv5.cmake
@@ -151,7 +151,7 @@ if(NOT DEFINED ${extProjName}_DIR AND NOT ${USE_SYSTEM_${extProjName}})
   ### --- End Project specific additions
   set(${proj}_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITK.git)
   # set(${proj}_REPOSITORY ${git_protocol}://github.com/stnava/ITK.git)
-  set(${proj}_GIT_TAG 683ba61ad9a95e9bbab9dd30e53c1fda3a37519b ) ## 20190703 Fix warning
+  set(${proj}_GIT_TAG  bccf5544c9a689bb70ddfc228da68734f9c54052) ## 20190816 Allow building with LEGACY_REMOVE =on
   set(ITK_VERSION_ID ITK-5.1) ### NOTE: When updating GIT_TAG, also update ITK_VERSION_ID
 
   ExternalProject_Add(${proj}


### PR DESCRIPTION
The VectorExpandImage filter specialization is no longer needed because
the ExpandImage filter now works with both vector and scalar types
uniformly.