### PR TITLE
COMP: CMake 3.19 has problems with ITK, set version to 3.18 in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/nul
     | apt-key add - \
   && apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ bionic main' \
   && apt-get update \
-  && apt-get -y install cmake
+  && apt-get -y install cmake=3.18.3-0kitware1 cmake-data=3.18.3-0kitware1 
 
 ADD . /tmp/ants/source
 RUN mkdir -p /tmp/ants/build \


### PR DESCRIPTION
There's an issues with CMake 3.19 that breaks compilation of ITK. ITK has downgraded to 3.18.3 until it's fixed. See

https://gitlab.kitware.com/cmake/cmake/-/issues/21529

