### PR TITLE
ENH: Updating issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,12 @@
 ---
-name: Bug report
-about: Report errors or unexpected results when running ANTs programs
+name: Bugs or other run time problems
+about: Report potential bugs or other problems running ANTs programs.
 
 ---
 
-Before opening an issue, please check the ANTs wiki:
+**Before opening an issue**
+
+Please check the ANTs wiki:
 
 https://github.com/ANTsX/ANTs/wiki
 
@@ -23,27 +25,45 @@ https://github.com/ANTsX/ANTs/issues
 is:issue <your search terms>
 ```
 
-**Describe the bug**
-A clear and concise description of what the bug is. 
+If you need to open an issue, you can remove this text and fill out the sections
+below. Please leave the section titles in place, but replace the instruction
+text with details of your issue.
+
+
+**Describe the problem**
+Please describe the problem.
+
 
 **To Reproduce**
-Steps to reproduce the behavior.
+Steps to reproduce the problem. The majority of issues with ANTs are specific to
+the data, so uploading example data will make it much easier to provide help. If
+it is impossible to share the data in question, attempting to reproduce the
+problem with other public data is helpful.
 
- * The exact command line as it was run
+Please include:
+
+ * The exact command line as it was run. Please run all commands with
+   verbose output where possible. If your command takes a long time, please try
+   to produce a faster example that still shows the problem (eg, by running
+   fewer iterations). 
+
+ * The full verbose output printed to the terminal when you run the command. If
+   this is very long, please paste into a text file and upload as an attachment.
  
  * Example input data that goes with the command line you provide. You
-   can share your own data or link to any public data that produces
-   the problem. If uploading data as an attachment, please try to
-   minimize the file size by downsampling or otherwise creating
-   smaller images that demonstrate the bug. 
-   
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+   can share your own data or link to any public data that reproduces the
+   problem you are experiencing. If you cannot reproduce the problem with public
+   data, please let us know which data sets you tried.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+If uploading data as an attachment, please try to minimize the file size by
+compressing, downsampling or otherwise creating smaller images that demonstrate
+the problem.
+
 
 **System information (please complete the following information)**
+Many issues are specific to a particular system. Please include all information
+about your computing environment.
+
  - OS: [e.g. Mac OS]
  - OS version: [e.g. 10.15.1]
  - Type of system: [Desktop, laptop, HPC cluster, cloud instance,
@@ -60,5 +80,5 @@ If applicable, add screenshots to help explain your problem.
    (from where?), installed by another package (which?), installed in
    container (URL?), other (please specify)]
 
-**Additional context**
-Add any other context about the problem here.
+**Additional information**
+Add any other information that might help solve the problem.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ANTsPy Issues
+    url: https://github.com/ANTsX/ANTsPy/issues
+    about: Please report issues with ANTsPy here.
+  - name: ANTsR Issues
+    url: https://github.com/ANTsX/ANTsR/issues
+    about: Please report issues with ANTsR here.

--- a/.github/ISSUE_TEMPLATE/other_questions.md
+++ b/.github/ISSUE_TEMPLATE/other_questions.md
@@ -1,0 +1,37 @@
+---
+name: Other questions
+about: General questions about ANTs.
+
+---
+
+If you are having problems running ANTs on a particular data set, please use the
+bug report template.
+
+If you are having problems compiling or installing ANTs, please use the build
+problems template.
+
+
+**Before opening an issue**
+
+Please check the ANTs wiki:
+
+https://github.com/ANTsX/ANTs/wiki
+
+The Github wiki search only covers page titles, but you can do a full
+text search by entering into Google:
+
+```
+<your search terms> site:https://github.com/ANTsX/ANTs/wiki
+```
+
+Please check previous issues on Github at
+
+https://github.com/ANTsX/ANTs/issues
+
+```
+is:issue <your search terms>
+```
+
+If you need to open an issue, you can remove this text before typing your
+question. 
+


### PR DESCRIPTION
I've added a config file that will direct people to ANTsR or ANTsPy for issues with those tools.

I also disabled the blank issue, and tried to clarify when people should use the other templates. I added a general questions template to replace the blank issue, with reminders to use the appropriate template for bugs / runtime issues or build errors.