### PR TITLE
Sharpening options in ImageMath, updates to AverageImages, template scripts

### DIFF
--- a/Examples/AverageImages.cxx
+++ b/Examples/AverageImages.cxx
@@ -44,24 +44,15 @@ int AverageImages1(unsigned int argc, char *argv[])
   typedef itk::ImageFileReader<ImageType>              ImageFileReader;
   typedef itk::ImageFileWriter<ImageType>              writertype;
 
+    
+  const int normalizei = std::stoi(argv[3]);
+    
+  if( ( normalizei < 0 ) || ( normalizei > 2 ) )
     {
-    const std::string temp(argv[1]);
-    if( !( ( temp == "2" ) || ( temp == "3" ) || ( temp == "4" ) ) )
-      {
-      std::cerr << "ERROR:  Dimension option must be 2 or 3 or 4, " << temp << "given" << std::endl;
-      return EXIT_FAILURE;
-      }
+    std::cerr << "ERROR:  Normalize option must be 0 or 1 or 2, " << normalizei << " given" << std::endl;
+    return EXIT_FAILURE;
     }
-    {
-    const std::string temp(argv[3]);
-    if( !( ( temp == "0" ) || ( temp == "1" )  ) )
-      {
-      std::cerr << "ERROR:  Normalize option must be 0 or 1, " << temp << "given" << std::endl;
-      return EXIT_FAILURE;
-      }
-    }
-
-  const bool  normalizei = std::stoi(argv[3]);
+  
   const float numberofimages = static_cast<float>( argc ) - 4.0f;
 
   typename ImageType::SizeType maxSize;
@@ -116,7 +107,7 @@ int AverageImages1(unsigned int argc, char *argv[])
     typename ImageType::Pointer image2 = resampler->GetOutput();
     Iterator      vfIter2( image2,  image2->GetLargestPossibleRegion() );
     unsigned long ct = 0;
-    if( normalizei )
+    if( normalizei > 0 )
       {
       meanval = 0;
       for(  vfIter2.GoToBegin(); !vfIter2.IsAtEnd(); ++vfIter2 )
@@ -137,7 +128,7 @@ int AverageImages1(unsigned int argc, char *argv[])
     for(  vfIter2.GoToBegin(); !vfIter2.IsAtEnd(); ++vfIter2 )
       {
       PixelType val = vfIter2.Get();
-      if( normalizei )
+      if( normalizei > 0)
         {
         val /= meanval;
         }
@@ -150,14 +141,15 @@ int AverageImages1(unsigned int argc, char *argv[])
   //  typedef itk::OptimalSharpeningImageFilter<ImageType,ImageType > sharpeningFilter;
   typedef itk::LaplacianSharpeningImageFilter<ImageType, ImageType> sharpeningFilter;
   typename sharpeningFilter::Pointer shFilter = sharpeningFilter::New();
-  if( normalizei && argc > 3 && vectorlength == 1 )
+  if( (normalizei == 1) && (argc > 3) && (vectorlength == 1) )
     {
+    std::cout << " applying Laplacian sharpening " << std::endl;
     shFilter->SetInput( averageimage );
     //    shFilter->SetSValue(0.5);
     averageimage =  shFilter->GetOutput();
     }
 
-  std::cout << " writing output ";
+  std::cout << " writing output " << std::endl;
     {
     typename writertype::Pointer writer = writertype::New();
     writer->SetFileName(argv[2]);
@@ -309,10 +301,11 @@ private:
     std::cout << " Compulsory arguments: \n" << std::endl;
     std::cout << " ImageDimension: 2 or 3 (for 2 or 3 dimensional input).\n " << std::endl;
     std::cout << " Outputfname.nii.gz: the name of the resulting image.\n" << std::endl;
-    std::cout
-      <<
-      " Normalize: 0 (false) or 1 (true); if true, the 2nd image is divided by its mean. This will select the largest image to average into.\n"
-      << std::endl;
+    std::cout <<   " Normalize: 0 - no normalization\n"  
+              <<   "            1 - input images are divided by their mean before averaging; Laplacian sharpening is applied to the average\n"
+              <<   "            2 - input images are divided by their mean before averaging; no sharpening\n"
+              << std::endl;
+    std::cout <<   " Images are resampled into the space of the largest input image.\n" << std::endl;
     std::cout << " Example Usage:\n" << std::endl;
     std::cout << argv[0] << " 3 average.nii.gz  1  *.nii.gz \n" << std::endl;
     std::cout << " \n" << std::endl;

--- a/Examples/ImageMath.cxx
+++ b/Examples/ImageMath.cxx
@@ -632,8 +632,11 @@ private:
     std::cout << "\n  SigmoidImage   : " << std::endl;
     std::cout << "      Usage        : SigmoidImage ImageIn [alpha=1.0] [beta=0.0]" << std::endl;
 
-    std::cout << "\n  Sharpen   : " << std::endl;
+    std::cout << "\n  Sharpen        : Apply a Laplacian sharpening filter" << std::endl;
     std::cout << "      Usage        : Sharpen ImageIn" << std::endl;
+
+    std::cout << "\n  UnsharpMask     Apply an Unsharp Mask filter" << std::endl;
+    std::cout << "      Usage        : UnsharpMask ImageIn [amount=0.5] [radius=1 (mm)] [threshold=0]" << std::endl;
 
     std::cout << "\n  CoordinateComponentImages   : " << std::endl;
     std::cout << "      Usage        : CoordinateComponentImages domainImage" << std::endl;

--- a/Examples/ImageMath.cxx
+++ b/Examples/ImageMath.cxx
@@ -636,7 +636,7 @@ private:
     std::cout << "      Usage        : Sharpen ImageIn" << std::endl;
 
     std::cout << "\n  UnsharpMask     Apply an Unsharp Mask filter" << std::endl;
-    std::cout << "      Usage        : UnsharpMask ImageIn [amount=0.5] [radius=1 (mm)] [threshold=0]" << std::endl;
+    std::cout << "      Usage        : UnsharpMask ImageIn [amount=0.5] [radius=1] [threshold=0] [radius in spacing unit (0)/1]" << std::endl;
 
     std::cout << "\n  CoordinateComponentImages   : " << std::endl;
     std::cout << "      Usage        : CoordinateComponentImages domainImage" << std::endl;

--- a/Examples/ImageMath_Templates.hxx
+++ b/Examples/ImageMath_Templates.hxx
@@ -114,6 +114,7 @@
 #include "itkTileImageFilter.h"
 #include "itkTimeProbe.h"
 #include "itkTranslationTransform.h"
+#include "itkUnsharpMaskImageFilter.h"
 #include "itkVariableSizeMatrix.h"
 #include "itkVectorLinearInterpolateImageFunction.h"
 #include "itkWeightedCentroidKdTreeGenerator.h"
@@ -2108,7 +2109,59 @@ int SharpenImage(int argc, char *argv[])
   filter->Update();
 
   WriteImage<ImageType>( filter->GetOutput(), outputFilename.c_str() );
-  return 0;
+  return EXIT_SUCCESS;
+}
+
+template <unsigned int ImageDimension>
+int UnsharpMaskImage(int argc, char *argv[])
+{
+  if( argc < 5 )
+    {
+    // std::cout << "Error.  Not enough arguments.  See help menu." << std::endl;
+    return EXIT_FAILURE;
+    }
+
+  typedef float                                 PixelType;
+  typedef itk::Image<PixelType, ImageDimension> ImageType;
+
+  const std::string outputFilename = std::string( argv[2] );
+  const std::string inputFilename = std::string( argv[4] );
+
+  typename ImageType::Pointer inputImage = nullptr;
+  ReadImage<ImageType>( inputImage, inputFilename.c_str() );
+
+  // These are from the filter defaults
+  float amount = 0.5;
+  float radius = 1.0;
+  float threshold = 0;
+
+  if (argc > 5)
+    {
+    amount = std::stof( std::string(argv[5]).c_str() );
+    }
+  if (argc > 6)
+    {
+    radius = std::stof( std::string(argv[6]).c_str() );
+    }
+  if (argc > 7)
+    {
+    threshold = std::stof( std::string(argv[7]).c_str() );
+    }
+
+  typedef itk::UnsharpMaskImageFilter<ImageType, ImageType> FilterType;
+  typename FilterType::Pointer filter = FilterType::New();
+
+  filter->SetAmount(amount);
+  filter->SetSigma(radius);
+  filter->SetThreshold(threshold);
+
+  filter->SetInput( inputImage );
+  filter->Update();
+
+  WriteImage<ImageType>( filter->GetOutput(), outputFilename.c_str() );
+
+  return EXIT_SUCCESS;
+
 }
 
 template <unsigned int ImageDimension>
@@ -14525,6 +14578,12 @@ ImageMathHelperAll(int argc, char **argv)
     SharpenImage<DIM>(argc, argv);
     return EXIT_SUCCESS;
     }
+  if( operation == "UnsharpMask" )
+    {
+    UnsharpMaskImage<DIM>(argc, argv);
+    return EXIT_SUCCESS;
+    }
+
   if( operation == "MakeImage" )
     {
     MakeImage<DIM>(argc, argv);

--- a/Scripts/antsMultivariateTemplateConstruction.sh
+++ b/Scripts/antsMultivariateTemplateConstruction.sh
@@ -219,11 +219,15 @@ function shapeupdatetotemplate() {
     echo
     echo "--------------------------------------------------------------------------------------"
     echo " shapeupdatetotemplate---voxel-wise averaging of the warped images to the current template"
-    echo "   ${ANTSPATH}/AverageImages $dim ${template} 1 ${templatename}${whichtemplate}*WarpedToTemplate.nii.gz    "
+    echo "   ${ANTSPATH}/AverageImages $dim ${template} 2 ${templatename}${whichtemplate}*WarpedToTemplate.nii.gz    "
     echo "--------------------------------------------------------------------------------------"
     # Compute a normalized average
     ${ANTSPATH}/AverageImages $dim ${template} 2 ${templatename}${whichtemplate}*WarpedToTemplate.nii.gz
 
+    echo "--------------------------------------------------------------------------------------"
+    echo " shapeupdatetotemplate---sharpening of the new template"
+    echo "   ${ANTSPATH}/ImageMath $dim ${template} UnsharpMask ${template}"
+    echo "--------------------------------------------------------------------------------------"
     # Sharpen the average image with UnsharpMask.
     # To use the Laplacian, replace ImageMath function UnsharpMask with Sharpen
     ${ANTSPATH}/ImageMath $dim ${template} UnsharpMask ${template}

--- a/Scripts/antsMultivariateTemplateConstruction.sh
+++ b/Scripts/antsMultivariateTemplateConstruction.sh
@@ -226,11 +226,11 @@ function shapeupdatetotemplate() {
 
     echo "--------------------------------------------------------------------------------------"
     echo " shapeupdatetotemplate---sharpening of the new template"
-    echo "   ${ANTSPATH}/ImageMath $dim ${template} UnsharpMask ${template}"
+    echo "   ${ANTSPATH}/ImageMath $dim ${template} UnsharpMask ${template} 0.7 2 0 0"
     echo "--------------------------------------------------------------------------------------"
     # Sharpen the average image with UnsharpMask.
     # To use the Laplacian, replace ImageMath function UnsharpMask with Sharpen
-    ${ANTSPATH}/ImageMath $dim ${template} UnsharpMask ${template}
+    ${ANTSPATH}/ImageMath $dim ${template} UnsharpMask ${template} 0.7 2 0 0
 
     if [[ $whichtemplate -eq 0 ]] ;
       then

--- a/Scripts/antsMultivariateTemplateConstruction.sh
+++ b/Scripts/antsMultivariateTemplateConstruction.sh
@@ -221,7 +221,12 @@ function shapeupdatetotemplate() {
     echo " shapeupdatetotemplate---voxel-wise averaging of the warped images to the current template"
     echo "   ${ANTSPATH}/AverageImages $dim ${template} 1 ${templatename}${whichtemplate}*WarpedToTemplate.nii.gz    "
     echo "--------------------------------------------------------------------------------------"
-    ${ANTSPATH}/AverageImages $dim ${template} 1 ${templatename}${whichtemplate}*WarpedToTemplate.nii.gz
+    # Compute a normalized average
+    ${ANTSPATH}/AverageImages $dim ${template} 2 ${templatename}${whichtemplate}*WarpedToTemplate.nii.gz
+
+    # Sharpen the average image with UnsharpMask.
+    # To use the Laplacian, replace ImageMath function UnsharpMask with Sharpen
+    ${ANTSPATH}/ImageMath $dim ${template} UnsharpMask ${template}
 
     if [[ $whichtemplate -eq 0 ]] ;
       then

--- a/Scripts/antsMultivariateTemplateConstruction2.sh
+++ b/Scripts/antsMultivariateTemplateConstruction2.sh
@@ -275,11 +275,11 @@ function summarizeimageset() {
   case $method in
     0) #mean
       ${ANTSPATH}/AverageImages $dim $output 0 ${images[*]}
-      ${ANTSPATH}/ImageMath $dim $output UnsharpMask $output
+      ${ANTSPATH}/ImageMath $dim $output UnsharpMask $output 0.7 2 0 0
       ;;
     1) #mean of normalized images
       ${ANTSPATH}/AverageImages $dim $output 2 ${images[*]}
-      ${ANTSPATH}/ImageMath $dim $output UnsharpMask $output
+      ${ANTSPATH}/ImageMath $dim $output UnsharpMask $output 0.7 2 0 0
       ;;
     2) #median
       local image
@@ -289,7 +289,7 @@ function summarizeimageset() {
         done
 
       ${ANTSPATH}/ImageSetStatistics $dim ${output}_list.txt ${output} 0
-      ${ANTSPATH}/ImageMath $dim $output UnsharpMask $output
+      ${ANTSPATH}/ImageMath $dim $output UnsharpMask $output 0.7 2 0 0
       rm ${output}_list.txt
       ;;
   esac

--- a/Scripts/antsMultivariateTemplateConstruction2.sh
+++ b/Scripts/antsMultivariateTemplateConstruction2.sh
@@ -269,13 +269,17 @@ function summarizeimageset() {
   shift
   local images=( "${@}" "" )
 
+  # Unsharp mask used below to reduce halo artifacts
+  # To use Laplacian sharpening, use ${ANTSPATH}/ImageMath $dim $output Sharpen $output 
+
   case $method in
     0) #mean
       ${ANTSPATH}/AverageImages $dim $output 0 ${images[*]}
-      ${ANTSPATH}/ImageMath $dim $output Sharpen $output
+      ${ANTSPATH}/ImageMath $dim $output UnsharpMask $output
       ;;
-    1) #mean of normalized images, sharpens automatically
-      ${ANTSPATH}/AverageImages $dim $output 1 ${images[*]}
+    1) #mean of normalized images
+      ${ANTSPATH}/AverageImages $dim $output 2 ${images[*]}
+      ${ANTSPATH}/ImageMath $dim $output UnsharpMask $output
       ;;
     2) #median
       local image
@@ -285,7 +289,7 @@ function summarizeimageset() {
         done
 
       ${ANTSPATH}/ImageSetStatistics $dim ${output}_list.txt ${output} 0
-      ${ANTSPATH}/ImageMath $dim $output Sharpen $output
+      ${ANTSPATH}/ImageMath $dim $output UnsharpMask $output
       rm ${output}_list.txt
       ;;
   esac


### PR DESCRIPTION
New features:

`ImageMath` UnsharpMask command, which provides access to this filter

https://itk.org/Doxygen/html/classitk_1_1UnsharpMaskImageFilter.html

and its main parameters: amount (default 0.5, useful range 0-2), radius (default 1mm) and threshold (default 0).

`AverageImages` now has three options:

0 - just get the mean in each voxel
1 - mean of each voxel, but input volumes are divided by the mean within the volume, then Laplacian sharpening is applied to the result
2 - mean of each voxel, but input volumes are divided by the mean within the volume. No sharpening

This allows users to sharpen using their choice of method with ImageMath, or have backwards compatibility by choosing option 0 or 1.

In `antsMultivariateTemplateConstruction.sh` (and 2.sh), I've left Laplacian sharpening for the initial / rigid template steps, as a more aggressive approach is probably a good thing there. For the main template update, I switched to UnsharpMask with default parameters. 

Depending on the application one might do better with a larger radius or larger amount, but this will likely be data dependent. With amount = 0.75 and radius = 3mm, I was getting pretty good results but there was a small amount of halo artifact again, but less than with Laplacian. 

FYI the UnsharpMask filter can introduce negative intensities.