### PR TITLE
COMP: Install ANTs with the make command

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -297,7 +297,6 @@ ExternalProject_Add(${proj}
     ${CMAKE_OSX_EXTERNAL_PROJECT_ARGS}
     ${COMMON_EXTERNAL_PROJECT_ARGS}
     -D${LOCAL_PROJECT_NAME}_SUPERBUILD:BOOL=OFF
-  INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
   )
 
 ## Force rebuilding of the main subproject every time building from super structure

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -297,7 +297,7 @@ ExternalProject_Add(${proj}
     ${CMAKE_OSX_EXTERNAL_PROJECT_ARGS}
     ${COMMON_EXTERNAL_PROJECT_ARGS}
     -D${LOCAL_PROJECT_NAME}_SUPERBUILD:BOOL=OFF
-  INSTALL_COMMAND ""
+  INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
   )
 
 ## Force rebuilding of the main subproject every time building from super structure


### PR DESCRIPTION
This installs to CMAKE_INSTALL_PREFIX after building, removes need for

cd ANTS-build
make install

