### PR TITLE
WIP:  Add N4 bells and whistles to N3.

### DIFF
--- a/Examples/N3BiasFieldCorrection.cxx
+++ b/Examples/N3BiasFieldCorrection.cxx
@@ -322,8 +322,8 @@ int N3( itk::ants::CommandLineParser *parser )
       std::cout << "which could cause failure or problematic results.  A" << std::endl;
       std::cout << "possible workaround would be to:" << std::endl;
       std::cout << "   1. rescale your image to positive values e.g., [10,100]." << std::endl;
-      std::cout << "   2. run N4 on your rescaled image." << std::endl;
-      std::cout << "   3. (optional) rescale the N4 output to the original" << std::endl;
+      std::cout << "   2. run N3 on your rescaled image." << std::endl;
+      std::cout << "   3. (optional) rescale the N3 output to the original" << std::endl;
       std::cout << "      intensity range." << std::endl;
       std::cout << "***********************************************************" << std::endl;
       std::cout << std::endl;
@@ -358,21 +358,15 @@ int N3( itk::ants::CommandLineParser *parser )
       correcter->SetMaximumNumberOfIterations( maximumNumberOfIterations );
       correcter->SetConvergenceThreshold( 0.0 );
       }
-    if( convergenceOption->GetFunction( 0 )->GetNumberOfParameters() > 2 )
-      {
-      correcter->SetNumberOfFittingLevels( parser->Convert<unsigned int>(
-                                            convergenceOption->GetFunction( 0 )->GetParameter( 1 ) ) );
-      }
-    if( convergenceOption->GetFunction( 0 )->GetNumberOfParameters() > 2 )
+    if( convergenceOption->GetFunction( 0 )->GetNumberOfParameters() > 1 )
       {
       correcter->SetConvergenceThreshold( parser->Convert<float>(
-                                            convergenceOption->GetFunction( 0 )->GetParameter( 2 ) ) );
+                                            convergenceOption->GetFunction( 0 )->GetParameter( 1 ) ) );
       }
     }
   else // set default values
     {
     correcter->SetMaximumNumberOfIterations( 50 );
-    correcter->SetNumberOfFittingLevels( 4 );
     correcter->SetConvergenceThreshold( 0.0 );
     }
 
@@ -392,10 +386,15 @@ int N3( itk::ants::CommandLineParser *parser )
     parser->GetOption( "bspline-fitting" );
   if( bsplineOption && bsplineOption->GetNumberOfFunctions() )
     {
-    if( bsplineOption->GetFunction( 0 )->GetNumberOfParameters() > 1 )
+    if( bsplineOption->GetFunction( 0 )->GetNumberOfParameters() > 2 )
       {
       correcter->SetSplineOrder( parser->Convert<unsigned int>(
-                                   bsplineOption->GetFunction( 0 )->GetParameter( 1 ) ) );
+                                   bsplineOption->GetFunction( 0 )->GetParameter( 2 ) ) );
+      }
+    if( bsplineOption->GetFunction( 0 )->GetNumberOfParameters() > 1 )
+      {
+      correcter->SetNumberOfFittingLevels( parser->Convert<unsigned int>(
+                                            bsplineOption->GetFunction( 0 )->GetParameter( 1 ) ) );
       }
     if( bsplineOption->GetFunction( 0 )->GetNumberOfParameters() > 0 )
       {
@@ -753,7 +752,7 @@ void N3InitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
   {
   std::string description =
     std::string( "A scalar image is expected as input for bias correction.  " )
-    + std::string( "Since N4 log transforms the intensities, negative values " )
+    + std::string( "Since N3 log transforms the intensities, negative values " )
     + std::string( "or values close to zero should be processed prior to " )
     + std::string( "correction." );
 
@@ -854,7 +853,7 @@ void N3InitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
   OptionType::Pointer option = OptionType::New();
   option->SetLongName( "convergence" );
   option->SetShortName( 'c' );
-  option->SetUsageOption( 0, "[<numberOfIterations=50>,<numberOfFittingLevels=4>,<convergenceThreshold=0.0>]" );
+  option->SetUsageOption( 0, "[<numberOfIterations=50>,<convergenceThreshold=0.0>]" );
   option->SetDescription( description );
   parser->AddOption( option );
   }
@@ -869,13 +868,13 @@ void N3InitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
     + std::string( "of the mesh elements. The latter option is typically preferred. " )
     + std::string( "The default setting " )
     + std::string( "is to employ a single mesh element over the entire domain, i.e., " )
-    + std::string( "-b [1x1x1,3]." );
+    + std::string( "-b [1x1x1,4,3]." );
 
   OptionType::Pointer option = OptionType::New();
   option->SetLongName( "bspline-fitting" );
   option->SetShortName( 'b' );
-  option->SetUsageOption( 0, "[splineDistance,<splineOrder=3>]" );
-  option->SetUsageOption( 1, "[meshResolution,<splineOrder=3>]" );
+  option->SetUsageOption( 0, "[splineDistance,<numberOfFittingLevels=4>,<splineOrder=3>]" );
+  option->SetUsageOption( 1, "[meshResolution,<numberOfFittingLevels=4>,<splineOrder=3>]" );
   option->SetDescription( description );
   parser->AddOption( option );
   }

--- a/Examples/N3BiasFieldCorrection.cxx
+++ b/Examples/N3BiasFieldCorrection.cxx
@@ -1,16 +1,30 @@
-
 #include "antsUtilities.h"
 #include "antsAllocImage.h"
-#include <algorithm>
+#include "antsCommandLineParser.h"
+
 #include "ReadWriteData.h"
+
+#include "itkBinaryThresholdImageFilter.h"
 #include "itkBSplineControlPointImageFilter.h"
+#include "itkConstantPadImageFilter.h"
 #include "itkExpImageFilter.h"
+#include "itkExtractImageFilter.h"
 #include "itkImageFileReader.h"
 #include "itkImageFileWriter.h"
 #include "itkImageRegionIterator.h"
+#include "itkImageRegionIteratorWithIndex.h"
+#include "itkLabelStatisticsImageFilter.h"
 #include "itkN3MRIBiasFieldCorrectionImageFilter.h"
+#include "itkN3BiasFieldCorrectionImageFilter.h"
 #include "itkOtsuThresholdImageFilter.h"
+#include "itkTimeProbe.h"
 #include "itkShrinkImageFilter.h"
+
+#include <string>
+#include <algorithm>
+#include <vector>
+
+#include "ANTsVersion.h"
 
 namespace ants
 {
@@ -197,86 +211,988 @@ int N3BiasFieldCorrection( int argc, char *argv[] )
   return EXIT_SUCCESS;
 }
 
-// entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
-// 'main()'
-int N3BiasFieldCorrection( std::vector<std::string> args, std::ostream* /*out_stream = nullptr */ )
+template <unsigned int ImageDimension>
+int N3( itk::ants::CommandLineParser *parser )
 {
-  // put the arguments coming in as 'args' into standard (argc,argv) format;
-  // 'args' doesn't have the command name as first, argument, so add it manually;
-  // 'args' may have adjacent arguments concatenated into one argument,
-  // which the parser should handle
-  args.insert( args.begin(), "N3BiasFieldCorrection" );
+  using RealType = float;
 
-  int     argc = args.size();
-  char* * argv = new char *[args.size() + 1];
-  for( unsigned int i = 0; i < args.size(); ++i )
+  using ImageType = itk::Image<RealType, ImageDimension>;
+  typename ImageType::Pointer inputImage = nullptr;
+
+  using MaskImageType = itk::Image<RealType, ImageDimension>;
+  typename MaskImageType::Pointer maskImage = nullptr;
+
+  bool verbose = false;
+  typename itk::ants::CommandLineParser::OptionType::Pointer verboseOption =
+    parser->GetOption( "verbose" );
+  if( verboseOption && verboseOption->GetNumberOfFunctions() )
     {
-    // allocate space for the string plus a null character
-    argv[i] = new char[args[i].length() + 1];
-    std::strncpy( argv[i], args[i].c_str(), args[i].length() );
-    // place the null character in the end
-    argv[i][args[i].length()] = '\0';
+    verbose = parser->Convert<bool>( verboseOption->GetFunction( 0 )->GetName() );
     }
-  argv[argc] = nullptr;
-  // class to automatically cleanup argv upon destruction
-  class Cleanup_argv
-  {
-public:
-    Cleanup_argv( char* * argv_, int argc_plus_one_ ) : argv( argv_ ), argc_plus_one( argc_plus_one_ )
+  if( verbose )
     {
+    std::cout << std::endl << "Running N3 for "
+             << ImageDimension << "-dimensional images." << std::endl << std::endl;
     }
 
-    ~Cleanup_argv()
+  using CorrecterType = itk::N3BiasFieldCorrectionImageFilter<ImageType, MaskImageType, ImageType>;
+  typename CorrecterType::Pointer correcter = CorrecterType::New();
+
+  typename itk::ants::CommandLineParser::OptionType::Pointer inputImageOption =
+    parser->GetOption( "input-image" );
+  if( inputImageOption && inputImageOption->GetNumberOfFunctions() )
     {
-      for( unsigned int i = 0; i < argc_plus_one; ++i )
-        {
-        delete[] argv[i];
-        }
-      delete[] argv;
+    std::string inputFile = inputImageOption->GetFunction( 0 )->GetName();
+    ReadImage<ImageType>( inputImage, inputFile.c_str() );
     }
-
-private:
-    char* *      argv;
-    unsigned int argc_plus_one;
-  };
-  Cleanup_argv cleanup_argv( argv, argc + 1 );
-
-  // antscout->set_stream( out_stream );
-
-  if( argc < 4 )
+  else
     {
-    std::cout << "Usage: " << argv[0] << " imageDimension inputImage "
-             << "outputImage [shrinkFactor] [maskImage] [numberOfIterations] "
-             << "[numberOfFittingLevels] [outputBiasField] [verbose]" << std::endl;
-    if( argc >= 2 &&
-        ( std::string( argv[1] ) == std::string("--help") || std::string( argv[1] ) == std::string("-h") ) )
+    if( verbose )
       {
-      return EXIT_SUCCESS;
+      std::cerr << "Input image not specified." << std::endl;
       }
     return EXIT_FAILURE;
     }
 
-  switch( std::stoi( argv[1] ) )
+  /**
+   * handle the mask image
+   */
+
+  bool isMaskImageSpecified = false;
+
+  typename itk::ants::CommandLineParser::OptionType::Pointer maskImageOption =
+    parser->GetOption( "mask-image" );
+  if( maskImageOption && maskImageOption->GetNumberOfFunctions() )
     {
-    case 2:
-      {
-      return N3BiasFieldCorrection<2>( argc, argv );
-      }
-      break;
-    case 3:
-      {
-      return N3BiasFieldCorrection<3>( argc, argv );
-      }
-      break;
-    case 4:
-      {
-      return N3BiasFieldCorrection<4>( argc, argv );
-      }
-      break;
-    default:
-      std::cout << "Unsupported dimension" << std::endl;
-      return EXIT_FAILURE;
+    std::string inputMaskFile = maskImageOption->GetFunction( 0 )->GetName();
+    ReadImage<MaskImageType>( maskImage, inputMaskFile.c_str() );
+
+    isMaskImageSpecified = true;
     }
+  if( maskImage.IsNull() )
+    {
+    if( verbose )
+      {
+      std::cout << "Mask not read.  Using the entire image as the mask." << std::endl << std::endl;
+      }
+    maskImage = MaskImageType::New();
+    maskImage->CopyInformation( inputImage );
+    maskImage->SetRegions( inputImage->GetRequestedRegion() );
+    maskImage->Allocate();
+    maskImage->FillBuffer( itk::NumericTraits<typename MaskImageType::PixelType>::OneValue() );
+    }
+
+  /**
+   * check for negative values in the masked region
+   */
+  using ThresholderType = itk::BinaryThresholdImageFilter<MaskImageType, MaskImageType>;
+  typename ThresholderType::Pointer thresholder = ThresholderType::New();
+  thresholder->SetInsideValue( itk::NumericTraits<typename MaskImageType::PixelType>::ZeroValue() );
+  thresholder->SetOutsideValue( itk::NumericTraits<typename MaskImageType::PixelType>::OneValue() );
+  thresholder->SetLowerThreshold( itk::NumericTraits<typename MaskImageType::PixelType>::ZeroValue() );
+  thresholder->SetUpperThreshold( itk::NumericTraits<typename MaskImageType::PixelType>::ZeroValue() );
+  thresholder->SetInput( maskImage );
+
+  using StatsType = itk::LabelStatisticsImageFilter<ImageType, MaskImageType>;
+  typename StatsType::Pointer statsOriginal = StatsType::New();
+  statsOriginal->SetInput( inputImage );
+  statsOriginal->SetLabelInput( thresholder->GetOutput() );
+  statsOriginal->UseHistogramsOff();
+  statsOriginal->Update();
+
+  using StatsLabelType = typename StatsType::LabelPixelType;
+  StatsLabelType maskLabel = itk::NumericTraits<StatsLabelType>::OneValue();
+
+  RealType minOriginal = statsOriginal->GetMinimum( maskLabel );
+  RealType maxOriginal = statsOriginal->GetMaximum( maskLabel );
+
+  if( verbose )
+    {
+    std::cout << "Original intensity range:  [" << minOriginal
+              << ", " << maxOriginal << "]" << std::endl;
+    }
+
+  if( minOriginal <= 0 )
+    {
+    if( verbose )
+      {
+      std::cout << std::endl;
+      std::cout << "***********************************************************" << std::endl;
+      std::cout << "Warning:  Your input image contains nonpositive values" << std::endl;
+      std::cout << "which could cause failure or problematic results.  A" << std::endl;
+      std::cout << "possible workaround would be to:" << std::endl;
+      std::cout << "   1. rescale your image to positive values e.g., [10,100]." << std::endl;
+      std::cout << "   2. run N4 on your rescaled image." << std::endl;
+      std::cout << "   3. (optional) rescale the N4 output to the original" << std::endl;
+      std::cout << "      intensity range." << std::endl;
+      std::cout << "***********************************************************" << std::endl;
+      std::cout << std::endl;
+      }
+    }
+
+  /**
+   * handle the weight image
+   */
+
+  typename ImageType::Pointer weightImage = nullptr;
+
+  typename itk::ants::CommandLineParser::OptionType::Pointer weightImageOption =
+    parser->GetOption( "weight-image" );
+  if( weightImageOption && weightImageOption->GetNumberOfFunctions() )
+    {
+    std::string inputFile = weightImageOption->GetFunction( 0 )->GetName();
+    ReadImage<ImageType>( weightImage, inputFile.c_str() );
+    }
+
+  /**
+   * convergence options
+   */
+  typename itk::ants::CommandLineParser::OptionType::Pointer convergenceOption =
+    parser->GetOption( "convergence" );
+  if( convergenceOption && convergenceOption->GetNumberOfFunctions() )
+    {
+    if( convergenceOption->GetFunction( 0 )->GetNumberOfParameters() > 0 )
+      {
+      unsigned int maximumNumberOfIterations = parser->Convert<unsigned int>(
+          convergenceOption->GetFunction( 0 )->GetParameter( 0 ) );
+      correcter->SetMaximumNumberOfIterations( maximumNumberOfIterations );
+      correcter->SetConvergenceThreshold( 0.0 );
+      }
+    if( convergenceOption->GetFunction( 0 )->GetNumberOfParameters() > 2 )
+      {
+      correcter->SetNumberOfFittingLevels( parser->Convert<unsigned int>(
+                                            convergenceOption->GetFunction( 0 )->GetParameter( 1 ) ) );
+      }
+    if( convergenceOption->GetFunction( 0 )->GetNumberOfParameters() > 2 )
+      {
+      correcter->SetConvergenceThreshold( parser->Convert<float>(
+                                            convergenceOption->GetFunction( 0 )->GetParameter( 2 ) ) );
+      }
+    }
+  else // set default values
+    {
+    correcter->SetMaximumNumberOfIterations( 50 );
+    correcter->SetNumberOfFittingLevels( 4 );
+    correcter->SetConvergenceThreshold( 0.0 );
+    }
+
+  /**
+   * B-spline options -- we place this here to take care of the case where
+   * the user wants to specify things in terms of the spline distance.
+   */
+
+  typename ImageType::IndexType inputImageIndex =
+    inputImage->GetLargestPossibleRegion().GetIndex();
+  typename ImageType::SizeType inputImageSize =
+    inputImage->GetLargestPossibleRegion().GetSize();
+
+  typename ImageType::PointType newOrigin = inputImage->GetOrigin();
+
+  typename itk::ants::CommandLineParser::OptionType::Pointer bsplineOption =
+    parser->GetOption( "bspline-fitting" );
+  if( bsplineOption && bsplineOption->GetNumberOfFunctions() )
+    {
+    if( bsplineOption->GetFunction( 0 )->GetNumberOfParameters() > 1 )
+      {
+      correcter->SetSplineOrder( parser->Convert<unsigned int>(
+                                   bsplineOption->GetFunction( 0 )->GetParameter( 1 ) ) );
+      }
+    if( bsplineOption->GetFunction( 0 )->GetNumberOfParameters() > 0 )
+      {
+      std::vector<float> array = parser->ConvertVector<float>(
+          bsplineOption->GetFunction( 0 )->GetParameter( 0 ) );
+      typename CorrecterType::ArrayType numberOfControlPoints;
+      if( array.size() == 1 )
+        {
+        // the user wants to specify things in terms of spline distance.
+        //  1. need to pad the images to get as close to possible to the
+        //     requested domain size.
+        float splineDistance = array[0];
+
+        typename ImageType::SizeType originalImageSize = inputImage->GetLargestPossibleRegion().GetSize();
+
+        itk::Size<ImageDimension> lowerBound;
+        itk::Size<ImageDimension> upperBound;
+        for( unsigned int d = 0; d < ImageDimension; d++ )
+          {
+          float domain = static_cast<float>( originalImageSize[d] - 1 ) * static_cast<float>( inputImage->GetSpacing()[d] );
+          auto numberOfSpans = static_cast<unsigned int>(
+              std::ceil( domain / splineDistance ) );
+          auto extraPadding = static_cast<unsigned long>( ( numberOfSpans
+                                                                     * splineDistance
+                                                                     - domain ) / static_cast<float>( inputImage->GetSpacing()[d] ) + static_cast<float>( 0.5 ) );
+          lowerBound[d] = static_cast<unsigned long>( 0.5 * extraPadding );
+          upperBound[d] = extraPadding - lowerBound[d];
+          newOrigin[d] -= ( static_cast<double>( lowerBound[d] )
+                            * inputImage->GetSpacing()[d] );
+          numberOfControlPoints[d] = numberOfSpans + correcter->GetSplineOrder();
+          }
+
+        using PadderType = itk::ConstantPadImageFilter<ImageType, ImageType>;
+        typename PadderType::Pointer padder = PadderType::New();
+        padder->SetInput( inputImage );
+        padder->SetPadLowerBound( lowerBound );
+        padder->SetPadUpperBound( upperBound );
+        padder->SetConstant( itk::NumericTraits<typename ImageType::PixelType>::ZeroValue() );
+        padder->Update();
+
+        inputImage = padder->GetOutput();
+        inputImage->DisconnectPipeline();
+
+        using MaskPadderType = itk::ConstantPadImageFilter<MaskImageType, MaskImageType>;
+        typename MaskPadderType::Pointer maskPadder = MaskPadderType::New();
+        maskPadder->SetInput( maskImage );
+        maskPadder->SetPadLowerBound( lowerBound );
+        maskPadder->SetPadUpperBound( upperBound );
+        maskPadder->SetConstant( 0 );
+        maskPadder->Update();
+
+        maskImage = maskPadder->GetOutput();
+        maskImage->DisconnectPipeline();
+
+        if( weightImage )
+          {
+          typename PadderType::Pointer weightPadder = PadderType::New();
+          weightPadder->SetInput( weightImage );
+          weightPadder->SetPadLowerBound( lowerBound );
+          weightPadder->SetPadUpperBound( upperBound );
+          weightPadder->SetConstant( 0 );
+          weightPadder->Update();
+
+          weightImage = weightPadder->GetOutput();
+          weightImage->DisconnectPipeline();
+          }
+
+        if( verbose )
+          {
+          std::cout << "Specified spline distance: " << splineDistance << "mm" << std::endl;
+          std::cout << "  original image size:  " << originalImageSize << std::endl;
+          std::cout << "  padded image size:  " << inputImage->GetLargestPossibleRegion().GetSize() << std::endl;
+          std::cout << "  number of control points:  " << numberOfControlPoints << std::endl;
+          std::cout << std::endl;
+          }
+        }
+      else if( array.size() == ImageDimension )
+        {
+        for( unsigned int d = 0; d < ImageDimension; d++ )
+          {
+          numberOfControlPoints[d] = static_cast<unsigned int>( array[d] )
+            + correcter->GetSplineOrder();
+          }
+        }
+      else
+        {
+        if( verbose )
+          {
+          std::cerr << "Incorrect mesh resolution" << std::endl;
+          }
+        return EXIT_FAILURE;
+        }
+      correcter->SetNumberOfControlPoints( numberOfControlPoints );
+      }
+    }
+
+  using ShrinkerType = itk::ShrinkImageFilter<ImageType, ImageType>;
+  typename ShrinkerType::Pointer shrinker = ShrinkerType::New();
+  shrinker->SetInput( inputImage );
+  shrinker->SetShrinkFactors( 1 );
+
+  using MaskShrinkerType = itk::ShrinkImageFilter<MaskImageType, MaskImageType>;
+  typename MaskShrinkerType::Pointer maskshrinker = MaskShrinkerType::New();
+  maskshrinker->SetInput( maskImage );
+  maskshrinker->SetShrinkFactors( 1 );
+
+  typename itk::ants::CommandLineParser::OptionType::Pointer shrinkFactorOption =
+    parser->GetOption( "shrink-factor" );
+  int shrinkFactor = 4;
+  if( shrinkFactorOption && shrinkFactorOption->GetNumberOfFunctions() )
+    {
+    shrinkFactor = parser->Convert<int>( shrinkFactorOption->GetFunction( 0 )->GetName() );
+    }
+  shrinker->SetShrinkFactors( shrinkFactor );
+  maskshrinker->SetShrinkFactors( shrinkFactor );
+  if( ImageDimension == 4 )
+    {
+    shrinker->SetShrinkFactor( 3, 1 );
+    maskshrinker->SetShrinkFactor( 3, 1 );
+    }
+  shrinker->Update();
+  maskshrinker->Update();
+
+  itk::TimeProbe timer;
+  timer.Start();
+
+  correcter->SetInput( shrinker->GetOutput() );
+  correcter->SetMaskImage( maskshrinker->GetOutput() );
+
+  using WeightShrinkerType = itk::ShrinkImageFilter<ImageType, ImageType>;
+  typename WeightShrinkerType::Pointer weightshrinker = WeightShrinkerType::New();
+  if( weightImage )
+    {
+    weightshrinker->SetInput( weightImage );
+    weightshrinker->SetShrinkFactors( shrinker->GetShrinkFactors() );
+    weightshrinker->Update();
+
+    correcter->SetConfidenceImage( weightshrinker->GetOutput() );
+    }
+
+  if( verbose )
+    {
+    using CommandType = CommandIterationUpdate<CorrecterType>;
+    typename CommandType::Pointer observer = CommandType::New();
+    correcter->AddObserver( itk::IterationEvent(), observer );
+    }
+
+  /**
+   * histogram sharpening options
+   */
+  typename itk::ants::CommandLineParser::OptionType::Pointer histOption =
+    parser->GetOption( "histogram-sharpening" );
+  if( histOption && histOption->GetNumberOfFunctions() )
+    {
+    if( histOption->GetFunction( 0 )->GetNumberOfParameters() > 0 )
+      {
+      correcter->SetBiasFieldFullWidthAtHalfMaximum( parser->Convert<float>(
+                                                       histOption->GetFunction( 0 )->GetParameter( 0 ) ) );
+      }
+    if( histOption->GetFunction( 0 )->GetNumberOfParameters() > 1 )
+      {
+      correcter->SetWienerFilterNoise( parser->Convert<float>(
+                                         histOption->GetFunction( 0 )->GetParameter( 1 ) ) );
+      }
+    if( histOption->GetFunction( 0 )->GetNumberOfParameters() > 2 )
+      {
+      correcter->SetNumberOfHistogramBins( parser->Convert<unsigned int>(
+                                             histOption->GetFunction( 0 )->GetParameter( 2 ) ) );
+      }
+    }
+
+  try
+    {
+    // correcter->DebugOn();
+    correcter->Update();
+    }
+  catch( itk::ExceptionObject & e )
+    {
+    if( verbose )
+      {
+      std::cerr << "Exception caught: " << e << std::endl;
+      }
+    return EXIT_FAILURE;
+    }
+
+  if( verbose )
+    {
+    correcter->Print( std::cout, 3 );
+    }
+
+  timer.Stop();
+  if( verbose )
+    {
+    std::cout << "Elapsed time: " << timer.GetMean() << std::endl;
+    }
+
+  /**
+   * output
+   */
+
+  typename itk::ants::CommandLineParser::OptionType::Pointer outputOption =
+    parser->GetOption( "output" );
+  if( outputOption && outputOption->GetNumberOfFunctions() )
+    {
+    /**
+     * Reconstruct the bias field at full image resolution.  Divide
+     * the original input image by the bias field to get the final
+     * corrected image.
+     */
+    using BSplinerType = itk::BSplineControlPointImageFilter<typename CorrecterType::BiasFieldControlPointLatticeType, typename CorrecterType::ScalarImageType>;
+    typename BSplinerType::Pointer bspliner = BSplinerType::New();
+    bspliner->SetInput( correcter->GetLogBiasFieldControlPointLattice() );
+    bspliner->SetSplineOrder( correcter->GetSplineOrder() );
+    bspliner->SetSize( inputImage->GetLargestPossibleRegion().GetSize() );
+    bspliner->SetOrigin( newOrigin );
+    bspliner->SetDirection( inputImage->GetDirection() );
+    bspliner->SetSpacing( inputImage->GetSpacing() );
+    bspliner->Update();
+
+    typename ImageType::Pointer logField = AllocImage<ImageType>( inputImage );
+
+    itk::ImageRegionIterator<typename CorrecterType::ScalarImageType> ItB(
+      bspliner->GetOutput(),
+      bspliner->GetOutput()->GetLargestPossibleRegion() );
+    itk::ImageRegionIterator<ImageType> ItF( logField,
+                                             logField->GetLargestPossibleRegion() );
+    for( ItB.GoToBegin(), ItF.GoToBegin(); !ItB.IsAtEnd(); ++ItB, ++ItF )
+      {
+      ItF.Set( ItB.Get()[0] );
+      }
+
+    using ExpFilterType = itk::ExpImageFilter<ImageType, ImageType>;
+    typename ExpFilterType::Pointer expFilter = ExpFilterType::New();
+    expFilter->SetInput( logField );
+    expFilter->Update();
+
+    using DividerType = itk::DivideImageFilter<ImageType, ImageType, ImageType>;
+    typename DividerType::Pointer divider = DividerType::New();
+    divider->SetInput1( inputImage );
+    divider->SetInput2( expFilter->GetOutput() );
+
+    typename ImageType::Pointer dividedImage = divider->GetOutput();
+    dividedImage->Update();
+    dividedImage->DisconnectPipeline();
+
+    if( maskImageOption && maskImageOption->GetNumberOfFunctions() > 0 )
+      {
+      itk::ImageRegionIteratorWithIndex<ImageType> ItD( dividedImage,
+                                                        dividedImage->GetLargestPossibleRegion() );
+      itk::ImageRegionIterator<ImageType> ItI( inputImage,
+                                               inputImage->GetLargestPossibleRegion() );
+      for( ItD.GoToBegin(), ItI.GoToBegin(); !ItD.IsAtEnd(); ++ItD, ++ItI )
+        {
+        if( itk::Math::FloatAlmostEqual( maskImage->GetPixel( ItD.GetIndex() ), itk::NumericTraits<typename MaskImageType::PixelType>::ZeroValue() ) )
+          {
+          ItD.Set( ItI.Get() );
+          }
+        }
+      }
+
+    bool doRescale = true;
+
+    typename itk::ants::CommandLineParser::OptionType::Pointer rescaleOption =
+      parser->GetOption( "rescale-intensities" );
+    if( ! isMaskImageSpecified || ( rescaleOption && rescaleOption->GetNumberOfFunctions() &&
+      ! parser->Convert<bool>( rescaleOption->GetFunction()->GetName() ) ) )
+      {
+      doRescale = false;
+      }
+
+    if( doRescale )
+      {
+      typename ThresholderType::Pointer thresholder2 = ThresholderType::New();
+      thresholder2->SetInsideValue( itk::NumericTraits<typename MaskImageType::PixelType>::ZeroValue() );
+      thresholder2->SetOutsideValue( itk::NumericTraits<typename MaskImageType::PixelType>::OneValue() );
+      thresholder2->SetLowerThreshold( itk::NumericTraits<typename MaskImageType::PixelType>::ZeroValue() );
+      thresholder2->SetUpperThreshold( itk::NumericTraits<typename MaskImageType::PixelType>::ZeroValue() );
+      thresholder2->SetInput( maskImage );
+
+      typename StatsType::Pointer statsBiasCorrected = StatsType::New();
+      statsBiasCorrected->SetInput( dividedImage );
+      statsBiasCorrected->SetLabelInput( thresholder2->GetOutput() );
+      statsBiasCorrected->UseHistogramsOff();
+      statsBiasCorrected->Update();
+
+      RealType minBiasCorrected = statsBiasCorrected->GetMinimum( maskLabel );
+      RealType maxBiasCorrected = statsBiasCorrected->GetMaximum( maskLabel );
+
+      RealType slope = ( maxOriginal - minOriginal ) / ( maxBiasCorrected - minBiasCorrected );
+
+      itk::ImageRegionIteratorWithIndex<ImageType> ItD( dividedImage,
+                                                        dividedImage->GetLargestPossibleRegion() );
+      for( ItD.GoToBegin(); !ItD.IsAtEnd(); ++ItD )
+        {
+        if( itk::Math::FloatAlmostEqual( maskImage->GetPixel( ItD.GetIndex() ), static_cast<RealType>( maskLabel ) ) )
+          {
+          RealType originalIntensity = ItD.Get();
+          RealType rescaledIntensity = maxOriginal - slope * ( maxBiasCorrected - originalIntensity );
+          ItD.Set( rescaledIntensity );
+          }
+        }
+      }
+
+    typename ImageType::RegionType inputRegion;
+    inputRegion.SetIndex( inputImageIndex );
+    inputRegion.SetSize( inputImageSize );
+
+    using CropperType = itk::ExtractImageFilter<ImageType, ImageType>;
+    typename CropperType::Pointer cropper = CropperType::New();
+    cropper->SetInput( dividedImage );
+    cropper->SetExtractionRegion( inputRegion );
+    cropper->SetDirectionCollapseToSubmatrix();
+    cropper->Update();
+
+    typename CropperType::Pointer biasFieldCropper = CropperType::New();
+    biasFieldCropper->SetInput( expFilter->GetOutput() );
+    biasFieldCropper->SetExtractionRegion( inputRegion );
+    biasFieldCropper->SetDirectionCollapseToSubmatrix();
+    biasFieldCropper->Update();
+
+    if( outputOption->GetFunction( 0 )->GetNumberOfParameters() == 0 )
+      {
+      WriteImage<ImageType>( cropper->GetOutput(),  ( outputOption->GetFunction( 0 )->GetName() ).c_str() );
+      }
+    else if( outputOption->GetFunction( 0 )->GetNumberOfParameters() > 0 )
+      {
+      WriteImage<ImageType>( cropper->GetOutput(),  ( outputOption->GetFunction( 0 )->GetParameter( 0 ) ).c_str() );
+      if( outputOption->GetFunction( 0 )->GetNumberOfParameters() > 1 )
+        {
+        WriteImage<ImageType>( biasFieldCropper->GetOutput(),  ( outputOption->GetFunction( 0 )->GetParameter( 1 ) ).c_str() );
+        }
+      }
+    }
+
   return EXIT_SUCCESS;
+}
+
+void N3InitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
+{
+  using OptionType = itk::ants::CommandLineParser::OptionType;
+
+  {
+  std::string description =
+      std::string( "This option forces the image to be treated as a specified-" )
+      + std::string( "dimensional image.  If not specified, N3 tries to " )
+      + std::string( "infer the dimensionality from the input image." );
+  OptionType::Pointer option = OptionType::New();
+  option->SetLongName( "image-dimensionality" );
+  option->SetShortName( 'd' );
+  option->SetUsageOption( 0, "2/3/4" );
+  option->SetDescription( description );
+  parser->AddOption( option );
+  }
+
+  {
+  std::string description =
+    std::string( "A scalar image is expected as input for bias correction.  " )
+    + std::string( "Since N4 log transforms the intensities, negative values " )
+    + std::string( "or values close to zero should be processed prior to " )
+    + std::string( "correction." );
+
+  OptionType::Pointer option = OptionType::New();
+  option->SetLongName( "input-image" );
+  option->SetShortName( 'i' );
+  option->SetUsageOption( 0, "inputImageFilename" );
+  option->SetDescription( description );
+  parser->AddOption( option );
+  }
+
+  {
+  std::string description =
+    std::string( "If a mask image is specified, the final bias correction is " )
+    + std::string( "only performed in the mask region.  If a weight image is not " )
+    + std::string( "specified, only intensity values inside the masked region are " )
+    + std::string( "used during the execution of the algorithm.  If a weight " )
+    + std::string( "image is specified, only the non-zero weights are used in the " )
+    + std::string( "execution of the algorithm although the mask region defines " )
+    + std::string( "where bias correction is performed in the final output. " )
+    + std::string( "Otherwise bias correction occurs over the entire image domain. " )
+    + std::string( "See also the option description for the weight image. " )
+    + std::string( "If a mask image is *not* specified then the entire image region " )
+    + std::string( "will be used as the mask region.  Note that this is different than " )
+    + std::string( "the N3 implementation which uses the results of Otsu thresholding " )
+    + std::string( "to define a mask.  However, this leads to unknown anatomical regions being " )
+    + std::string( "included and excluded during the bias correction." );
+
+  OptionType::Pointer option = OptionType::New();
+  option->SetLongName( "mask-image" );
+  option->SetShortName( 'x' );
+  option->SetUsageOption( 0, "maskImageFilename" );
+  option->SetDescription( description );
+  parser->AddOption( option );
+  }
+
+  {
+  std::string description =
+    std::string( "At each iteration, a new intensity mapping is calculated " )
+    + std::string( "and applied but there is nothing which constrains the " )
+    + std::string( "new intensity range to be within certain values.  The " )
+    + std::string( "result is that the range can \"drift\" from the original " )
+    + std::string( "at each iteration.  This option rescales to the [min,max] " )
+    + std::string( "range of the original image intensities within the user-specified mask." );
+
+  OptionType::Pointer option = OptionType::New();
+  option->SetLongName( "rescale-intensities" );
+  option->SetShortName( 'r' );
+  option->SetUsageOption( 0, "0/(1)" );
+  option->SetDescription( description );
+  parser->AddOption( option );
+  }
+
+  {
+  std::string description =
+    std::string( "The weight image allows the user to perform a relative " )
+    + std::string( "weighting of specific voxels during the B-spline fitting. " )
+    + std::string( "For example, some studies have shown that N3 performed on " )
+    + std::string( "white matter segmentations improves performance.  If one " )
+    + std::string( "has a spatial probability map of the white matter, one can " )
+    + std::string( "use this map to weight the b-spline fitting towards those " )
+    + std::string( "voxels which are more probabilistically classified as white " )
+    + std::string( "matter.  See also the option description for the mask image." );
+
+  OptionType::Pointer option = OptionType::New();
+  option->SetLongName( "weight-image" );
+  option->SetUsageOption( 0, "weightImageFilename" );
+  option->SetShortName( 'w' );
+  option->SetDescription( description );
+  parser->AddOption( option );
+  }
+
+  {
+  std::string description =
+    std::string( "Running N3 on large images can be time consuming. " )
+    + std::string( "To lessen computation time, the input image can be resampled. " )
+    + std::string( "The shrink factor, specified as a single integer, describes " )
+    + std::string( "this resampling.  Shrink factors <= 4 are commonly used." )
+    + std::string( "Note that the shrink factor is only applied to the first two or " )
+    + std::string( "three dimensions which we assume are spatial.  " );
+
+  OptionType::Pointer option = OptionType::New();
+  option->SetLongName( "shrink-factor" );
+  option->SetShortName( 's' );
+  option->SetUsageOption( 0, "1/2/3/(4)/..." );
+  option->SetDescription( description );
+  parser->AddOption( option );
+  }
+
+  {
+  std::string description =
+    std::string( "Convergence is determined by calculating the sigma of the coefficient of " )
+    + std::string( "variation between subsequent iterations. When this value " )
+    + std::string( "is less than the specified threshold " )
+    + std::string( "from the previous iteration or the maximum number of " )
+    + std::string( "iterations is exceeded the program terminates." );
+
+  OptionType::Pointer option = OptionType::New();
+  option->SetLongName( "convergence" );
+  option->SetShortName( 'c' );
+  option->SetUsageOption( 0, "[<numberOfIterations=50>,<numberOfFittingLevels=4>,<convergenceThreshold=0.0>]" );
+  option->SetDescription( description );
+  parser->AddOption( option );
+  }
+
+  {
+  std::string description =
+    std::string( "These options describe the b-spline fitting parameters. " )
+    + std::string( "The b-spline mesh is " )
+    + std::string( "specified either as the number of elements in each dimension, " )
+    + std::string( "e.g. 2x2x3 for 3-D images, or it can be specified as a " )
+    + std::string( "single scalar parameter which describes the isotropic sizing " )
+    + std::string( "of the mesh elements. The latter option is typically preferred. " )
+    + std::string( "The default setting " )
+    + std::string( "is to employ a single mesh element over the entire domain, i.e., " )
+    + std::string( "-b [1x1x1,3]." );
+
+  OptionType::Pointer option = OptionType::New();
+  option->SetLongName( "bspline-fitting" );
+  option->SetShortName( 'b' );
+  option->SetUsageOption( 0, "[splineDistance,<splineOrder=3>]" );
+  option->SetUsageOption( 1, "[meshResolution,<splineOrder=3>]" );
+  option->SetDescription( description );
+  parser->AddOption( option );
+  }
+
+  {
+  std::string description =
+    std::string( "These options describe the histogram sharpening parameters, " )
+    + std::string( "i.e. the deconvolution step parameters described in the " )
+    + std::string( "original N3 algorithm.  The default values have been shown " )
+    + std::string( "to work fairly well." );
+
+  OptionType::Pointer option = OptionType::New();
+  option->SetLongName( "histogram-sharpening" );
+  option->SetShortName( 't' );
+  option->SetUsageOption( 0, "[<FWHM=0.15>,<wienerNoise=0.01>,<numberOfHistogramBins=200>]" );
+  option->SetDescription( description );
+  parser->AddOption( option );
+  }
+
+  {
+  std::string description =
+    std::string( "The output consists of the bias corrected version of the " )
+    + std::string( "input image.  Optionally, one can also output the estimated " )
+    + std::string( "bias field." );
+
+  OptionType::Pointer option = OptionType::New();
+  option->SetLongName( "output" );
+  option->SetShortName( 'o' );
+  option->SetUsageOption( 0, "correctedImage" );
+  option->SetUsageOption( 1, "[correctedImage,<biasField>]" );
+  option->SetDescription( description );
+  parser->AddOption( option );
+  }
+
+  {
+  std::string description = std::string( "Get Version Information." );
+  OptionType::Pointer option = OptionType::New();
+  option->SetLongName( "version" );
+  option->SetDescription( description );
+  parser->AddOption( option );
+  }
+
+  {
+  std::string description = std::string( "Verbose output." );
+
+  OptionType::Pointer option = OptionType::New();
+  option->SetShortName( 'v' );
+  option->SetLongName( "verbose" );
+  option->SetUsageOption( 0, "(0)/1" );
+  option->SetDescription( description );
+  parser->AddOption( option );
+  }
+
+  {
+  std::string description = std::string( "Print the help menu (short version)." );
+
+  OptionType::Pointer option = OptionType::New();
+  option->SetShortName( 'h' );
+  option->SetDescription( description );
+  parser->AddOption( option );
+  }
+
+  {
+  std::string description = std::string( "Print the help menu." );
+
+  OptionType::Pointer option = OptionType::New();
+  option->SetLongName( "help" );
+  option->SetDescription( description );
+  parser->AddOption( option );
+  }
+}
+
+// entry point for the library; parameter 'args' is equivalent to 'argv' in (argc,argv) of commandline parameters to
+// 'main()'
+int N3BiasFieldCorrection( std::vector<std::string> args, std::ostream* /*out_stream = nullptr */ )
+{
+
+  if( args.size() >= 1 && std::string( args[0] ) == std::string( "x" ) )
+    {
+    args.erase( args.begin() );
+
+    // put the arguments coming in as 'args' into standard (argc,argv) format;
+    // 'args' doesn't have the command name as first, argument, so add it manually;
+    // 'args' may have adjacent arguments concatenated into one argument,
+    // which the parser should handle
+    args.insert( args.begin(), "N3BiasFieldCorrection" );
+
+    int     argc = args.size();
+    char* * argv = new char *[args.size() + 1];
+    for( unsigned int i = 0; i < args.size(); ++i )
+      {
+      // allocate space for the string plus a null character
+      argv[i] = new char[args[i].length() + 1];
+      std::strncpy( argv[i], args[i].c_str(), args[i].length() );
+      // place the null character in the end
+      argv[i][args[i].length()] = '\0';
+      }
+    argv[argc] = nullptr;
+    // class to automatically cleanup argv upon destruction
+    class Cleanup_argv
+    {
+    public:
+      Cleanup_argv( char* * argv_, int argc_plus_one_ ) : argv( argv_ ), argc_plus_one( argc_plus_one_ )
+      {
+      }
+
+      ~Cleanup_argv()
+      {
+        for( unsigned int i = 0; i < argc_plus_one; ++i )
+          {
+          delete[] argv[i];
+          }
+        delete[] argv;
+      }
+
+    private:
+      char* *      argv;
+      unsigned int argc_plus_one;
+    };
+    Cleanup_argv cleanup_argv( argv, argc + 1 );
+
+    // antscout->set_stream( out_stream );
+
+    itk::ants::CommandLineParser::Pointer parser =
+      itk::ants::CommandLineParser::New();
+
+    parser->SetCommand( argv[0] );
+
+    std::string commandDescription =
+      std::string( "This N3 is a variant of the popular N3 (nonparameteric nonuniform " )
+      + std::string( "normalization) retrospective bias correction algorithm. Based " )
+      + std::string( "on the assumption that the corruption of the low frequency bias " )
+      + std::string( "field can be modeled as a convolution of the intensity histogram " )
+      + std::string( "by a Gaussian, the basic algorithmic protocol is to iterate " )
+      + std::string( "between deconvolving the intensity histogram by a Gaussian, " )
+      + std::string( "remapping the intensities, and then spatially smoothing this " )
+      + std::string( "result by a B-spline modeling of the bias field itself. "  );
+
+    parser->SetCommandDescription( commandDescription );
+    N3InitializeCommandLineOptions( parser );
+
+    if( parser->Parse( argc, argv ) == EXIT_FAILURE )
+      {
+      return EXIT_FAILURE;
+      }
+
+    if( argc == 1 )
+      {
+      parser->PrintMenu( std::cerr, 5, false );
+      return EXIT_FAILURE;
+      }
+    else if( parser->GetOption( "help" )->GetFunction() && parser->Convert<bool>( parser->GetOption( "help" )->GetFunction()->GetName() ) )
+      {
+      parser->PrintMenu( std::cout, 5, false );
+      return EXIT_SUCCESS;
+      }
+    else if( parser->GetOption( 'h' )->GetFunction() && parser->Convert<bool>( parser->GetOption( 'h' )->GetFunction()->GetName() ) )
+      {
+      parser->PrintMenu( std::cout, 5, true );
+      return EXIT_SUCCESS;
+      }
+    // Show automatic version
+    itk::ants::CommandLineParser::OptionType::Pointer versionOption = parser->GetOption( "version" );
+    if( versionOption && versionOption->GetNumberOfFunctions() )
+      {
+      std::string versionFunction = versionOption->GetFunction( 0 )->GetName();
+      ConvertToLowerCase( versionFunction );
+      if( versionFunction.compare( "1" ) == 0 || versionFunction.compare( "true" ) == 0 )
+        {
+        //Print Version Information
+        std::cout << ANTs::Version::ExtendedVersionString() << std::endl;
+        return EXIT_SUCCESS;
+        }
+      }
+    // Get dimensionality
+    unsigned int dimension = 3;
+
+    itk::ants::CommandLineParser::OptionType::Pointer dimOption =
+      parser->GetOption( "image-dimensionality" );
+    if( dimOption && dimOption->GetNumberOfFunctions() )
+      {
+      dimension = parser->Convert<unsigned int>( dimOption->GetFunction( 0 )->GetName() );
+      }
+    else
+      {
+      // Read in the first intensity image to get the image dimension.
+      std::string filename;
+
+      itk::ants::CommandLineParser::OptionType::Pointer imageOption =
+        parser->GetOption( "input-image" );
+      if( imageOption && imageOption->GetNumberOfFunctions() > 0 )
+        {
+        if( imageOption->GetFunction( 0 )->GetNumberOfParameters() > 0 )
+          {
+          filename = imageOption->GetFunction( 0 )->GetParameter( 0 );
+          }
+        else
+          {
+          filename = imageOption->GetFunction( 0 )->GetName();
+          }
+        }
+      else
+        {
+        std::cerr << "No input images were specified.  Specify an input image"
+                  << " with the -i option" << std::endl;
+        return EXIT_FAILURE;
+        }
+      itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
+          filename.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode );
+      dimension = imageIO->GetNumberOfDimensions();
+      }
+
+    int returnValue = EXIT_FAILURE;
+
+    switch( dimension )
+      {
+      case 2:
+        {
+        returnValue = N3<2>( parser );
+        }
+        break;
+      case 3:
+        {
+        returnValue = N3<3>( parser );
+        }
+        break;
+      case 4:
+        {
+        returnValue = N3<4>( parser );
+        }
+        break;
+      default:
+        std::cout << "Unsupported dimension" << std::endl;
+        return EXIT_FAILURE;
+      }
+    return returnValue;
+
+    }
+  else
+    {
+    // put the arguments coming in as 'args' into standard (argc,argv) format;
+    // 'args' doesn't have the command name as first, argument, so add it manually;
+    // 'args' may have adjacent arguments concatenated into one argument,
+    // which the parser should handle
+    args.insert( args.begin(), "N3BiasFieldCorrection" );
+
+    int     argc = args.size();
+    char* * argv = new char *[args.size() + 1];
+    for( unsigned int i = 0; i < args.size(); ++i )
+      {
+      // allocate space for the string plus a null character
+      argv[i] = new char[args[i].length() + 1];
+      std::strncpy( argv[i], args[i].c_str(), args[i].length() );
+      // place the null character in the end
+      argv[i][args[i].length()] = '\0';
+      }
+    argv[argc] = nullptr;
+    // class to automatically cleanup argv upon destruction
+    class Cleanup_argv
+    {
+  public:
+      Cleanup_argv( char* * argv_, int argc_plus_one_ ) : argv( argv_ ), argc_plus_one( argc_plus_one_ )
+      {
+      }
+
+      ~Cleanup_argv()
+      {
+        for( unsigned int i = 0; i < argc_plus_one; ++i )
+          {
+          delete[] argv[i];
+          }
+        delete[] argv;
+      }
+
+  private:
+      char* *      argv;
+      unsigned int argc_plus_one;
+    };
+    Cleanup_argv cleanup_argv( argv, argc + 1 );
+
+    // antscout->set_stream( out_stream );
+
+    if( argc < 4 )
+      {
+      std::cout << "Usage: " << argv[0] << " imageDimension inputImage "
+              << "outputImage [shrinkFactor] [maskImage] [numberOfIterations] "
+              << "[numberOfFittingLevels] [outputBiasField] [verbose]" << std::endl;
+      if( argc >= 2 &&
+          ( std::string( argv[1] ) == std::string("--help") || std::string( argv[1] ) == std::string("-h") ) )
+        {
+        return EXIT_SUCCESS;
+        }
+      return EXIT_FAILURE;
+      }
+
+    switch( std::stoi( argv[1] ) )
+      {
+      case 2:
+        {
+        return N3BiasFieldCorrection<2>( argc, argv );
+        }
+        break;
+      case 3:
+        {
+        return N3BiasFieldCorrection<3>( argc, argv );
+        }
+        break;
+      case 4:
+        {
+        return N3BiasFieldCorrection<4>( argc, argv );
+        }
+        break;
+      default:
+        std::cout << "Unsupported dimension" << std::endl;
+        return EXIT_FAILURE;
+      }
+    return EXIT_SUCCESS;
+    }
 }
 } // namespace ants

--- a/Examples/N3BiasFieldCorrection.cxx
+++ b/Examples/N3BiasFieldCorrection.cxx
@@ -952,10 +952,10 @@ void N3InitializeCommandLineOptions( itk::ants::CommandLineParser *parser )
 int N3BiasFieldCorrection( std::vector<std::string> args, std::ostream* /*out_stream = nullptr */ )
 {
 
-  if( args.size() >= 1 && std::string( args[0] ) == std::string( "x" ) )
+  if( args.size() >= 1 && std::string( args[0] ) != std::string( "2" ) &&
+                          std::string( args[0] ) != std::string( "3" ) &&
+                          std::string( args[0] ) != std::string( "4" ) )
     {
-    args.erase( args.begin() );
-
     // put the arguments coming in as 'args' into standard (argc,argv) format;
     // 'args' doesn't have the command name as first, argument, so add it manually;
     // 'args' may have adjacent arguments concatenated into one argument,

--- a/Utilities/itkN3BiasFieldCorrectionImageFilter.h
+++ b/Utilities/itkN3BiasFieldCorrectionImageFilter.h
@@ -1,0 +1,425 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkN3BiasFieldCorrectionImageFilter_h
+#define itkN3BiasFieldCorrectionImageFilter_h
+
+#include "itkImageToImageFilter.h"
+
+#include "itkArray.h"
+#include "itkBSplineScatteredDataPointSetToImageFilter.h"
+#include "itkPointSet.h"
+#include "itkVector.h"
+
+#include "vnl/vnl_vector.h"
+
+namespace itk
+{
+
+/**
+ * \class N3BiasFieldCorrectionImageFilter
+ * \brief Implementation of the N3 MRI bias field correction algorithm.
+ *
+ * The nonparametric nonuniform intensity normalization (N3) algorithm
+ * is a method for correcting nonuniformity associated with MR images.
+ * The algorithm assumes a simple parametric model (Gaussian) for the bias field
+ * but does not require tissue class segmentation.  In addition, there are
+ * only a couple of parameters to tune with the default values performing
+ * quite well.
+ *
+ * N3 has been publicly available as a set of perl scripts
+ * (http://www.bic.mni.mcgill.ca/software/N3/) but, with this class, has been
+ * reimplemented for the ITK library with only one minor variation involving
+ * the b-spline fitting routine.  We replaced the original fitting approach
+ * with the itkBSplineScatteredDataPointSetToImageFilter which is not
+ * susceptible to ill-conditioned matrix calculation as is the original proposed
+ * fitting component.
+ *
+ * Notes for the user:
+ *  1. Since much of the image manipulation is done in the log space of the
+ *     intensities, input images with negative and small values (< 1) are
+ *     discouraged.
+ *  2. The original authors recommend performing the bias field correction
+ *      on a downsampled version of the original image.
+ *  3. A mask and/or confidence image can be supplied.
+ *  4. The filter returns the corrected image.  If the bias field is wanted, one
+ *     can reconstruct it using the class itkBSplineControlPointImageFilter.
+ *     See the IJ article and the test file for an example.
+ *  5. The 'Z' parameter in Sled's 1998 paper is the square root
+ *     of the class variable 'm_WienerFilterNoise'.
+ *
+ * \author Nicholas J. Tustison
+ *
+ * Contributed by Nicholas J. Tustison, James C. Gee
+ * in the Insight Journal paper:
+ *
+ * \par REFERENCE
+ * J.G. Sled, P. Zijdenbos and A.C. Evans, "A comparison of retrospective
+ * intensity non-uniformity correction methods for MRI".  Information
+ * Processing Medical Imaging Proc, 15th Int. Conf. IMPI'97, vol.1230,
+ * pp 459-464,1997.
+ *
+ * J.G. Sled, A.P. Zijdenbos and A.C. Evans.  "A Nonparametric Method for
+ * Automatic Correction of Intensity Nonuniformity in MRI Data"
+ * IEEE Transactions on Medical Imaging, Vol 17, No 1. Feb 1998.
+ *
+ */
+
+template <typename TInputImage,
+          typename TMaskImage = Image<unsigned char, TInputImage::ImageDimension>,
+          class TOutputImage = TInputImage>
+class N3BiasFieldCorrectionImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
+{
+public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(N3BiasFieldCorrectionImageFilter);
+
+  /** Standard class type aliases. */
+  using Self = N3BiasFieldCorrectionImageFilter;
+  using Superclass = ImageToImageFilter<TInputImage, TOutputImage>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
+
+  /** Runtime information support. */
+  itkTypeMacro(N3BiasFieldCorrectionImageFilter, ImageToImageFilter);
+
+  /** Standard New method. */
+  itkNewMacro(Self);
+
+  /** ImageDimension constants */
+  static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
+
+  /** Some convenient type alias. */
+  using InputImageType = TInputImage;
+  using OutputImageType = TOutputImage;
+  using MaskImageType = TMaskImage;
+  using MaskPixelType = typename MaskImageType::PixelType;
+
+  using RealType = float;
+  using RealImageType = Image<RealType, ImageDimension>;
+  using RealImagePointer = typename RealImageType::Pointer;
+  using VariableSizeArrayType = Array<unsigned int>;
+
+  /** B-spline smoothing filter argument type alias */
+  using ScalarType = Vector<RealType, 1>;
+  using PointSetType = PointSet<ScalarType, Self::ImageDimension>;
+  using ScalarImageType = Image<ScalarType, Self::ImageDimension>;
+  using PointSetPointer = typename PointSetType::Pointer;
+  using PointType = typename PointSetType::PointType;
+
+  /** B-sline filter type alias */
+  using BSplineFilterType = BSplineScatteredDataPointSetToImageFilter<PointSetType, ScalarImageType>;
+  using BiasFieldControlPointLatticeType = typename BSplineFilterType::PointDataImageType;
+  using ArrayType = typename BSplineFilterType::ArrayType;
+
+  /** Ensures that this filter can compute the entire output at once.  */
+  void
+  EnlargeOutputRequestedRegion(DataObject *) override;
+
+  /**
+   * The image expected for input for bias correction.
+   */
+  void
+  SetInput1(const InputImageType * image)
+  {
+    this->SetInput(image);
+  }
+
+  /**
+   * Set mask image function.  If a binary mask image is specified, only
+   * those input image voxels inside the mask image values are used in
+   * estimating the bias field.
+   */
+  itkSetInputMacro(MaskImage, MaskImageType);
+  void
+  SetInput2(const MaskImageType * mask)
+  {
+    this->SetMaskImage(mask);
+  }
+
+  /**
+   * Get mask image function.  If a binary mask image is specified, only
+   * those input image voxels inside the mask image values are used in
+   * estimating the bias field.
+   */
+  itkGetInputMacro(MaskImage, MaskImageType);
+
+  /**
+   * Set/Get mask label value. If a binary mask image is specified and if
+   * UseMaskValue is true, only those input image voxels corresponding
+   * with mask image values equal to MaskLabel are used in estimating the
+   * bias field. If a MaskImage is specified and UseMaskLabel is false, all
+   * input image voxels corresponding to non-zero voxels in the MaskImage
+   * are used in estimating the bias field. Default = 1.
+   */
+  itkSetMacro(MaskLabel, MaskPixelType);
+  itkGetConstMacro(MaskLabel, MaskPixelType);
+
+  /**
+   * Use a mask label for identifying mask functionality. See SetMaskLabel.
+   * Defaults to false. */
+  itkSetMacro(UseMaskLabel, bool);
+  itkGetConstMacro(UseMaskLabel, bool);
+  itkBooleanMacro(UseMaskLabel);
+
+  /**
+   * Set confidence image function.  If a confidence image is specified,
+   * estimation of the bias field weights the contribution of each voxel
+   * according the value of the corresponding voxel in the confidence image.
+   * For example, when estimating the bias field using brain , one can use
+   * a soft segmentation of the white matter as the confidence image instead of
+   * using a hard segmentation of the white matter as the mask image (as has
+   * been done in the literature) as an alternative strategy to estimating the
+   * bias field.
+   */
+  itkSetInputMacro(ConfidenceImage, RealImageType);
+  void
+  SetInput3(const RealImageType * image)
+  {
+    this->SetConfidenceImage(image);
+  }
+
+  /**
+   * Get confidence image function.  If a confidence image is specified,
+   * estimation of the bias field weights the contribution of each voxel
+   * according the value of the corresponding voxel in the confidence image.
+   * For example, when estimating the bias field using brain , one can use
+   * a soft segmentation of the white matter as the confidence image instead of
+   * using a hard segmentation of the white matter as the mask image (as has
+   * been done in the literature) as an alternative strategy to estimating the
+   * bias field.
+   */
+  itkGetInputMacro(ConfidenceImage, RealImageType);
+
+  // Sharpen histogram parameters: in estimating the bias field, the
+  // first step is to sharpen the intensity histogram by Wiener deconvolution
+  // with a 1-D Gaussian.  The following parameters define this operation.
+
+  /**
+   * Set number of bins defining the log input intensity histogram.
+   * Default = 200.
+   */
+  itkSetMacro(NumberOfHistogramBins, unsigned int);
+
+  /**
+   * Get number of bins defining the log input intensity histogram.
+   * Default = 200.
+   */
+  itkGetConstMacro(NumberOfHistogramBins, unsigned int);
+
+  /**
+   * Set the noise estimate defining the Wiener filter.  Default = 0.01.
+   */
+  itkSetMacro(WienerFilterNoise, RealType);
+
+  /**
+   * Get the noise estimate defining the Wiener filter.  Default = 0.01.
+   */
+  itkGetConstMacro(WienerFilterNoise, RealType);
+
+  /**
+   * Set the full width at half maximum parameter characterizing the width of
+   * the Gaussian deconvolution.  Default = 0.15.
+   */
+  itkSetMacro(BiasFieldFullWidthAtHalfMaximum, RealType);
+
+  /**
+   * Get the full width at half maximum parameter characterizing the width of
+   * the Gaussian deconvolution.  Default = 0.15.
+   */
+  itkGetConstMacro(BiasFieldFullWidthAtHalfMaximum, RealType);
+
+  // B-spline parameters governing the fitting routine
+
+  /**
+   * Set the spline order defining the bias field estimate.  Default = 3.
+   */
+  itkSetMacro(SplineOrder, unsigned int);
+
+  /**
+   * Get the spline order defining the bias field estimate.  Default = 3.
+   */
+  itkGetConstMacro(SplineOrder, unsigned int);
+
+  /**
+   * Set the control point grid size defining the B-spline estimate of the
+   * scalar bias field.  In each dimension, the B-spline mesh size is equal
+   * to the number of control points in that dimension minus the spline order.
+   * Default = 4 control points in each dimension for a mesh size of 1 in each
+   * dimension.
+   */
+  itkSetMacro(NumberOfControlPoints, ArrayType);
+
+  /**
+   * Get the control point grid size defining the B-spline estimate of the
+   * scalar bias field.  In each dimension, the B-spline mesh size is equal
+   * to the number of control points in that dimension minus the spline order.
+   * Default = 4 control points in each dimension for a mesh size of 1 in each
+   * dimension.
+   */
+  itkGetConstMacro(NumberOfControlPoints, ArrayType);
+
+  /**
+   * Set the number of fitting levels.  One of the contributions of N3 is the
+   * introduction of a multi-scale approach to fitting. This allows one to
+   * specify a B-spline mesh size for initial fitting followed by a doubling of
+   * the mesh resolution for each subsequent fitting level.  Default = 4 level.
+   */
+  itkSetMacro(NumberOfFittingLevels, unsigned int);
+
+  /**
+   * Get the number of fitting levels.  Default = 4 level.
+   */
+  itkGetConstMacro(NumberOfFittingLevels, unsigned int);
+
+  /**
+   * Set the maximum number of iterations. Default = 50.
+   */
+  itkSetMacro(MaximumNumberOfIterations, unsigned int);
+
+  /**
+   * Get the maximum number of iterations. Default = 50.
+   */
+  itkGetConstMacro(MaximumNumberOfIterations, unsigned int);
+
+  /**
+   * Set the convergence threshold.  Convergence is determined by the
+   * coefficient of variation of the difference image between the current bias
+   * field estimate and the previous estimate.  If this value is less than the
+   * specified threshold, the algorithm proceeds to the next fitting level or
+   * terminates if it is at the last level.
+   */
+  itkSetMacro(ConvergenceThreshold, RealType);
+
+  /**
+   * Get the convergence threshold.  Convergence is determined by the
+   * coefficient of variation of the difference image between the current bias
+   * field estimate and the previous estimate.  If this value is less than the
+   * specified threshold, the algorithm proceeds to the next fitting level or
+   * terminates if it is at the last level.
+   */
+  itkGetConstMacro(ConvergenceThreshold, RealType);
+
+  /**
+   * Typically, a reduced size image is used as input to the N3 filter using
+   * something like itkShrinkImageFilter.  Since the output is a corrected
+   * version of the input, the user will probably want to apply the bias
+   * field correction to the full resolution image.  This can be done by
+   * using the LogBiasFieldControlPointLattice to reconstruct the bias field
+   * at the full image resolution (using the class
+   * BSplineControlPointImageFilter).
+   */
+  itkGetConstObjectMacro(LogBiasFieldControlPointLattice, BiasFieldControlPointLatticeType);
+
+  /**
+   * Get the number of elapsed iterations.  This is a helper function for
+   * reporting observations.
+   */
+  itkGetConstMacro(ElapsedIterations, unsigned int);
+
+  /**
+   * Get the current convergence measurement.  This is a helper function for
+   * reporting observations.
+   */
+  itkGetConstMacro(CurrentConvergenceMeasurement, RealType);
+
+  /**
+   * Get the current fitting level.  This is a helper function for
+   * reporting observations.
+   */
+  itkGetConstMacro(CurrentLevel, unsigned int);
+
+  /**
+   * Reconstruct bias field given the control point lattice.
+   */
+  RealImagePointer
+  ReconstructBiasField(const BiasFieldControlPointLatticeType *);
+
+protected:
+  N3BiasFieldCorrectionImageFilter();
+  ~N3BiasFieldCorrectionImageFilter() override = default;
+  void
+  PrintSelf(std::ostream & os, Indent indent) const override;
+
+  void
+  GenerateData() override;
+
+private:
+  // N3 algorithm functions:  The basic algorithm iterates between sharpening
+  // the intensity histogram of the corrected input image and spatially
+  // smoothing those results with a B-spline scalar field estimate of the
+  // bias field.  The former is handled by the function SharpenImage()
+  // whereas the latter is handled by the function UpdateBiasFieldEstimate().
+  // Convergence is determined by the coefficient of variation of the difference
+  // image between the current bias field estimate and the previous estimate.
+
+  /**
+   * Sharpen the intensity histogram of the current estimate of the corrected
+   * image and map those results to a new estimate of the unsmoothed corrected
+   * image.
+   */
+  void
+  SharpenImage(const RealImageType * uncorrected, RealImageType * sharpened) const;
+
+  /**
+   * Given the unsmoothed estimate of the bias field, this function smooths
+   * the estimate and adds the resulting control point values to the total
+   * bias field estimate.
+   */
+  RealImagePointer
+  UpdateBiasFieldEstimate(RealImageType *, std::size_t);
+
+  /**
+   * Convergence is determined by the coefficient of variation of the difference
+   * image between the current bias field estimate and the previous estimate.
+   */
+  RealType
+  CalculateConvergenceMeasurement(const RealImageType *, const RealImageType *) const;
+
+  MaskPixelType m_MaskLabel;
+  bool          m_UseMaskLabel{ false };
+
+  // Parameters for deconvolution with Wiener filter
+
+  unsigned int m_NumberOfHistogramBins{ 200 };
+  RealType     m_WienerFilterNoise{ static_cast<RealType>(0.01) };
+  RealType     m_BiasFieldFullWidthAtHalfMaximum{ static_cast<RealType>(0.15) };
+
+  // Convergence parameters
+
+  unsigned int          m_MaximumNumberOfIterations{ 50 };
+  unsigned int          m_ElapsedIterations{ 0 };
+  RealType              m_ConvergenceThreshold{ static_cast<RealType>(0.001) };
+  RealType              m_CurrentConvergenceMeasurement;
+  unsigned int          m_CurrentLevel{ 0 };
+
+  // B-spline fitting parameters
+
+  typename BiasFieldControlPointLatticeType::Pointer m_LogBiasFieldControlPointLattice;
+
+  unsigned int m_SplineOrder{ 3 };
+  ArrayType    m_NumberOfControlPoints;
+  unsigned int m_NumberOfFittingLevels{ 4 };
+
+};
+
+} // end namespace itk
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#  include "itkN3BiasFieldCorrectionImageFilter.hxx"
+#endif
+
+#endif

--- a/Utilities/itkN3BiasFieldCorrectionImageFilter.h
+++ b/Utilities/itkN3BiasFieldCorrectionImageFilter.h
@@ -1,20 +1,17 @@
 /*=========================================================================
- *
- *  Copyright NumFOCUS
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
- *=========================================================================*/
+
+  Program:   Advanced Normalization Tools
+
+  Copyright (c) ConsortiumOfANTS. All rights reserved.
+  See accompanying COPYING.txt or
+ https://github.com/stnava/ANTs/blob/master/ANTSCopyright.txt for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+
 #ifndef itkN3BiasFieldCorrectionImageFilter_h
 #define itkN3BiasFieldCorrectionImageFilter_h
 

--- a/Utilities/itkN3BiasFieldCorrectionImageFilter.hxx
+++ b/Utilities/itkN3BiasFieldCorrectionImageFilter.hxx
@@ -1,20 +1,16 @@
 /*=========================================================================
- *
- *  Copyright NumFOCUS
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
- *=========================================================================*/
+
+  Program:   Advanced Normalization Tools
+
+  Copyright (c) ConsortiumOfANTS. All rights reserved.
+  See accompanying COPYING.txt or
+ https://github.com/stnava/ANTs/blob/master/ANTSCopyright.txt for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
 #ifndef itkN3BiasFieldCorrectionImageFilter_hxx
 #define itkN3BiasFieldCorrectionImageFilter_hxx
 

--- a/Utilities/itkN3BiasFieldCorrectionImageFilter.hxx
+++ b/Utilities/itkN3BiasFieldCorrectionImageFilter.hxx
@@ -1,0 +1,630 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkN3BiasFieldCorrectionImageFilter_hxx
+#define itkN3BiasFieldCorrectionImageFilter_hxx
+
+#include "itkN3BiasFieldCorrectionImageFilter.h"
+
+#include "itkAddImageFilter.h"
+#include "itkBSplineControlPointImageFilter.h"
+#include "itkDivideImageFilter.h"
+#include "itkExpImageFilter.h"
+#include "itkImageBufferRange.h"
+#include "itkImageRegionConstIteratorWithIndex.h"
+#include "itkImageRegionIterator.h"
+#include "itkImageRegionIteratorWithIndex.h"
+#include "itkImportImageFilter.h"
+#include "itkIterationReporter.h"
+#include "itkSubtractImageFilter.h"
+#include "itkVectorIndexSelectionCastImageFilter.h"
+
+CLANG_PRAGMA_PUSH
+CLANG_SUPPRESS_Wfloat_equal
+#include "vnl/algo/vnl_fft_1d.h"
+#include "vnl/vnl_complex_traits.h"
+#include "complex"
+CLANG_PRAGMA_POP
+
+namespace itk
+{
+
+  template <typename TInputImage, typename TMaskImage, typename TOutputImage>
+  N3BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::N3BiasFieldCorrectionImageFilter()
+    : m_MaskLabel(NumericTraits<MaskPixelType>::OneValue())
+    , m_CurrentConvergenceMeasurement(NumericTraits<RealType>::ZeroValue())
+
+  {
+    // implicit:
+    // #0 "Primary" required
+
+    // #1 "MaskImage" optional
+    Self::AddOptionalInputName("MaskImage", 1);
+
+    // #2 "ConfidenceImage" optional
+    Self::AddOptionalInputName("ConfidenceImage", 2);
+
+    this->SetNumberOfRequiredInputs(1);
+
+    this->m_LogBiasFieldControlPointLattice = nullptr;
+
+    this->m_NumberOfControlPoints.Fill(4);
+  }
+
+
+  template <typename TInputImage, typename TMaskImage, typename TOutputImage>
+  void N3BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::EnlargeOutputRequestedRegion(
+    DataObject * output)
+  {
+    Superclass::EnlargeOutputRequestedRegion(output);
+
+    if (output != nullptr)
+    {
+      output->SetRequestedRegionToLargestPossibleRegion();
+    }
+  }
+
+
+  template <typename TInputImage, typename TMaskImage, typename TOutputImage>
+  void N3BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::GenerateData()
+  {
+    this->AllocateOutputs();
+
+    const InputImageType * inputImage = this->GetInput();
+    using RegionType = typename InputImageType::RegionType;
+    const RegionType inputRegion = inputImage->GetBufferedRegion();
+
+    const typename InputImageType::SizeType inputImageSize = inputRegion.GetSize();
+
+    const MaskImageType * const maskImage = GetMaskImage();
+
+    if ((maskImage != nullptr) && (maskImage->GetBufferedRegion().GetSize() != inputImageSize))
+    {
+      itkExceptionMacro("If a mask image is specified, its size should be equal to the input image size");
+    }
+
+    const RealImageType * const confidenceImage = GetConfidenceImage();
+
+    if ((confidenceImage != nullptr) && (confidenceImage->GetBufferedRegion().GetSize() != inputImageSize))
+    {
+      itkExceptionMacro("If a confidence image is specified, its size should be equal to the input image size");
+    }
+
+    // Calculate the log of the input image.
+    RealImagePointer logInputImage = RealImageType::New();
+    logInputImage->CopyInformation(inputImage);
+    logInputImage->SetRegions(inputRegion);
+    logInputImage->Allocate(false);
+
+    ImageAlgorithm::Copy(inputImage, logInputImage.GetPointer(), inputRegion, inputRegion);
+
+    const auto          maskImageBufferRange = MakeImageBufferRange(maskImage);
+    const auto          confidenceImageBufferRange = MakeImageBufferRange(confidenceImage);
+    const MaskPixelType maskLabel = this->GetMaskLabel();
+    const bool          useMaskLabel = this->GetUseMaskLabel();
+
+    const ImageBufferRange<RealImageType> logInputImageBufferRange{ *logInputImage };
+    const std::size_t                     numberOfPixels = logInputImageBufferRange.size();
+
+    // Number of pixels of the input image that are included with the filter.
+    std::size_t numberOfIncludedPixels = 0;
+
+    for (std::size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue)
+    {
+      if ((maskImageBufferRange.empty() || (useMaskLabel && maskImageBufferRange[indexValue] == maskLabel) ||
+           (!useMaskLabel && maskImageBufferRange[indexValue] != NumericTraits<MaskPixelType>::ZeroValue())) &&
+          (confidenceImageBufferRange.empty() || confidenceImageBufferRange[indexValue] > 0.0))
+      {
+        ++numberOfIncludedPixels;
+        auto && logInputPixel = logInputImageBufferRange[indexValue];
+
+        if (logInputPixel > NumericTraits<typename InputImageType::PixelType>::ZeroValue())
+        {
+          logInputPixel = std::log(static_cast<RealType>(logInputPixel));
+        }
+      }
+    }
+
+    // Duplicate logInputImage since we reuse the original at each iteration.
+
+    using DuplicatorType = ImageDuplicator<RealImageType>;
+    typename DuplicatorType::Pointer duplicator = DuplicatorType::New();
+    duplicator->SetInputImage(logInputImage);
+    duplicator->Update();
+
+    RealImagePointer logUncorrectedImage = duplicator->GetOutput();
+
+    // Provide an initial log bias field of zeros
+
+    RealImagePointer logBiasField = RealImageType::New();
+    logBiasField->CopyInformation(inputImage);
+    logBiasField->SetRegions(inputImage->GetLargestPossibleRegion());
+    logBiasField->Allocate(true); // initialize buffer to zero
+
+    RealImagePointer logSharpenedImage = RealImageType::New();
+    logSharpenedImage->CopyInformation(inputImage);
+    logSharpenedImage->SetRegions(inputImage->GetLargestPossibleRegion());
+    logSharpenedImage->Allocate(false);
+
+    IterationReporter reporter(this, 0, 1);
+
+    this->m_ElapsedIterations = 0;
+    this->m_CurrentConvergenceMeasurement = NumericTraits<RealType>::max();
+    while (this->m_ElapsedIterations++ < this->m_MaximumNumberOfIterations &&
+            this->m_CurrentConvergenceMeasurement > this->m_ConvergenceThreshold)
+    {
+      using SubtracterType = SubtractImageFilter<RealImageType, RealImageType, RealImageType>;
+      typename SubtracterType::Pointer subtracter1 = SubtracterType::New();
+      subtracter1->SetInput1(logInputImage);
+      subtracter1->SetInput2(logBiasField);
+      subtracter1->Update();
+
+      // Sharpen the current estimate of the uncorrected image.
+      this->SharpenImage(subtracter1->GetOutput(), logSharpenedImage);
+
+      typename SubtracterType::Pointer subtracter2 = SubtracterType::New();
+      subtracter2->SetInput1(logInputImage);
+      subtracter2->SetInput2(logSharpenedImage);
+      subtracter2->Update();
+
+      // Smooth the residual bias field estimate
+      RealImagePointer newLogBiasField = this->UpdateBiasFieldEstimate(subtracter2->GetOutput(), numberOfIncludedPixels);
+
+      this->m_CurrentConvergenceMeasurement = this->CalculateConvergenceMeasurement(logBiasField, newLogBiasField);
+      logBiasField = newLogBiasField;
+
+      reporter.CompletedStep();
+    }
+
+    using CustomBinaryFilter = itk::BinaryGeneratorImageFilter<InputImageType, RealImageType, OutputImageType>;
+    typename CustomBinaryFilter::Pointer expAndDivFilter = CustomBinaryFilter::New();
+    auto                                 expAndDivLambda =
+      [](const typename InputImageType::PixelType & input, const typename RealImageType::PixelType & biasField) ->
+      typename OutputImageType::PixelType
+    {
+      return static_cast<typename OutputImageType::PixelType>(input / std::exp(biasField));
+    };
+    expAndDivFilter->SetFunctor(expAndDivLambda);
+    expAndDivFilter->SetInput1(inputImage);
+    expAndDivFilter->SetInput2(logBiasField);
+    expAndDivFilter->Update();
+
+    this->GraftOutput(expAndDivFilter->GetOutput());
+  }
+
+  template <typename TInputImage, typename TMaskImage, typename TOutputImage>
+  void N3BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::SharpenImage(
+    const RealImageType * unsharpenedImage, RealImageType * sharpenedImage) const
+  {
+    const auto          maskImageBufferRange = MakeImageBufferRange(this->GetMaskImage());
+    const auto          confidenceImageBufferRange = MakeImageBufferRange(this->GetConfidenceImage());
+    const MaskPixelType maskLabel = this->GetMaskLabel();
+    const bool          useMaskLabel = this->GetUseMaskLabel();
+
+    // Build the histogram for the uncorrected image.  Store copy
+    // in a vnl_vector to utilize vnl FFT routines.  Note that variables
+    // in real space are denoted by a single uppercase letter whereas their
+    // frequency counterparts are indicated by a trailing lowercase 'f'.
+
+    RealType binMaximum = NumericTraits<RealType>::NonpositiveMin();
+    RealType binMinimum = NumericTraits<RealType>::max();
+
+    const auto        unsharpenedImageBufferRange = MakeImageBufferRange(unsharpenedImage);
+    const std::size_t numberOfPixels = unsharpenedImageBufferRange.size();
+
+    for (std::size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue)
+    {
+      if ((maskImageBufferRange.empty() || (useMaskLabel && maskImageBufferRange[indexValue] == maskLabel) ||
+           (!useMaskLabel && maskImageBufferRange[indexValue] != NumericTraits<MaskPixelType>::ZeroValue())) &&
+          (confidenceImageBufferRange.empty() || confidenceImageBufferRange[indexValue] > 0.0))
+      {
+        RealType pixel = unsharpenedImageBufferRange[indexValue];
+        if (pixel > binMaximum)
+        {
+          binMaximum = pixel;
+        }
+        else if (pixel < binMinimum)
+        {
+          binMinimum = pixel;
+        }
+      }
+    }
+    RealType histogramSlope = (binMaximum - binMinimum) / static_cast<RealType>(this->m_NumberOfHistogramBins - 1);
+
+    // Create the intensity profile (within the masked region, if applicable)
+    // using a triangular parzen windowing scheme.
+
+    vnl_vector<RealType> H(this->m_NumberOfHistogramBins, 0.0);
+
+    for (std::size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue)
+    {
+      if ((maskImageBufferRange.empty() || (useMaskLabel && maskImageBufferRange[indexValue] == maskLabel) ||
+           (!useMaskLabel && maskImageBufferRange[indexValue] != NumericTraits<MaskPixelType>::ZeroValue())) &&
+          (confidenceImageBufferRange.empty() || confidenceImageBufferRange[indexValue] > 0.0))
+      {
+        RealType pixel = unsharpenedImageBufferRange[indexValue];
+
+        RealType     cidx = (static_cast<RealType>(pixel) - binMinimum) / histogramSlope;
+        unsigned int idx = itk::Math::floor(cidx);
+        RealType     offset = cidx - static_cast<RealType>(idx);
+
+        if (offset == 0.0)
+        {
+          H[idx] += 1.0;
+        }
+        else if (idx < this->m_NumberOfHistogramBins - 1)
+        {
+          H[idx] += 1.0 - offset;
+          H[idx + 1] += offset;
+        }
+      }
+    }
+
+    // Determine information about the intensity histogram and zero-pad
+    // histogram to a power of 2.
+
+    RealType exponent = std::ceil(std::log(static_cast<RealType>(this->m_NumberOfHistogramBins)) / std::log(2.0)) + 1;
+    auto     paddedHistogramSize = static_cast<unsigned int>(std::pow(static_cast<RealType>(2.0), exponent) + 0.5);
+    auto     histogramOffset = static_cast<unsigned int>(0.5 * (paddedHistogramSize - this->m_NumberOfHistogramBins));
+
+    using FFTComputationType = double;
+    using FFTComplexType = std::complex<FFTComputationType>;
+
+    vnl_vector<FFTComplexType> V(paddedHistogramSize, FFTComplexType(0.0, 0.0));
+
+    for (unsigned int n = 0; n < this->m_NumberOfHistogramBins; n++)
+    {
+      V[n + histogramOffset] = H[n];
+    }
+
+    // Instantiate the 1-d vnl fft routine.
+
+    vnl_fft_1d<FFTComputationType> fft(paddedHistogramSize);
+
+    vnl_vector<FFTComplexType> Vf(V);
+
+    fft.fwd_transform(Vf);
+
+    // Create the Gaussian filter.
+
+    RealType scaledFWHM = this->m_BiasFieldFullWidthAtHalfMaximum / histogramSlope;
+    RealType expFactor = 4.0 * std::log(2.0) / itk::Math::sqr(scaledFWHM);
+    RealType scaleFactor = 2.0 * std::sqrt(std::log(2.0) / itk::Math::pi) / scaledFWHM;
+
+    vnl_vector<FFTComplexType> F(paddedHistogramSize, FFTComplexType(0.0, 0.0));
+
+    F[0] = FFTComplexType(scaleFactor, 0.0);
+    auto halfSize = static_cast<unsigned int>(0.5 * paddedHistogramSize);
+    for (unsigned int n = 1; n <= halfSize; n++)
+    {
+      F[n] = F[paddedHistogramSize - n] =
+        FFTComplexType(scaleFactor * std::exp(-itk::Math::sqr(static_cast<RealType>(n)) * expFactor), 0.0);
+    }
+    if (paddedHistogramSize % 2 == 0)
+    {
+      F[halfSize] = FFTComplexType(
+        scaleFactor * std::exp(0.25 * -itk::Math::sqr(static_cast<RealType>(paddedHistogramSize)) * expFactor), 0.0);
+    }
+
+    vnl_vector<FFTComplexType> Ff(F);
+
+    fft.fwd_transform(Ff);
+
+    // Create the Wiener deconvolution filter.
+
+    vnl_vector<FFTComplexType> Gf(paddedHistogramSize);
+
+    const auto wienerNoiseValue = static_cast<FFTComputationType>(this->m_WienerFilterNoise);
+    for (unsigned int n = 0; n < paddedHistogramSize; n++)
+    {
+      FFTComplexType c = vnl_complex_traits<FFTComplexType>::conjugate(Ff[n]);
+      Gf[n] = c / (c * Ff[n] + wienerNoiseValue);
+    }
+
+    vnl_vector<FFTComplexType> Uf(paddedHistogramSize);
+
+    for (unsigned int n = 0; n < paddedHistogramSize; n++)
+    {
+      Uf[n] = Vf[n] * Gf[n].real();
+    }
+
+    vnl_vector<FFTComplexType> U(Uf);
+
+    fft.bwd_transform(U);
+    for (unsigned int n = 0; n < paddedHistogramSize; n++)
+    {
+      U[n] = FFTComplexType(std::max(U[n].real(), static_cast<FFTComputationType>(0.0)), 0.0);
+    }
+
+    // Compute mapping E(u|v).
+
+    vnl_vector<FFTComplexType> numerator(paddedHistogramSize);
+
+    for (unsigned int n = 0; n < paddedHistogramSize; n++)
+    {
+      numerator[n] =
+        FFTComplexType((binMinimum + (static_cast<RealType>(n) - histogramOffset) * histogramSlope) * U[n].real(), 0.0);
+    }
+    fft.fwd_transform(numerator);
+    for (unsigned int n = 0; n < paddedHistogramSize; n++)
+    {
+      numerator[n] *= Ff[n];
+    }
+    fft.bwd_transform(numerator);
+
+    vnl_vector<FFTComplexType> denominator(U);
+
+    fft.fwd_transform(denominator);
+    for (unsigned int n = 0; n < paddedHistogramSize; n++)
+    {
+      denominator[n] *= Ff[n];
+    }
+    fft.bwd_transform(denominator);
+
+    vnl_vector<RealType> E(paddedHistogramSize);
+
+    for (unsigned int n = 0; n < paddedHistogramSize; n++)
+    {
+      if (denominator[n].real() != 0.0)
+      {
+        E[n] = numerator[n].real() / denominator[n].real();
+      }
+      else
+      {
+        E[n] = 0.0;
+      }
+    }
+
+    // Remove the zero-padding from the mapping.
+
+    E = E.extract(this->m_NumberOfHistogramBins, histogramOffset);
+
+    // Sharpen the image with the new mapping, E(u|v)
+    sharpenedImage->FillBuffer(0);
+
+    const ImageBufferRange<RealImageType> sharpenedImageBufferRange{ *sharpenedImage };
+
+    for (std::size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue)
+    {
+      if ((maskImageBufferRange.empty() || (useMaskLabel && maskImageBufferRange[indexValue] == maskLabel) ||
+           (!useMaskLabel && maskImageBufferRange[indexValue] != NumericTraits<MaskPixelType>::ZeroValue())) &&
+          (confidenceImageBufferRange.empty() || confidenceImageBufferRange[indexValue] > 0.0))
+      {
+        RealType     cidx = (unsharpenedImageBufferRange[indexValue] - binMinimum) / histogramSlope;
+        unsigned int idx = itk::Math::floor(cidx);
+
+        RealType correctedPixel = 0;
+        if (idx < E.size() - 1)
+        {
+          correctedPixel = E[idx] + (E[idx + 1] - E[idx]) * (cidx - static_cast<RealType>(idx));
+        }
+        else
+        {
+          correctedPixel = E[E.size() - 1];
+        }
+        sharpenedImageBufferRange[indexValue] = correctedPixel;
+      }
+    }
+  }
+
+  template <typename TInputImage, typename TMaskImage, typename TOutputImage>
+  typename N3BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::RealImagePointer
+  N3BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::UpdateBiasFieldEstimate(
+    RealImageType * fieldEstimate, const std::size_t numberOfIncludedPixels)
+  {
+    // Temporarily set the direction cosine to identity since the B-spline
+    // approximation algorithm works in parametric space and not physical
+    // space.
+    typename ScalarImageType::DirectionType identity;
+    identity.SetIdentity();
+
+    const typename ScalarImageType::RegionType & bufferedRegion = fieldEstimate->GetBufferedRegion();
+    const SizeValueType                          numberOfPixels = bufferedRegion.GetNumberOfPixels();
+    const bool                                   filterHandlesMemory = false;
+
+    using ImporterType = ImportImageFilter<RealType, ImageDimension>;
+    typename ImporterType::Pointer importer = ImporterType::New();
+    importer->SetImportPointer(fieldEstimate->GetBufferPointer(), numberOfPixels, filterHandlesMemory);
+    importer->SetRegion(fieldEstimate->GetBufferedRegion());
+    importer->SetOrigin(fieldEstimate->GetOrigin());
+    importer->SetSpacing(fieldEstimate->GetSpacing());
+    importer->SetDirection(identity);
+    importer->Update();
+
+    const typename ImporterType::OutputImageType * parametricFieldEstimate = importer->GetOutput();
+
+    PointSetPointer fieldPoints = PointSetType::New();
+    fieldPoints->Initialize();
+    auto & pointSTLContainer = fieldPoints->GetPoints()->CastToSTLContainer();
+    pointSTLContainer.reserve(numberOfIncludedPixels);
+    auto & pointDataSTLContainer = fieldPoints->GetPointData()->CastToSTLContainer();
+    pointDataSTLContainer.reserve(numberOfIncludedPixels);
+
+    typename BSplineFilterType::WeightsContainerType::Pointer weights = BSplineFilterType::WeightsContainerType::New();
+    weights->Initialize();
+    auto & weightSTLContainer = weights->CastToSTLContainer();
+    weightSTLContainer.reserve(numberOfIncludedPixels);
+
+    const auto          maskImageBufferRange = MakeImageBufferRange(this->GetMaskImage());
+    const auto          confidenceImageBufferRange = MakeImageBufferRange(this->GetConfidenceImage());
+    const MaskPixelType maskLabel = this->GetMaskLabel();
+    const bool          useMaskLabel = this->GetUseMaskLabel();
+
+    ImageRegionConstIteratorWithIndex<RealImageType> It(parametricFieldEstimate,
+                                                        parametricFieldEstimate->GetRequestedRegion());
+
+    for (std::size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue, ++It)
+    {
+      if ((maskImageBufferRange.empty() || (useMaskLabel && maskImageBufferRange[indexValue] == maskLabel) ||
+           (!useMaskLabel && maskImageBufferRange[indexValue] != NumericTraits<MaskPixelType>::ZeroValue())) &&
+          (confidenceImageBufferRange.empty() || confidenceImageBufferRange[indexValue] > 0.0))
+      {
+        PointType point;
+        parametricFieldEstimate->TransformIndexToPhysicalPoint(It.GetIndex(), point);
+
+        ScalarType scalar;
+        scalar[0] = It.Get();
+
+        pointDataSTLContainer.push_back(scalar);
+        pointSTLContainer.push_back(point);
+
+        RealType confidenceWeight = 1.0;
+        if (!confidenceImageBufferRange.empty())
+        {
+          confidenceWeight = confidenceImageBufferRange[indexValue];
+        }
+        weightSTLContainer.push_back(confidenceWeight);
+      }
+    }
+
+    typename BSplineFilterType::Pointer bspliner = BSplineFilterType::New();
+
+    typename ScalarImageType::PointType parametricOrigin = fieldEstimate->GetOrigin();
+    for (unsigned int d = 0; d < ImageDimension; d++)
+    {
+      parametricOrigin[d] += (fieldEstimate->GetSpacing()[d] * fieldEstimate->GetLargestPossibleRegion().GetIndex()[d]);
+    }
+    bspliner->SetOrigin(parametricOrigin);
+    bspliner->SetSpacing(fieldEstimate->GetSpacing());
+    bspliner->SetSize(fieldEstimate->GetLargestPossibleRegion().GetSize());
+    bspliner->SetDirection(fieldEstimate->GetDirection());
+    bspliner->SetGenerateOutputImage(false);
+    bspliner->SetNumberOfLevels(this->m_NumberOfFittingLevels);
+    bspliner->SetSplineOrder(this->m_SplineOrder);
+    bspliner->SetNumberOfControlPoints(this->m_NumberOfControlPoints);
+    bspliner->SetInput(fieldPoints);
+    bspliner->SetPointWeights(weights);
+    bspliner->Update();
+
+    this->m_LogBiasFieldControlPointLattice = bspliner->GetPhiLattice();
+
+    RealImagePointer smoothField = this->ReconstructBiasField(this->m_LogBiasFieldControlPointLattice);
+
+    return smoothField;
+  }
+
+  template <typename TInputImage, typename TMaskImage, typename TOutputImage>
+  typename N3BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::RealImagePointer
+  N3BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::ReconstructBiasField(
+    const BiasFieldControlPointLatticeType * controlPointLattice)
+  {
+    const InputImageType * inputImage = this->GetInput();
+
+    using BSplineReconstructerType = BSplineControlPointImageFilter<BiasFieldControlPointLatticeType, ScalarImageType>;
+    typename BSplineReconstructerType::Pointer reconstructer = BSplineReconstructerType::New();
+    reconstructer->SetInput(controlPointLattice);
+    reconstructer->SetOrigin(inputImage->GetOrigin());
+    reconstructer->SetSpacing(inputImage->GetSpacing());
+    reconstructer->SetDirection(inputImage->GetDirection());
+    reconstructer->SetSplineOrder(this->m_SplineOrder);
+    reconstructer->SetSize(inputImage->GetLargestPossibleRegion().GetSize());
+
+    typename ScalarImageType::Pointer biasFieldBsplineImage = reconstructer->GetOutput();
+    biasFieldBsplineImage->Update();
+
+    using SelectorType = VectorIndexSelectionCastImageFilter<ScalarImageType, RealImageType>;
+    typename SelectorType::Pointer selector = SelectorType::New();
+    selector->SetInput(biasFieldBsplineImage);
+    selector->SetIndex(0);
+
+    RealImagePointer biasField = selector->GetOutput();
+    biasField->Update();
+
+    biasField->DisconnectPipeline();
+    biasField->SetRegions(inputImage->GetRequestedRegion());
+
+    return biasField;
+  }
+
+  template <typename TInputImage, typename TMaskImage, typename TOutputImage>
+  typename N3BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::RealType
+  N3BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::CalculateConvergenceMeasurement(
+    const RealImageType * fieldEstimate1, const RealImageType * fieldEstimate2) const
+  {
+    using SubtracterType = SubtractImageFilter<RealImageType, RealImageType, RealImageType>;
+    typename SubtracterType::Pointer subtracter = SubtracterType::New();
+    subtracter->SetInput1(fieldEstimate1);
+    subtracter->SetInput2(fieldEstimate2);
+    subtracter->Update();
+
+    // Calculate statistics over the mask region
+
+    RealType mu = 0.0;
+    RealType sigma = 0.0;
+    RealType N = 0.0;
+
+    const auto          maskImageBufferRange = MakeImageBufferRange(this->GetMaskImage());
+    const auto          confidenceImageBufferRange = MakeImageBufferRange(this->GetConfidenceImage());
+    const MaskPixelType maskLabel = this->GetMaskLabel();
+    const bool          useMaskLabel = this->GetUseMaskLabel();
+
+    const auto        subtracterImageBufferRange = MakeImageBufferRange(subtracter->GetOutput());
+    const std::size_t numberOfPixels = subtracterImageBufferRange.size();
+
+    for (std::size_t indexValue = 0; indexValue < numberOfPixels; ++indexValue)
+    {
+      if ((maskImageBufferRange.empty() || (useMaskLabel && maskImageBufferRange[indexValue] == maskLabel) ||
+           (!useMaskLabel && maskImageBufferRange[indexValue] != NumericTraits<MaskPixelType>::ZeroValue())) &&
+          (confidenceImageBufferRange.empty() || confidenceImageBufferRange[indexValue] > 0.0))
+      {
+        RealType pixel = std::exp(subtracterImageBufferRange[indexValue]);
+        N += 1.0;
+
+        if (N > 1.0)
+        {
+          sigma = sigma + itk::Math::sqr(pixel - mu) * (N - 1.0) / N;
+        }
+        mu = mu * (1.0 - 1.0 / N) + pixel / N;
+      }
+    }
+    sigma = std::sqrt(sigma / (N - 1.0));
+
+  /**
+   * Although Sled's paper proposes convergence determination via
+   * the coefficient of variation, the actual mnc implementation
+   * utilizes the standard deviation as the convergence measurement.
+   */
+  return sigma;
+  }
+
+  template <typename TInputImage, typename TMaskImage, typename TOutputImage>
+  void N3BiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>::PrintSelf(std::ostream & os,
+                                                                                          Indent indent) const
+  {
+    Superclass::PrintSelf(os, indent);
+
+    os << indent << "Use Mask Label: " << m_UseMaskLabel << std::endl;
+    os << indent << "Mask label: " << static_cast<typename NumericTraits<MaskPixelType>::PrintType>(this->m_MaskLabel)
+       << std::endl;
+    os << indent << "Number of histogram bins: " << this->m_NumberOfHistogramBins << std::endl;
+    os << indent << "Wiener filter noise: " << this->m_WienerFilterNoise << std::endl;
+    os << indent << "Bias field FWHM: " << this->m_BiasFieldFullWidthAtHalfMaximum << std::endl;
+    os << indent << "Maximum number of iterations: " << this->m_MaximumNumberOfIterations << std::endl;
+    os << indent << "Convergence threshold: " << this->m_ConvergenceThreshold << std::endl;
+    os << indent << "Spline order: " << this->m_SplineOrder << std::endl;
+    os << indent << "Number of fitting levels: " << this->m_NumberOfFittingLevels << std::endl;
+    os << indent << "Number of control points: " << this->m_NumberOfControlPoints << std::endl;
+    os << indent << "CurrentConvergenceMeasurement: " << this->m_CurrentConvergenceMeasurement << std::endl;
+    os << indent << "CurrentLevel: " << this->m_CurrentLevel << std::endl;
+    os << indent << "ElapsedIterations: " << this->m_ElapsedIterations << std::endl;
+    itkPrintSelfObjectMacro(LogBiasFieldControlPointLattice);
+
+  }
+
+} // end namespace itk
+
+#endif


### PR DESCRIPTION
Since N3 gets used quite a bit, I've always wanted to refactor it so that it has some of the add-ons that we've provided for N4.  I think N3 should use the ANTs command line interface.  So I have to do more testing but I think this works.  In order to access the refactored N3, one needs to simply add an 'x' after N3BiasField correction, i.e.,

```
N3BiasFieldCorrection x -h 1

COMMAND: 
     N3BiasFieldCorrection

OPTIONS: 
     -d, --image-dimensionality 2/3/4
     -i, --input-image inputImageFilename
     -x, --mask-image maskImageFilename
     -r, --rescale-intensities 0/(1)
     -w, --weight-image weightImageFilename
     -s, --shrink-factor 1/2/3/(4)/...
     -c, --convergence [<numberOfIterations=50>,<convergenceThreshold=0.0>]
     -b, --bspline-fitting [splineDistance,<numberOfFittingLevels=4>,<splineOrder=3>]
                           [meshResolution,<numberOfFittingLevels=4>,<splineOrder=3>]
     -t, --histogram-sharpening [<FWHM=0.15>,<wienerNoise=0.01>,<numberOfHistogramBins=200>]
     -o, --output correctedImage
                  [correctedImage,<biasField>]
     --version 
     -v, --verbose (0)/1
     -h 
     --help 
```

