### PR TITLE
COMP: Updated `enum` to `enum class` for c++11

### DIFF
--- a/Examples/ANTS.cxx
+++ b/Examples/ANTS.cxx
@@ -190,14 +190,14 @@ private:
   if( argc == 3 && ( std::stoi( argv[1] ) != '-' || std::stoi( argv[1] ) != 2 || std::stoi( argv[1] ) != 3 ) )
     {
     itk::ImageIOBase::Pointer fixedImageIO
-      = itk::ImageIOFactory::CreateImageIO( argv[1], itk::ImageIOFactory::ReadMode );
+      = itk::ImageIOFactory::CreateImageIO( argv[1], itk::ImageIOFactory::FileModeType::ReadMode );
     if( fixedImageIO.IsNull() )
       {
       std::cerr << "Invalid fixed image: " << argv[1] << std::endl;
       return EXIT_FAILURE;
       }
     itk::ImageIOBase::Pointer movingImageIO
-      = itk::ImageIOFactory::CreateImageIO( argv[2], itk::ImageIOFactory::ReadMode );
+      = itk::ImageIOFactory::CreateImageIO( argv[2], itk::ImageIOFactory::FileModeType::ReadMode );
     if( movingImageIO.IsNull() )
       {
       std::cerr << "Invalid moving image: " << argv[2] << std::endl;

--- a/Examples/ANTSIntegrateVectorField.cxx
+++ b/Examples/ANTSIntegrateVectorField.cxx
@@ -459,7 +459,7 @@ private:
 
   std::string               ifn = std::string(argv[1]);
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(ifn.c_str(), itk::ImageIOFactory::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(ifn.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
   imageIO->SetFileName(ifn.c_str() );
   imageIO->ReadImageInformation();
   unsigned int dim =  imageIO->GetNumberOfDimensions();

--- a/Examples/ANTSIntegrateVelocityField.cxx
+++ b/Examples/ANTSIntegrateVelocityField.cxx
@@ -169,7 +169,7 @@ private:
   std::cout << " start " << std::endl;
   std::string               ifn = std::string(argv[1]);
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(ifn.c_str(), itk::ImageIOFactory::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(ifn.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
   imageIO->SetFileName(ifn.c_str() );
   imageIO->ReadImageInformation();
   unsigned int dim =  imageIO->GetNumberOfDimensions();

--- a/Examples/ANTSUseDeformationFieldToGetAffineTransform.cxx
+++ b/Examples/ANTSUseDeformationFieldToGetAffineTransform.cxx
@@ -480,7 +480,7 @@ private:
   // Get the image dimension
   // std::string fn = std::string(argv[1]) + "xvec.nii.gz";
   // itk::ImageIOBase::Pointer imageIO =
-  //        itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::ReadMode);
+  //        itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
   // imageIO->SetFileName(fn.c_str());
   // imageIO->ReadImageInformation();
 

--- a/Examples/ANTSUseLandmarkImagesToGetAffineTransform.cxx
+++ b/Examples/ANTSUseLandmarkImagesToGetAffineTransform.cxx
@@ -435,7 +435,7 @@ private:
   // Get the image dimension
   std::string               fn = std::string(argv[1]);
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
   imageIO->SetFileName(fn.c_str() );
   imageIO->ReadImageInformation();
 

--- a/Examples/ANTSUseLandmarkImagesToGetBSplineDisplacementField.cxx
+++ b/Examples/ANTSUseLandmarkImagesToGetBSplineDisplacementField.cxx
@@ -541,7 +541,7 @@ private:
   // Get the image dimension
   std::string               fn = std::string(argv[1]);
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
   imageIO->SetFileName(fn.c_str() );
   imageIO->ReadImageInformation();
 

--- a/Examples/Atropos.cxx
+++ b/Examples/Atropos.cxx
@@ -1774,7 +1774,7 @@ private:
       return EXIT_FAILURE;
       }
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        filename.c_str(), itk::ImageIOFactory::ReadMode );
+        filename.c_str(), itk::ImageIOFactory::FileModeType::ReadMode );
     dimension = imageIO->GetNumberOfDimensions();
     }
 

--- a/Examples/AverageImages.cxx
+++ b/Examples/AverageImages.cxx
@@ -72,7 +72,7 @@ int AverageImages1(unsigned int argc, char *argv[])
     // Get the image dimension
     const std::string fn = std::string(argv[j]);
     typename itk::ImageIOBase::Pointer imageIO =
-      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::ReadMode);
+      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
     imageIO->SetFileName(fn.c_str() );
     imageIO->ReadImageInformation();
 
@@ -194,7 +194,7 @@ int AverageImages(unsigned int argc, char *argv[])
     std::string fn = std::string(argv[j]);
     std::cout << " fn " << fn << " " << ImageDimension << " " << NVectorComponents << std::endl;
     typename itk::ImageIOBase::Pointer imageIO =
-      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::ReadMode);
+      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
     imageIO->SetFileName( fn.c_str() );
     imageIO->ReadImageInformation();
 
@@ -326,7 +326,7 @@ private:
 
   const int                 dim = std::stoi( argv[1] );
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(argv[4], itk::ImageIOFactory::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(argv[4], itk::ImageIOFactory::FileModeType::ReadMode);
   imageIO->SetFileName(argv[4]);
   imageIO->ReadImageInformation();
   unsigned int ncomponents = imageIO->GetNumberOfComponents();

--- a/Examples/AverageTensorImages.cxx
+++ b/Examples/AverageTensorImages.cxx
@@ -37,7 +37,7 @@ int AverageTensorImages(unsigned int argc, char *argv[])
     std::string fn = std::string(argv[j]);
     std::cout << " fn " << fn << std::endl;
     typename itk::ImageIOBase::Pointer imageIO =
-      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::ReadMode);
+      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
     imageIO->SetFileName(fn.c_str() );
     imageIO->ReadImageInformation();
     for( unsigned int i = 0; i < imageIO->GetNumberOfDimensions(); i++ )

--- a/Examples/ConvertImagePixelType.cxx
+++ b/Examples/ConvertImagePixelType.cxx
@@ -170,7 +170,7 @@ private:
   std::string               fn = std::string(argv[1]);
   itk::ImageIOBase::Pointer imageIO =
     itk::ImageIOFactory::CreateImageIO(
-      fn.c_str(), itk::ImageIOFactory::ReadMode);
+      fn.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
   imageIO->SetFileName(fn.c_str() );
   imageIO->ReadImageInformation();
 

--- a/Examples/ConvertInputImagePixelTypeToFloat.cxx
+++ b/Examples/ConvertInputImagePixelTypeToFloat.cxx
@@ -150,7 +150,7 @@ private:
   std::string               fn = std::string(argv[1]);
   itk::ImageIOBase::Pointer imageIO =
     itk::ImageIOFactory::CreateImageIO(
-      fn.c_str(), itk::ImageIOFactory::ReadMode);
+      fn.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
   imageIO->SetFileName(fn.c_str() );
   imageIO->ReadImageInformation();
 

--- a/Examples/ConvertScalarImageToRGB.cxx
+++ b/Examples/ConvertScalarImageToRGB.cxx
@@ -73,51 +73,51 @@ int ConvertScalarImageToRGB( int argc, char *argv[] )
 
   if( colormapString == "red" )
     {
-    rgbfilter->SetColormap( RGBFilterType::Red );
+    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Red );
     }
   else if( colormapString == "green"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::Green );
+    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Green );
     }
   else if( colormapString == "blue"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::Blue );
+    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Blue );
     }
   else if( colormapString == "grey"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::Grey );
+    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Grey );
     }
   else if( colormapString == "cool"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::Cool );
+    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Cool );
     }
   else if( colormapString == "hot"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::Hot );
+    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Hot );
     }
   else if( colormapString == "spring"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::Spring );
+    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Spring );
     }
   else if( colormapString == "autumn"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::Autumn );
+    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Autumn );
     }
   else if( colormapString == "winter"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::Winter );
+    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Winter );
     }
   else if( colormapString == "copper"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::Copper );
+    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Copper );
     }
   else if( colormapString == "summer"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::Summer );
+    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Summer );
     }
   else if( colormapString == "jet"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::Jet );
+    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Jet );
 //    typedef itk::Function::JetColormapFunction<typename RealImageType::PixelType,
 //      typename RGBImageType::PixelType> ColormapType;
 //    typename ColormapType::Pointer colormap = ColormapType::New();
@@ -125,7 +125,7 @@ int ConvertScalarImageToRGB( int argc, char *argv[] )
     }
   else if( colormapString == "hsv"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::HSV );
+    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::HSV );
 //    typedef itk::Function::HSVColormapFunction<typename RealImageType::PixelType,
 //      typename RGBImageType::PixelType> ColormapType;
 //    typename ColormapType::Pointer colormap = ColormapType::New();
@@ -133,7 +133,7 @@ int ConvertScalarImageToRGB( int argc, char *argv[] )
     }
   else if( colormapString == "overunder"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::OverUnder );
+    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::OverUnder );
     }
   else if( colormapString == "custom"  )
     {

--- a/Examples/ConvertToJpg.cxx
+++ b/Examples/ConvertToJpg.cxx
@@ -148,7 +148,7 @@ private:
     std::string               fn = std::string(argv[1]);
     itk::ImageIOBase::Pointer imageIO =
       itk::ImageIOFactory::CreateImageIO(
-        fn.c_str(), itk::ImageIOFactory::ReadMode);
+        fn.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
     imageIO->SetFileName(fn.c_str() );
     imageIO->ReadImageInformation();
 

--- a/Examples/CopyImageHeaderInformation.cxx
+++ b/Examples/CopyImageHeaderInformation.cxx
@@ -184,7 +184,7 @@ private:
   std::string               fn = std::string(argv[1]);
   itk::ImageIOBase::Pointer imageIO =
     itk::ImageIOFactory::CreateImageIO(
-      fn.c_str(), itk::ImageIOFactory::ReadMode);
+      fn.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
   imageIO->SetFileName(fn.c_str() );
   imageIO->ReadImageInformation();
   unsigned int dim = imageIO->GetNumberOfDimensions();

--- a/Examples/CreateDTICohort.cxx
+++ b/Examples/CreateDTICohort.cxx
@@ -1180,7 +1180,7 @@ private:
       return EXIT_FAILURE;
       }
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        filename.c_str(), itk::ImageIOFactory::ReadMode );
+        filename.c_str(), itk::ImageIOFactory::FileModeType::ReadMode );
     dimension = imageIO->GetNumberOfDimensions();
     }
 

--- a/Examples/CreateTiledMosaic.cxx
+++ b/Examples/CreateTiledMosaic.cxx
@@ -1287,7 +1287,7 @@ private:
     filename = imageOption->GetFunction( 0 )->GetName();
 
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        filename.c_str(), itk::ImageIOFactory::ReadMode );
+        filename.c_str(), itk::ImageIOFactory::FileModeType::ReadMode );
     unsigned int dimension = imageIO->GetNumberOfDimensions();
 
     if( dimension == 3 )

--- a/Examples/DenoiseImage.cxx
+++ b/Examples/DenoiseImage.cxx
@@ -649,7 +649,7 @@ private:
       return EXIT_FAILURE;
       }
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        filename.c_str(), itk::ImageIOFactory::ReadMode );
+        filename.c_str(), itk::ImageIOFactory::FileModeType::ReadMode );
     dimension = imageIO->GetNumberOfDimensions();
     }
 

--- a/Examples/ImageMath_Templates.hxx
+++ b/Examples/ImageMath_Templates.hxx
@@ -1053,7 +1053,7 @@ int TileImages(unsigned int argc, char *argv[])
     // Get the image dimension
     std::string fn = std::string(argv[j]);
     typename itk::ImageIOBase::Pointer imageIO =
-      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::ReadMode);
+      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
     imageIO->SetFileName(fn.c_str() );
     imageIO->ReadImageInformation();
 
@@ -5762,7 +5762,7 @@ int TensorFunctions(int argc, char *argv[])
       " Convert a 4D tensor to a 3D tensor --- if there are 7 components to the tensor, we throw away the first component b/c its probably b0 "
       << std::endl;
     itk::ImageIOBase::Pointer imageIO =
-      itk::ImageIOFactory::CreateImageIO(fn1.c_str(), itk::ImageIOFactory::ReadMode);
+      itk::ImageIOFactory::CreateImageIO(fn1.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
     imageIO->SetFileName(fn1.c_str() );
     imageIO->ReadImageInformation();
     unsigned int dim = imageIO->GetNumberOfDimensions();
@@ -10966,7 +10966,7 @@ int ConvertImageSetToMatrix(unsigned int argc, char *argv[])
     // Get the image dimension
     std::string fn = std::string(argv[j]);
     typename itk::ImageIOBase::Pointer imageIO =
-      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::ReadMode);
+      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
     imageIO->SetFileName(fn.c_str() );
     imageIO->ReadImageInformation();
     for( unsigned int i = 0; i < imageIO->GetNumberOfDimensions(); i++ )
@@ -11263,7 +11263,7 @@ int ConvertImageSetToEigenvectors(unsigned int argc, char *argv[])
     // Get the image dimension
     std::string fn = std::string(argv[j]);
     typename itk::ImageIOBase::Pointer imageIO =
-      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::ReadMode);
+      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
     imageIO->SetFileName(fn.c_str() );
     imageIO->ReadImageInformation();
     for( unsigned int i = 0; i < imageIO->GetNumberOfDimensions(); i++ )

--- a/Examples/KellyKapowski.cxx
+++ b/Examples/KellyKapowski.cxx
@@ -834,7 +834,7 @@ private:
       return EXIT_FAILURE;
       }
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        filename.c_str(), itk::ImageIOFactory::ReadMode );
+        filename.c_str(), itk::ImageIOFactory::FileModeType::ReadMode );
     dimension = imageIO->GetNumberOfDimensions();
     }
 

--- a/Examples/LaplacianThickness.cxx
+++ b/Examples/LaplacianThickness.cxx
@@ -1002,7 +1002,7 @@ private:
   //  std::cout << " image " << ifn << std::endl;
   // Get the image dimension
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(ifn.c_str(), itk::ImageIOFactory::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(ifn.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
   imageIO->SetFileName(ifn.c_str() );
   imageIO->ReadImageInformation();
   unsigned int dim =  imageIO->GetNumberOfDimensions();

--- a/Examples/MeasureMinMaxMean.cxx
+++ b/Examples/MeasureMinMaxMean.cxx
@@ -187,7 +187,7 @@ private:
     }
   int                       dim = std::stoi( argv[1] );
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(argv[2], itk::ImageIOFactory::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(argv[2], itk::ImageIOFactory::FileModeType::ReadMode);
   imageIO->SetFileName(argv[2]);
   imageIO->ReadImageInformation();
   unsigned int ncomponents = imageIO->GetNumberOfComponents();

--- a/Examples/MultiplyImages.cxx
+++ b/Examples/MultiplyImages.cxx
@@ -185,7 +185,7 @@ private:
 
   int                       dim = std::stoi( argv[1] );
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(argv[2], itk::ImageIOFactory::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(argv[2], itk::ImageIOFactory::FileModeType::ReadMode);
   imageIO->SetFileName(argv[2]);
   imageIO->ReadImageInformation();
   unsigned int ncomponents = imageIO->GetNumberOfComponents();

--- a/Examples/N4BiasFieldCorrection.cxx
+++ b/Examples/N4BiasFieldCorrection.cxx
@@ -944,7 +944,7 @@ private:
       return EXIT_FAILURE;
       }
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        filename.c_str(), itk::ImageIOFactory::ReadMode );
+        filename.c_str(), itk::ImageIOFactory::FileModeType::ReadMode );
     dimension = imageIO->GetNumberOfDimensions();
     }
 

--- a/Examples/NonLocalSuperResolution.cxx
+++ b/Examples/NonLocalSuperResolution.cxx
@@ -717,7 +717,7 @@ private:
       return EXIT_FAILURE;
       }
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        filename.c_str(), itk::ImageIOFactory::ReadMode );
+        filename.c_str(), itk::ImageIOFactory::FileModeType::ReadMode );
     dimension = imageIO->GetNumberOfDimensions();
     }
 

--- a/Examples/PrintHeader.cxx
+++ b/Examples/PrintHeader.cxx
@@ -456,7 +456,7 @@ private:
     }
   itk::ImageIOBase::Pointer imageIO =
     itk::ImageIOFactory::CreateImageIO(
-      fn.c_str(), itk::ImageIOFactory::ReadMode);
+      fn.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
   imageIO->SetFileName(fn.c_str() );
   try
     {

--- a/Examples/ResetDirection.cxx
+++ b/Examples/ResetDirection.cxx
@@ -136,7 +136,7 @@ private:
   std::string               fn = std::string(argv[1]);
   itk::ImageIOBase::Pointer imageIO =
     itk::ImageIOFactory::CreateImageIO(
-      fn.c_str(), itk::ImageIOFactory::ReadMode);
+      fn.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
   imageIO->SetFileName(fn.c_str() );
   imageIO->ReadImageInformation();
 

--- a/Examples/SetDirectionByMatrix.cxx
+++ b/Examples/SetDirectionByMatrix.cxx
@@ -155,7 +155,7 @@ private:
   std::string               fn = std::string(argv[1]);
   itk::ImageIOBase::Pointer imageIO =
     itk::ImageIOFactory::CreateImageIO(
-      fn.c_str(), itk::ImageIOFactory::ReadMode);
+      fn.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
   imageIO->SetFileName(fn.c_str() );
   imageIO->ReadImageInformation();
 

--- a/Examples/StudentsTestOnImages.cxx
+++ b/Examples/StudentsTestOnImages.cxx
@@ -454,7 +454,7 @@ int StudentsTestOnImages(int argc, char *argv[])
   // Get the image dimension
   std::string               fn = std::string(argv[5]);
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
   imageIO->SetFileName(fn.c_str() );
   imageIO->ReadImageInformation();
   typename ImageType::SizeType size;

--- a/Examples/WarpImageMultiTransform.cxx
+++ b/Examples/WarpImageMultiTransform.cxx
@@ -808,7 +808,7 @@ private:
   if( is_parsing_ok )
     {
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(moving_image_filename,
-                                                                           itk::ImageIOFactory::ReadMode);
+                                                                           itk::ImageIOFactory::FileModeType::ReadMode);
     imageIO->SetFileName(moving_image_filename);
     imageIO->ReadImageInformation();
     unsigned int ncomponents = imageIO->GetNumberOfComponents();

--- a/Examples/WarpTimeSeriesImageMultiTransform.cxx
+++ b/Examples/WarpTimeSeriesImageMultiTransform.cxx
@@ -483,7 +483,7 @@ void WarpImageMultiTransform(char *moving_image_filename, char *output_image_fil
 
   typename VectorImageType::Pointer img_mov;
   typename itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(moving_image_filename, itk::ImageIOFactory::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(moving_image_filename, itk::ImageIOFactory::FileModeType::ReadMode);
   imageIO->SetFileName(moving_image_filename);
   imageIO->ReadImageInformation();
   //    std::cout << " Dimension " << imageIO->GetNumberOfDimensions()  << " Components "

--- a/Examples/antsAlignOrigin.cxx
+++ b/Examples/antsAlignOrigin.cxx
@@ -323,7 +323,7 @@ private:
     parser->GetOption( "input-image-type" );
 
   itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-      filename.c_str(), itk::ImageIOFactory::ReadMode );
+      filename.c_str(), itk::ImageIOFactory::FileModeType::ReadMode );
   unsigned int dimension = imageIO->GetNumberOfDimensions();
 
   itk::ants::CommandLineParser::OptionType::Pointer dimOption =

--- a/Examples/antsApplyTransforms.cxx
+++ b/Examples/antsApplyTransforms.cxx
@@ -1042,7 +1042,7 @@ private:
 
   // BA - code below creates problems in ANTsR
   //  itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-  //                                                            filename.c_str(), itk::ImageIOFactory::ReadMode );
+  //                                                            filename.c_str(), itk::ImageIOFactory::FileModeType::ReadMode );
   //  dimension = imageIO->GetNumberOfDimensions();
 
   itk::ants::CommandLineParser::OptionType::Pointer dimOption =

--- a/Examples/antsJointFusion.cxx
+++ b/Examples/antsJointFusion.cxx
@@ -1002,7 +1002,7 @@ private:
       return EXIT_FAILURE;
       }
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        filename.c_str(), itk::ImageIOFactory::ReadMode );
+        filename.c_str(), itk::ImageIOFactory::FileModeType::ReadMode );
     dimension = imageIO->GetNumberOfDimensions();
     }
 

--- a/Examples/antsJointTensorFusion.cxx
+++ b/Examples/antsJointTensorFusion.cxx
@@ -974,7 +974,7 @@ private:
       return EXIT_FAILURE;
       }
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        filename.c_str(), itk::ImageIOFactory::ReadMode );
+        filename.c_str(), itk::ImageIOFactory::FileModeType::ReadMode );
     dimension = imageIO->GetNumberOfDimensions();
     }
 

--- a/Examples/antsMotionCorrDiffusionDirection.cxx
+++ b/Examples/antsMotionCorrDiffusionDirection.cxx
@@ -319,7 +319,7 @@ int ants_motion_directions( itk::ants::CommandLineParser *parser )
   // Therefore check reference image is 3D, and fail if not
   //
  itk::ImageIOBase::Pointer imageIO =
-   itk::ImageIOFactory::CreateImageIO(physicalName.c_str(), itk::ImageIOFactory::ReadMode);
+   itk::ImageIOFactory::CreateImageIO(physicalName.c_str(), itk::ImageIOFactory::FileModeType::ReadMode);
  imageIO->SetFileName(physicalName.c_str() );
  try
    {

--- a/Examples/antsRegistrationTemplateHeader.h
+++ b/Examples/antsRegistrationTemplateHeader.h
@@ -1240,8 +1240,8 @@ DoRegistration(typename ParserType::Pointer & parser)
       }
     unsigned int numStateComponents = savedStateTx->GetNumberOfTransforms();
     // If the last two transforms are displacement field transforms, we add their inverse displacement field to the saved state composite.
-    if( savedStateTx->GetNthTransform( numStateComponents-1 )->GetTransformCategory() == TransformType::DisplacementField
-       && savedStateTx->GetNthTransform( numStateComponents-2 )->GetTransformCategory() == TransformType::DisplacementField )
+    if( savedStateTx->GetNthTransform( numStateComponents-1 )->GetTransformCategory() == TransformType::TransformCategoryType::DisplacementField
+       && savedStateTx->GetNthTransform( numStateComponents-2 )->GetTransformCategory() == TransformType::TransformCategoryType::DisplacementField )
       {
       typename DisplacementFieldTransformType::Pointer oneToEndTransform =
         dynamic_cast<DisplacementFieldTransformType *>( savedStateTx->GetNthTransform( numStateComponents-2 ).GetPointer() );
@@ -1281,13 +1281,13 @@ DoRegistration(typename ParserType::Pointer & parser)
       TransformTypeNames.clear();
       for( unsigned int i = 0; i < numTransforms; i++ )
         {
-        if( transformToWrite->GetNthTransform( i )->GetTransformCategory() == TransformType::Linear )
+        if( transformToWrite->GetNthTransform( i )->GetTransformCategory() == TransformType::TransformCategoryType::Linear )
           {
           // The output type must be Affine, not matrixoffset!  TransformTypeNames.push_back( "matrixoffset" );
           TransformTypeNames.emplace_back("genericaffine" );
           }
         else if( transformToWrite->GetNthTransform( i )->GetTransformCategory() ==
-          TransformType::DisplacementField )
+          TransformType::TransformCategoryType::DisplacementField )
           {
           typename DisplacementFieldTransformType::Pointer nthTransform =
             dynamic_cast<DisplacementFieldTransformType *>( transformToWrite->GetNthTransform( i ).GetPointer() );
@@ -1305,7 +1305,7 @@ DoRegistration(typename ParserType::Pointer & parser)
             TransformTypeNames.emplace_back("gdf" );
             }
           }
-        else if( transformToWrite->GetNthTransform( i )->GetTransformCategory() == TransformType::BSpline )
+        else if( transformToWrite->GetNthTransform( i )->GetTransformCategory() == TransformType::TransformCategoryType::BSpline )
           {
           TransformTypeNames.emplace_back("bspline" );
           }

--- a/Examples/antsSurf.cxx
+++ b/Examples/antsSurf.cxx
@@ -1097,7 +1097,7 @@ private:
       inputFile = imageOption->GetFunction( 0 )->GetParameter( 0 );
       }
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        inputFile.c_str(), itk::ImageIOFactory::ReadMode );
+        inputFile.c_str(), itk::ImageIOFactory::FileModeType::ReadMode );
     unsigned int dimension = imageIO->GetNumberOfDimensions();
 
     if( dimension == 3 )

--- a/Examples/antsVol.cxx
+++ b/Examples/antsVol.cxx
@@ -563,7 +563,7 @@ private:
       inputFile = imageOption->GetFunction( 0 )->GetParameter( 0 );
       }
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        inputFile.c_str(), itk::ImageIOFactory::ReadMode );
+        inputFile.c_str(), itk::ImageIOFactory::FileModeType::ReadMode );
     unsigned int dimension = imageIO->GetNumberOfDimensions();
 
     if( dimension == 3 )

--- a/Examples/itkantsRegistrationHelper.hxx
+++ b/Examples/itkantsRegistrationHelper.hxx
@@ -3336,10 +3336,10 @@ RegistrationHelper<TComputeType, VImageDimension>
     // transforms for a SyN registration.
     //
     unsigned int numTransforms = compToRestore->GetNumberOfTransforms();
-    if( (compToRestore->GetNthTransform( numTransforms-1 )->GetTransformCategory() == TransformType::DisplacementField)
-       && (compToRestore->GetNthTransform( numTransforms-2 )->GetTransformCategory() == TransformType::DisplacementField)
-       && (compToRestore->GetNthTransform( numTransforms-3 )->GetTransformCategory() == TransformType::DisplacementField)
-       && (compToRestore->GetNthTransform( numTransforms-4 )->GetTransformCategory() == TransformType::DisplacementField) )
+    if( (compToRestore->GetNthTransform( numTransforms-1 )->GetTransformCategory() == TransformType::TransformCategoryType::DisplacementField)
+       && (compToRestore->GetNthTransform( numTransforms-2 )->GetTransformCategory() == TransformType::TransformCategoryType::DisplacementField)
+       && (compToRestore->GetNthTransform( numTransforms-3 )->GetTransformCategory() == TransformType::TransformCategoryType::DisplacementField)
+       && (compToRestore->GetNthTransform( numTransforms-4 )->GetTransformCategory() == TransformType::TransformCategoryType::DisplacementField) )
       {
       typename DisplacementFieldTransformType::Pointer fixedToMiddleForwardTx =
         dynamic_cast<DisplacementFieldTransformType *>( compToRestore->GetNthTransform( numTransforms-4 ).GetPointer() );
@@ -3505,7 +3505,7 @@ RegistrationHelper<TComputeType, VImageDimension>
 {
   typename CompositeTransformType::Pointer combinedCompositeTransform = CompositeTransformType::New();
 
-  if( compositeTransform->GetTransformCategory() != TransformType::DisplacementField  )
+  if( compositeTransform->GetTransformCategory() != TransformType::TransformCategoryType::DisplacementField  )
     {
     itkExceptionMacro( "The composite transform is not composed strictly of displacement fields." );
     }
@@ -3604,7 +3604,7 @@ RegistrationHelper<TComputeType, VImageDimension>
     collapsedCompositeTransform->AddTransform( this->CollapseLinearTransforms( compositeTransform ) );
     return collapsedCompositeTransform;
     }
-  else if( compositeTransform->GetTransformCategory() == TransformType::DisplacementField )
+  else if( compositeTransform->GetTransformCategory() == TransformType::TransformCategoryType::DisplacementField )
     {
     collapsedCompositeTransform->AddTransform( this->CollapseDisplacementFieldTransforms( compositeTransform ) );
     collapsedCompositeTransform->FlattenTransformQueue();
@@ -3612,13 +3612,13 @@ RegistrationHelper<TComputeType, VImageDimension>
     }
 
   // Find the first linear or displacement field transform
-  typename TransformType::TransformCategoryType currentTransformCategory = TransformType::UnknownTransformCategory;
+  typename TransformType::TransformCategoryType currentTransformCategory = TransformType::TransformCategoryType::UnknownTransformCategory;
   unsigned int startIndex = 0;
   for( unsigned int n = 0; n < compositeTransform->GetNumberOfTransforms(); n++ )
     {
     typename TransformType::TransformCategoryType transformCategory =
       compositeTransform->GetNthTransform( n )->GetTransformCategory();
-    if( transformCategory == TransformType::Linear || transformCategory == TransformType::DisplacementField )
+    if( transformCategory == TransformType::TransformCategoryType::Linear || transformCategory == TransformType::TransformCategoryType::DisplacementField )
       {
       currentTransformCategory = transformCategory;
       startIndex = n;
@@ -3632,7 +3632,7 @@ RegistrationHelper<TComputeType, VImageDimension>
 
   // If a linear or displacement field transform is found then we can break down the
   // composite transform into neighboring sets of like transform types.
-  if( currentTransformCategory != TransformType::UnknownTransformCategory )
+  if( currentTransformCategory != TransformType::TransformCategoryType::UnknownTransformCategory )
     {
     CompositeTransformPointer currentCompositeTransform = CompositeTransformType::New();
     currentCompositeTransform->AddTransform( compositeTransform->GetNthTransform( startIndex ) );
@@ -3645,11 +3645,11 @@ RegistrationHelper<TComputeType, VImageDimension>
         currentCompositeTransform->AddTransform( compositeTransform->GetNthTransform( n ) );
         if( n == compositeTransform->GetNumberOfTransforms() - 1 )
           {
-          if( currentTransformCategory == TransformType::Linear )
+          if( currentTransformCategory == TransformType::TransformCategoryType::Linear )
             {
             collapsedCompositeTransform->AddTransform( this->CollapseLinearTransforms( currentCompositeTransform ) );
             }
-          else if( currentTransformCategory == TransformType::DisplacementField )
+          else if( currentTransformCategory == TransformType::TransformCategoryType::DisplacementField )
             {
             collapsedCompositeTransform->AddTransform( this->CollapseDisplacementFieldTransforms(
                                                          currentCompositeTransform ) );
@@ -3658,12 +3658,12 @@ RegistrationHelper<TComputeType, VImageDimension>
         }
       else
         {
-        if( currentTransformCategory == TransformType::Linear )
+        if( currentTransformCategory == TransformType::TransformCategoryType::Linear )
           {
           collapsedCompositeTransform->AddTransform( this->CollapseLinearTransforms( currentCompositeTransform ) );
           currentCompositeTransform->ClearTransformQueue();
           }
-        else if( currentTransformCategory == TransformType::DisplacementField )
+        else if( currentTransformCategory == TransformType::TransformCategoryType::DisplacementField )
           {
           collapsedCompositeTransform->AddTransform( this->CollapseDisplacementFieldTransforms(
                                                        currentCompositeTransform ) );
@@ -3671,7 +3671,7 @@ RegistrationHelper<TComputeType, VImageDimension>
           }
         currentTransformCategory = transformCategory;
 
-        if( ( transformCategory == TransformType::Linear || transformCategory == TransformType::DisplacementField ) &&
+        if( ( transformCategory == TransformType::TransformCategoryType::Linear || transformCategory == TransformType::TransformCategoryType::DisplacementField ) &&
             n < compositeTransform->GetNumberOfTransforms() - 1 )
           {
           currentCompositeTransform->AddTransform( compositeTransform->GetNthTransform( n ) );

--- a/SuperBuild/External_ITKv5.cmake
+++ b/SuperBuild/External_ITKv5.cmake
@@ -151,7 +151,7 @@ if(NOT DEFINED ${extProjName}_DIR AND NOT ${USE_SYSTEM_${extProjName}})
   ### --- End Project specific additions
   set(${proj}_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITK.git)
   # set(${proj}_REPOSITORY ${git_protocol}://github.com/stnava/ITK.git)
-  set(${proj}_GIT_TAG  bccf5544c9a689bb70ddfc228da68734f9c54052) ## 20190816 Allow building with LEGACY_REMOVE =on
+  set(${proj}_GIT_TAG  81c14ce858a530699ee2fbf7fa48b884ad26b984 ) #20190914 - ITKv5 Enumerations with legacy OFF
   set(ITK_VERSION_ID ITK-5.1) ### NOTE: When updating GIT_TAG, also update ITK_VERSION_ID
 
   ExternalProject_Add(${proj}


### PR DESCRIPTION
Improve use of enumerations to new features in C++11.  A set of
refactorings to move from "c enumerations" to "strongly typed
enumerations" is included.

See: http://www.stroustrup.com/C++11FAQ.html#enum

The ITKSmoothing module now has a library that must be linked, so the
module dependancies must be moved from COMPILE_DEPENDS to DEPENDS.

Proper ENABLE_SHARED, and ITK{MODULENAME}_EXPORT with
`#include "ITK{MODULENAME}_Export.h"` instrumentation for
the ostream operators used with the enumerations are added.