### PR TITLE
COMP: Trying to reduce the Travis overhead by only building master + PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ dist: bionic
 git:
   depth: false
 
+# Only build the master branch, and pull-requests.
+# This turns off commit builds to other branches
+branches:
+  only: 
+    - master
+
 before_cache:
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew cleanup; fi
 # Credit https://discourse.brew.sh/t/best-practice-for-homebrew-on-travis-brew-update-is-5min-to-build-time/5215/9


### PR DESCRIPTION
Trying out this addition to .travis.yml:

```
branches:
  only:
    - master
```

The idea is to build only the master branch. Pull requests should still get built. If we need to be testing development branches, we can add them here.

There is a button on the Travis UI to turn off branch builds entirely. But then you don't get a build of master after a merge.

My aim is to avoid the situation where one of us makes a small change and a PR, and then both the branch commit itself and the PR are building at the same time.

The alternative as previously suggested by @gdevenyi is for all of us to fork ANTs and then issue PRs from there.