### PR TITLE
BUG: Restoring semi-colon at end of warning macro

### DIFF
--- a/ImageSegmentation/antsAtroposSegmentationImageFilter.hxx
+++ b/ImageSegmentation/antsAtroposSegmentationImageFilter.hxx
@@ -388,7 +388,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
     if( *it < 1 || *it > this->m_NumberOfTissueClasses )
       {
       itkWarningMacro( "The label " << *it << " is outside the specified "
-                                    << "range of the specified tissue class labels." )
+                                    << "range of the specified tissue class labels." );
       return;
       }
     }

--- a/Utilities/antsCommandLineParser.cxx
+++ b/Utilities/antsCommandLineParser.cxx
@@ -73,13 +73,13 @@ CommandLineParser
         this->GetOption( option->GetShortName() ) )
       {
       itkWarningMacro( "Duplicate short option '-"
-                       << option->GetShortName() << "'" )
+                       << option->GetShortName() << "'" );
       }
     if( !( option->GetLongName().empty() ) &&
         this->GetOption( option->GetLongName() ) )
       {
       itkWarningMacro( "Duplicate long option '--"
-                       << option->GetLongName() << "'" )
+                       << option->GetLongName() << "'" );
       }
     }
 }

--- a/Utilities/itkLabeledPointSetFileReader.hxx
+++ b/Utilities/itkLabeledPointSetFileReader.hxx
@@ -143,7 +143,7 @@ LabeledPointSetFileReader<TOutputMesh>
       this->GetOutput()->GetPoints()->Size() )
     {
     itkWarningMacro( "Number of points does not match number of labels. "
-                     << "Filling point data with label zero." )
+                     << "Filling point data with label zero." );
     typename OutputMeshType::PointsContainerIterator It =
       this->GetOutput()->GetPoints()->Begin();
 


### PR DESCRIPTION
The semi-colon was recently removed to address a
compiler warning about duplicate `;`.  This warning
was also addressed in upstream ITK, and now the the
`;` is required to compile with ITK versions after 11/06/2019.