### PR TITLE
DOC: Include version information and citation in docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
             e=1 && for i in {1..5}; do
               docker build \
                 --rm=false \
+                --label version="CircleCI automated build commit ${CIRCLE_SHA1}" \
                 -t antsx/ants:latest . \
               && e=0 && break || sleep 15
             done && [ "$e" -eq "0" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,10 @@ RUN mkdir -p /tmp/ants/build \
 FROM ubuntu:bionic-20200112
 COPY --from=builder /opt/ants /opt/ants
 
+LABEL maintainer="ANTsX team" \
+      description="ANTs is part of the ANTsX ecosystem (https://github.com/ANTsX). \
+ANTs Citation: https://pubmed.ncbi.nlm.nih.gov/24879923"
+
 ENV ANTSPATH="/opt/ants/bin" \
     PATH="/opt/ants/bin:$PATH" \
     LD_LIBRARY_PATH="/opt/ants/lib:$LD_LIBRARY_PATH"


### PR DESCRIPTION
Adding a label at build time to identify the source code version from an automated build using docker inspect.