### PR TITLE
COMP: Assigning non-static data member within const member

### DIFF
--- a/Examples/TimeSCCAN.cxx
+++ b/Examples/TimeSCCAN.cxx
@@ -859,12 +859,11 @@ private:
       parser->GetOptions();
     for( unsigned int n = 0; n < longHelpOption->GetNumberOfFunctions(); n++ )
       {
-      std::string                                                  value = longHelpOption->GetFunction( n )->GetName();
-      itk::ants::CommandLineParser::OptionListType::const_iterator it;
-      for( it = options.begin(); it != options.end(); ++it )
+      const std::string & value = longHelpOption->GetFunction( n )->GetName();
+      for( auto it = options.cbegin(); it != options.cend(); ++it )
         {
-        const char *longName = ( ( *it )->GetLongName() ).c_str();
-        if( strstr( longName, value.c_str() ) == longName  )
+        const std::string & longname = ( *it )->GetLongName();
+        if ( longname.rfind(value, 0) == 0 )  // determining if `longname` starts with `value`
           {
           parser->PrintMenu( std::cout, 5, false );
           }


### PR DESCRIPTION
ANTs/Examples/TimeSCCAN.cxx:866:32: warning:
object backing the pointer will be destroyed at the end of the full-expression [-Wdangling-gsl]
        const char *longName = ( ( *it )->GetLongName() ).c_str();
                               ^~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.

error: cannot assign to non-static data member within const member function 'operator()'