### PR TITLE
Use BinShrinkFilter instead of ShrinkFilter for N4 Downampling

### DIFF
--- a/Examples/N4BiasFieldCorrection.cxx
+++ b/Examples/N4BiasFieldCorrection.cxx
@@ -14,6 +14,7 @@
 #include "itkLabelStatisticsImageFilter.h"
 #include "itkN4BiasFieldCorrectionImageFilter.h"
 #include "itkShrinkImageFilter.h"
+#include "itkBinShrinkImageFilter.h"
 #include "itkTimeProbe.h"
 
 #include <string>
@@ -355,12 +356,12 @@ int N4( itk::ants::CommandLineParser *parser )
       }
     }
 
-  using ShrinkerType = itk::ShrinkImageFilter<ImageType, ImageType>;
+  using ShrinkerType = itk::BinShrinkImageFilter<ImageType, ImageType>;
   typename ShrinkerType::Pointer shrinker = ShrinkerType::New();
   shrinker->SetInput( inputImage );
   shrinker->SetShrinkFactors( 1 );
 
-  using MaskShrinkerType = itk::ShrinkImageFilter<MaskImageType, MaskImageType>;
+  using MaskShrinkerType = itk::BinShrinkImageFilter<MaskImageType, MaskImageType>;
   typename MaskShrinkerType::Pointer maskshrinker = MaskShrinkerType::New();
   maskshrinker->SetInput( maskImage );
   maskshrinker->SetShrinkFactors( 1 );
@@ -388,7 +389,7 @@ int N4( itk::ants::CommandLineParser *parser )
   correcter->SetInput( shrinker->GetOutput() );
   correcter->SetMaskImage( maskshrinker->GetOutput() );
 
-  using WeightShrinkerType = itk::ShrinkImageFilter<ImageType, ImageType>;
+  using WeightShrinkerType = itk::BinShrinkImageFilter<ImageType, ImageType>;
   typename WeightShrinkerType::Pointer weightshrinker = WeightShrinkerType::New();
   if( weightImage )
     {


### PR DESCRIPTION
Through experiments with N4BiasFieldCorrection, I've found that with noisy data N4 can be weirdly unstable to the underlying noise field of the data, through choices such as exactly how much padding the image gets. I believe this is due to the use of the ShrinkImage filter, which simply takes every Nth voxel to achieve downsampling. If we instead use the BinShrinkImage filter when downsampling, we reduce the noise and stabilize estimates for noisy data by performing a smoothing.

This isn't the only solution to this problem, we could explicitly smooth with a gaussian before downsample, but this the fastest drop-in replacement.

Ref: https://hdl.handle.net/10380/3450