### PR TITLE
COMP: Use modern ITK paradigms

### DIFF
--- a/Examples/ANTS.cxx
+++ b/Examples/ANTS.cxx
@@ -190,14 +190,14 @@ private:
   if( argc == 3 && ( std::stoi( argv[1] ) != '-' || std::stoi( argv[1] ) != 2 || std::stoi( argv[1] ) != 3 ) )
     {
     itk::ImageIOBase::Pointer fixedImageIO
-      = itk::ImageIOFactory::CreateImageIO( argv[1], itk::ImageIOFactory::FileModeEnum::ReadMode );
+      = itk::ImageIOFactory::CreateImageIO( argv[1], itk::IOFileModeEnum::ReadMode );
     if( fixedImageIO.IsNull() )
       {
       std::cerr << "Invalid fixed image: " << argv[1] << std::endl;
       return EXIT_FAILURE;
       }
     itk::ImageIOBase::Pointer movingImageIO
-      = itk::ImageIOFactory::CreateImageIO( argv[2], itk::ImageIOFactory::FileModeEnum::ReadMode );
+      = itk::ImageIOFactory::CreateImageIO( argv[2], itk::IOFileModeEnum::ReadMode );
     if( movingImageIO.IsNull() )
       {
       std::cerr << "Invalid moving image: " << argv[2] << std::endl;

--- a/Examples/ANTSIntegrateVectorField.cxx
+++ b/Examples/ANTSIntegrateVectorField.cxx
@@ -61,7 +61,7 @@ SmoothImage(typename TImage::Pointer image, float sig)
   using dgf = itk::DiscreteGaussianImageFilter<TImage, TImage>;
   typename dgf::Pointer filter = dgf::New();
   filter->SetVariance(sig);
-  filter->SetUseImageSpacingOn();
+  filter->SetUseImageSpacing(true);
   filter->SetMaximumError(.01f);
   filter->SetInput(image);
   filter->Update();
@@ -463,7 +463,7 @@ private:
 
   std::string               ifn = std::string(argv[1]);
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(ifn.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(ifn.c_str(), itk::IOFileModeEnum::ReadMode);
   imageIO->SetFileName(ifn.c_str() );
   imageIO->ReadImageInformation();
   unsigned int dim =  imageIO->GetNumberOfDimensions();

--- a/Examples/ANTSIntegrateVelocityField.cxx
+++ b/Examples/ANTSIntegrateVelocityField.cxx
@@ -168,7 +168,7 @@ private:
   std::cout << " start " << std::endl;
   std::string               ifn = std::string(argv[1]);
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(ifn.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(ifn.c_str(), itk::IOFileModeEnum::ReadMode);
   imageIO->SetFileName(ifn.c_str() );
   imageIO->ReadImageInformation();
   unsigned int dim =  imageIO->GetNumberOfDimensions();

--- a/Examples/ANTSJacobian.cxx
+++ b/Examples/ANTSJacobian.cxx
@@ -392,7 +392,7 @@ ComputeJacobian(TDisplacementField* field, char* fnm, char* maskfn, bool uselog 
     {
     typename dgf::Pointer filter = dgf::New();
     filter->SetVariance(sig);
-    filter->SetUseImageSpacingOff();
+    filter->SetUseImageSpacing(false);
     filter->SetMaximumError(.01f);
     filter->SetInput(m_FloatImage);
     filter->Update();
@@ -402,7 +402,7 @@ ComputeJacobian(TDisplacementField* field, char* fnm, char* maskfn, bool uselog 
     {
     typename dgf::Pointer filter = dgf::New();
     filter->SetVariance(sig);
-    filter->SetUseImageSpacingOff();
+    filter->SetUseImageSpacing(false);
     filter->SetMaximumError(.01f);
     filter->SetInput(temp);
     filter->Update();

--- a/Examples/ANTSUseLandmarkImagesToGetAffineTransform.cxx
+++ b/Examples/ANTSUseLandmarkImagesToGetAffineTransform.cxx
@@ -432,7 +432,7 @@ private:
   // Get the image dimension
   std::string               fn = std::string(argv[1]);
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::IOFileModeEnum::ReadMode);
   imageIO->SetFileName(fn.c_str() );
   imageIO->ReadImageInformation();
 

--- a/Examples/ANTSUseLandmarkImagesToGetBSplineDisplacementField.cxx
+++ b/Examples/ANTSUseLandmarkImagesToGetBSplineDisplacementField.cxx
@@ -540,7 +540,7 @@ private:
   // Get the image dimension
   std::string               fn = std::string(argv[1]);
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::IOFileModeEnum::ReadMode);
   imageIO->SetFileName(fn.c_str() );
   imageIO->ReadImageInformation();
 

--- a/Examples/AddNoiseToImage.cxx
+++ b/Examples/AddNoiseToImage.cxx
@@ -507,7 +507,7 @@ private:
       return EXIT_FAILURE;
       }
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        filename.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode );
+        filename.c_str(), itk::IOFileModeEnum::ReadMode );
     dimension = imageIO->GetNumberOfDimensions();
     }
 

--- a/Examples/Atropos.cxx
+++ b/Examples/Atropos.cxx
@@ -1766,7 +1766,7 @@ private:
       return EXIT_FAILURE;
       }
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        filename.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode );
+        filename.c_str(), itk::IOFileModeEnum::ReadMode );
     dimension = imageIO->GetNumberOfDimensions();
     }
 

--- a/Examples/AverageImages.cxx
+++ b/Examples/AverageImages.cxx
@@ -63,7 +63,7 @@ int AverageImages1(unsigned int argc, char *argv[])
     // Get the image dimension
     const std::string fn = std::string(argv[j]);
     typename itk::ImageIOBase::Pointer imageIO =
-      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::IOFileModeEnum::ReadMode);
     imageIO->SetFileName(fn.c_str() );
     imageIO->ReadImageInformation();
 
@@ -186,7 +186,7 @@ int AverageImages(unsigned int argc, char *argv[])
     std::string fn = std::string(argv[j]);
     std::cout << " fn " << fn << " " << ImageDimension << " " << NVectorComponents << std::endl;
     typename itk::ImageIOBase::Pointer imageIO =
-      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::IOFileModeEnum::ReadMode);
     imageIO->SetFileName( fn.c_str() );
     imageIO->ReadImageInformation();
 
@@ -319,7 +319,7 @@ private:
 
   const int                 dim = std::stoi( argv[1] );
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(argv[4], itk::ImageIOFactory::FileModeEnum::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(argv[4], itk::IOFileModeEnum::ReadMode);
   imageIO->SetFileName(argv[4]);
   imageIO->ReadImageInformation();
   unsigned int ncomponents = imageIO->GetNumberOfComponents();

--- a/Examples/AverageTensorImages.cxx
+++ b/Examples/AverageTensorImages.cxx
@@ -37,7 +37,7 @@ int AverageTensorImages(unsigned int argc, char *argv[])
     std::string fn = std::string(argv[j]);
     std::cout << " fn " << fn << std::endl;
     typename itk::ImageIOBase::Pointer imageIO =
-      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::IOFileModeEnum::ReadMode);
     imageIO->SetFileName(fn.c_str() );
     imageIO->ReadImageInformation();
     for( unsigned int i = 0; i < imageIO->GetNumberOfDimensions(); i++ )

--- a/Examples/CheckTopology.cxx
+++ b/Examples/CheckTopology.cxx
@@ -131,7 +131,7 @@ typename TImage::Pointer SmoothImage( typename TImage::Pointer image, float sig 
   using dgf = itk::DiscreteGaussianImageFilter<ImageType, ImageType>;
   typename dgf::Pointer filter = dgf::New();
   filter->SetVariance(sig);
-  filter->SetUseImageSpacingOff();
+  filter->SetUseImageSpacing(false);
   filter->SetMaximumError(.01f);
   filter->SetInput(image);
   filter->Update();

--- a/Examples/ConformalMapping.cxx
+++ b/Examples/ConformalMapping.cxx
@@ -246,7 +246,7 @@ SmoothImage( typename TImage::Pointer input, double var)
   typename dgf::Pointer filter = dgf::New();
   filter->SetVariance(var);
   filter->SetMaximumError(.01f);
-  filter->SetUseImageSpacingOn();
+  filter->SetUseImageSpacing(true);
   filter->SetInput(input);
   filter->Update();
 

--- a/Examples/ConvertImagePixelType.cxx
+++ b/Examples/ConvertImagePixelType.cxx
@@ -170,7 +170,7 @@ private:
   std::string               fn = std::string(argv[1]);
   itk::ImageIOBase::Pointer imageIO =
     itk::ImageIOFactory::CreateImageIO(
-      fn.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+      fn.c_str(), itk::IOFileModeEnum::ReadMode);
   imageIO->SetFileName(fn.c_str() );
   imageIO->ReadImageInformation();
 

--- a/Examples/ConvertInputImagePixelTypeToFloat.cxx
+++ b/Examples/ConvertInputImagePixelTypeToFloat.cxx
@@ -150,7 +150,7 @@ private:
   std::string               fn = std::string(argv[1]);
   itk::ImageIOBase::Pointer imageIO =
     itk::ImageIOFactory::CreateImageIO(
-      fn.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+      fn.c_str(), itk::IOFileModeEnum::ReadMode);
   imageIO->SetFileName(fn.c_str() );
   imageIO->ReadImageInformation();
 

--- a/Examples/ConvertScalarImageToRGB.cxx
+++ b/Examples/ConvertScalarImageToRGB.cxx
@@ -72,51 +72,51 @@ int ConvertScalarImageToRGB( int argc, char *argv[] )
 
   if( colormapString == "red" )
     {
-    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Red );
+      rgbfilter->SetColormap( RGBFilterType::RGBColormapFilterEnum::Red );
     }
   else if( colormapString == "green"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Green );
+      rgbfilter->SetColormap( RGBFilterType::RGBColormapFilterEnum::Green );
     }
   else if( colormapString == "blue"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Blue );
+      rgbfilter->SetColormap( RGBFilterType::RGBColormapFilterEnum::Blue );
     }
   else if( colormapString == "grey"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Grey );
+      rgbfilter->SetColormap( RGBFilterType::RGBColormapFilterEnum::Grey );
     }
   else if( colormapString == "cool"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Cool );
+      rgbfilter->SetColormap( RGBFilterType::RGBColormapFilterEnum::Cool );
     }
   else if( colormapString == "hot"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Hot );
+      rgbfilter->SetColormap( RGBFilterType::RGBColormapFilterEnum::Hot );
     }
   else if( colormapString == "spring"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Spring );
+      rgbfilter->SetColormap( RGBFilterType::RGBColormapFilterEnum::Spring );
     }
   else if( colormapString == "autumn"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Autumn );
+      rgbfilter->SetColormap( RGBFilterType::RGBColormapFilterEnum::Autumn );
     }
   else if( colormapString == "winter"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Winter );
+      rgbfilter->SetColormap( RGBFilterType::RGBColormapFilterEnum::Winter );
     }
   else if( colormapString == "copper"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Copper );
+    rgbfilter->SetColormap( RGBFilterType::RGBColormapFilterEnum::Copper );
     }
   else if( colormapString == "summer"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Summer );
+    rgbfilter->SetColormap( RGBFilterType::RGBColormapFilterEnum::Summer );
     }
   else if( colormapString == "jet"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::Jet );
+    rgbfilter->SetColormap( RGBFilterType::RGBColormapFilterEnum::Jet );
 //    typedef itk::Function::JetColormapFunction<typename RealImageType::PixelType,
 //      typename RGBImageType::PixelType> ColormapType;
 //    typename ColormapType::Pointer colormap = ColormapType::New();
@@ -124,7 +124,7 @@ int ConvertScalarImageToRGB( int argc, char *argv[] )
     }
   else if( colormapString == "hsv"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::HSV );
+    rgbfilter->SetColormap( RGBFilterType::RGBColormapFilterEnum::HSV );
 //    typedef itk::Function::HSVColormapFunction<typename RealImageType::PixelType,
 //      typename RGBImageType::PixelType> ColormapType;
 //    typename ColormapType::Pointer colormap = ColormapType::New();
@@ -132,7 +132,7 @@ int ConvertScalarImageToRGB( int argc, char *argv[] )
     }
   else if( colormapString == "overunder"  )
     {
-    rgbfilter->SetColormap( RGBFilterType::ColormapEnumType::OverUnder );
+    rgbfilter->SetColormap( RGBFilterType::RGBColormapFilterEnum::OverUnder );
     }
   else if( colormapString == "custom"  )
     {

--- a/Examples/ConvertToJpg.cxx
+++ b/Examples/ConvertToJpg.cxx
@@ -148,7 +148,7 @@ private:
     std::string               fn = std::string(argv[1]);
     itk::ImageIOBase::Pointer imageIO =
       itk::ImageIOFactory::CreateImageIO(
-        fn.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+        fn.c_str(), itk::IOFileModeEnum::ReadMode);
     imageIO->SetFileName(fn.c_str() );
     imageIO->ReadImageInformation();
 

--- a/Examples/CopyImageHeaderInformation.cxx
+++ b/Examples/CopyImageHeaderInformation.cxx
@@ -184,7 +184,7 @@ private:
   std::string               fn = std::string(argv[1]);
   itk::ImageIOBase::Pointer imageIO =
     itk::ImageIOFactory::CreateImageIO(
-      fn.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+      fn.c_str(), itk::IOFileModeEnum::ReadMode);
   imageIO->SetFileName(fn.c_str() );
   imageIO->ReadImageInformation();
   unsigned int dim = imageIO->GetNumberOfDimensions();

--- a/Examples/CreateDTICohort.cxx
+++ b/Examples/CreateDTICohort.cxx
@@ -1177,7 +1177,7 @@ private:
       return EXIT_FAILURE;
       }
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        filename.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode );
+        filename.c_str(), itk::IOFileModeEnum::ReadMode );
     dimension = imageIO->GetNumberOfDimensions();
     }
 

--- a/Examples/CreateTiledMosaic.cxx
+++ b/Examples/CreateTiledMosaic.cxx
@@ -1286,7 +1286,7 @@ private:
     filename = imageOption->GetFunction( 0 )->GetName();
 
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        filename.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode );
+        filename.c_str(), itk::IOFileModeEnum::ReadMode );
     unsigned int dimension = imageIO->GetNumberOfDimensions();
 
     if( dimension == 3 )

--- a/Examples/DenoiseImage.cxx
+++ b/Examples/DenoiseImage.cxx
@@ -649,7 +649,7 @@ private:
       return EXIT_FAILURE;
       }
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        filename.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode );
+        filename.c_str(), itk::IOFileModeEnum::ReadMode );
     dimension = imageIO->GetNumberOfDimensions();
     }
 

--- a/Examples/ImageMath_Templates.hxx
+++ b/Examples/ImageMath_Templates.hxx
@@ -49,6 +49,7 @@
 #include "itkExtractImageFilter.h"
 #include "itkFastMarchingExtensionImageFilterBase.h"
 #include "itkFastMarchingExtensionImageFilter.h"
+#include "itkFastMarchingBase.h"
 #include "itkGaussianImageSource.h"
 #include "itkGradientAnisotropicDiffusionImageFilter.h"
 #include "itkGradientMagnitudeRecursiveGaussianImageFilter.h"
@@ -1109,7 +1110,7 @@ int TileImages(unsigned int argc, char *argv[])
     // Get the image dimension
     std::string fn = std::string(argv[j]);
     typename itk::ImageIOBase::Pointer imageIO =
-      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::IOFileModeEnum::ReadMode);
     imageIO->SetFileName(fn.c_str() );
     imageIO->ReadImageInformation();
 
@@ -1516,7 +1517,7 @@ int CorruptImage(int argc, char *argv[])
       typedef itk::DiscreteGaussianImageFilter<ImageType, ImageType> dgf;
       typename dgf::Pointer filter = dgf::New();
       filter->SetVariance(smoothlevel);
-      filter->SetUseImageSpacingOff();
+      filter->SetUseImageSpacing(false);
       filter->SetMaximumError(.01f);
       filter->SetInput(image1);
       filter->Update();
@@ -5896,7 +5897,7 @@ int TensorFunctions(int argc, char *argv[])
       " Convert a 4D tensor to a 3D tensor --- if there are 7 components to the tensor, we throw away the first component b/c its probably b0 "
       << std::endl;
     itk::ImageIOBase::Pointer imageIO =
-      itk::ImageIOFactory::CreateImageIO(fn1.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+      itk::ImageIOFactory::CreateImageIO(fn1.c_str(), itk::IOFileModeEnum::ReadMode);
     imageIO->SetFileName(fn1.c_str() );
     imageIO->ReadImageInformation();
     unsigned int dim = imageIO->GetNumberOfDimensions();
@@ -7082,7 +7083,7 @@ int CompareHeadersAndImages(int argc, char *argv[])
 //       ExtractedComponentImageType, ExtractedComponentImageType >  SmoothingFilterType2;
 //     typename SmoothingFilterType::Pointer smoother = SmoothingFilterType::New();
 //     smoother->SetVariance(1.0);
-//     smoother->SetUseImageSpacingOff();
+//     smoother->SetUseImageSpacing(false);
 //     //smoother->SetDomainSigma(1);
 //     //smoother->SetRangeSigma(1);
 //     filter->SetSmoothingFilter( smoother );
@@ -7812,11 +7813,11 @@ int SmoothImage(int argc, char *argv[])
   bool usespacing = true;
   if( !usespacing )
     {
-    filter->SetUseImageSpacingOff();
+    filter->SetUseImageSpacing(false);
     }
   else
     {
-    filter->SetUseImageSpacingOn();
+    filter->SetUseImageSpacing(true);
     }
   filter->SetMaximumError(.01f);
   filter->SetInput(image1);
@@ -8020,16 +8021,16 @@ int PropagateLabelsThroughMask(int argc, char *argv[])
 
     fastMarching = FastMarchingFilterType::New();
     fastMarching->SetInput( speedimage );
-    fastMarching->SetTopologyCheck( FastMarchingFilterType::None );
+    fastMarching->SetTopologyCheck( FastMarchingFilterType::TopologyCheckType::Nothing );
     if( topocheck == 1 )  // Strict
       {
       // std::cout << " strict " << std::endl;
-      fastMarching->SetTopologyCheck( FastMarchingFilterType::Strict );
+      fastMarching->SetTopologyCheck( itk::FastMarchingTraitsEnums::TopologyCheck::Strict );
       }
     if( topocheck == 2 )  // No handles
       {
       // std::cout << " no handles " << std::endl;
-      fastMarching->SetTopologyCheck( FastMarchingFilterType::NoHandles );
+      fastMarching->SetTopologyCheck( itk::FastMarchingTraitsEnums::TopologyCheck::NoHandles );
       }
     typedef typename FastMarchingFilterType::NodeContainer NodeContainer;
     typedef typename FastMarchingFilterType::NodeType      NodeType;
@@ -8314,12 +8315,12 @@ int itkPropagateLabelsThroughMask(int argc, char *argv[])
     if( topocheck == 1 )  // Strict
       {
       // std::cout << " strict " << std::endl;
-      fastMarching->SetTopologyCheck( FastMarchingFilterType::Strict );
+      fastMarching->SetTopologyCheck( itk::FastMarchingTraitsEnums::TopologyCheck::Strict );
       }
     if( topocheck == 2 )  // No handles
       {
       // std::cout << " no handles " << std::endl;
-      fastMarching->SetTopologyCheck( FastMarchingFilterType::NoHandles );
+      fastMarching->SetTopologyCheck( itk::FastMarchingTraitsEnums::TopologyCheck::NoHandles );
       }
     typedef typename FastMarchingFilterType::NodePairContainerType NodeContainer;
     typedef typename FastMarchingFilterType::NodePairType      NodePairType;
@@ -11133,7 +11134,7 @@ int ConvertImageSetToMatrix(unsigned int argc, char *argv[])
     // Get the image dimension
     std::string fn = std::string(argv[j]);
     typename itk::ImageIOBase::Pointer imageIO =
-      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::IOFileModeEnum::ReadMode);
     imageIO->SetFileName(fn.c_str() );
     imageIO->ReadImageInformation();
     for( unsigned int i = 0; i < imageIO->GetNumberOfDimensions(); i++ )
@@ -11430,7 +11431,7 @@ int ConvertImageSetToEigenvectors(unsigned int argc, char *argv[])
     // Get the image dimension
     std::string fn = std::string(argv[j]);
     typename itk::ImageIOBase::Pointer imageIO =
-      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+      itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::IOFileModeEnum::ReadMode);
     imageIO->SetFileName(fn.c_str() );
     imageIO->ReadImageInformation();
     for( unsigned int i = 0; i < imageIO->GetNumberOfDimensions(); i++ )

--- a/Examples/ImageSetStatistics.cxx
+++ b/Examples/ImageSetStatistics.cxx
@@ -124,7 +124,7 @@ SmoothImage(typename TImage::Pointer image, float sig)
   using dgf = itk::DiscreteGaussianImageFilter<TImage, TImage>;
   typename dgf::Pointer filter = dgf::New();
   filter->SetVariance(sig);
-  filter->SetUseImageSpacingOn();
+  filter->SetUseImageSpacing(true);
   filter->SetMaximumError(.01f);
   filter->SetInput(image);
   filter->Update();

--- a/Examples/KellyKapowski.cxx
+++ b/Examples/KellyKapowski.cxx
@@ -172,7 +172,7 @@ int DiReCT( itk::ants::CommandLineParser *parser )
     using SmootherType = itk::DiscreteGaussianImageFilter<LabelImageType, ImageType>;
     typename SmootherType::Pointer smoother = SmootherType::New();
     smoother->SetVariance( 1.0 );
-    smoother->SetUseImageSpacingOn();
+    smoother->SetUseImageSpacing(true);
     smoother->SetMaximumError( 0.01 );
     smoother->SetInput( thresholder->GetOutput() );
     smoother->Update();
@@ -209,7 +209,7 @@ int DiReCT( itk::ants::CommandLineParser *parser )
     using SmootherType = itk::DiscreteGaussianImageFilter<ImageType, ImageType>;
     typename SmootherType::Pointer smoother = SmootherType::New();
     smoother->SetVariance( 1.0 );
-    smoother->SetUseImageSpacingOn();
+    smoother->SetUseImageSpacing(true);
     smoother->SetMaximumError( 0.01 );
     smoother->SetInput( thresholder->GetOutput() );
     smoother->Update();
@@ -833,7 +833,7 @@ private:
       return EXIT_FAILURE;
       }
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        filename.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode );
+        filename.c_str(), itk::IOFileModeEnum::ReadMode );
     dimension = imageIO->GetNumberOfDimensions();
     }
 

--- a/Examples/KellySlater.cxx
+++ b/Examples/KellySlater.cxx
@@ -97,7 +97,7 @@ SmoothImage(typename TImage::Pointer image, double sig)
   using dgf = itk::DiscreteGaussianImageFilter<TImage, TImage>;
   typename dgf::Pointer filter = dgf::New();
   filter->SetVariance(sig);
-  filter->SetUseImageSpacingOn();
+  filter->SetUseImageSpacing(true);
   filter->SetMaximumError(.01f);
   filter->SetInput(image);
   filter->Update();

--- a/Examples/LaplacianThickness.cxx
+++ b/Examples/LaplacianThickness.cxx
@@ -59,7 +59,7 @@ SmoothImage(typename TImage::Pointer image, float sig)
   using dgf = itk::DiscreteGaussianImageFilter<TImage, TImage>;
   typename dgf::Pointer filter = dgf::New();
   filter->SetVariance(sig);
-  filter->SetUseImageSpacingOn();
+  filter->SetUseImageSpacing(true);
   filter->SetMaximumError(.01f);
   filter->SetInput(image);
   filter->Update();
@@ -997,7 +997,7 @@ private:
   //  std::cout << " image " << ifn << std::endl;
   // Get the image dimension
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(ifn.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(ifn.c_str(), itk::IOFileModeEnum::ReadMode);
   imageIO->SetFileName(ifn.c_str() );
   imageIO->ReadImageInformation();
   unsigned int dim =  imageIO->GetNumberOfDimensions();

--- a/Examples/MeasureMinMaxMean.cxx
+++ b/Examples/MeasureMinMaxMean.cxx
@@ -187,7 +187,7 @@ private:
     }
   int                       dim = std::stoi( argv[1] );
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(argv[2], itk::ImageIOFactory::FileModeEnum::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(argv[2], itk::IOFileModeEnum::ReadMode);
   imageIO->SetFileName(argv[2]);
   imageIO->ReadImageInformation();
   unsigned int ncomponents = imageIO->GetNumberOfComponents();

--- a/Examples/MultiplyImages.cxx
+++ b/Examples/MultiplyImages.cxx
@@ -185,7 +185,7 @@ private:
 
   int                       dim = std::stoi( argv[1] );
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(argv[2], itk::ImageIOFactory::FileModeEnum::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(argv[2], itk::IOFileModeEnum::ReadMode);
   imageIO->SetFileName(argv[2]);
   imageIO->ReadImageInformation();
   unsigned int ncomponents = imageIO->GetNumberOfComponents();

--- a/Examples/N3BiasFieldCorrection.cxx
+++ b/Examples/N3BiasFieldCorrection.cxx
@@ -1083,7 +1083,7 @@ int N3BiasFieldCorrection( std::vector<std::string> args, std::ostream* /*out_st
         return EXIT_FAILURE;
         }
       itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-          filename.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode );
+          filename.c_str(), itk::IOFileModeEnum::ReadMode );
       dimension = imageIO->GetNumberOfDimensions();
       }
 

--- a/Examples/N4BiasFieldCorrection.cxx
+++ b/Examples/N4BiasFieldCorrection.cxx
@@ -951,7 +951,7 @@ private:
       return EXIT_FAILURE;
       }
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        filename.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode );
+        filename.c_str(), itk::IOFileModeEnum::ReadMode );
     dimension = imageIO->GetNumberOfDimensions();
     }
 

--- a/Examples/NonLocalSuperResolution.cxx
+++ b/Examples/NonLocalSuperResolution.cxx
@@ -717,7 +717,7 @@ private:
       return EXIT_FAILURE;
       }
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        filename.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode );
+        filename.c_str(), itk::IOFileModeEnum::ReadMode );
     dimension = imageIO->GetNumberOfDimensions();
     }
 

--- a/Examples/PrintHeader.cxx
+++ b/Examples/PrintHeader.cxx
@@ -456,7 +456,7 @@ private:
     }
   itk::ImageIOBase::Pointer imageIO =
     itk::ImageIOFactory::CreateImageIO(
-      fn.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+      fn.c_str(), itk::IOFileModeEnum::ReadMode);
   imageIO->SetFileName(fn.c_str() );
   try
     {

--- a/Examples/ResetDirection.cxx
+++ b/Examples/ResetDirection.cxx
@@ -136,7 +136,7 @@ private:
   std::string               fn = std::string(argv[1]);
   itk::ImageIOBase::Pointer imageIO =
     itk::ImageIOFactory::CreateImageIO(
-      fn.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+      fn.c_str(), itk::IOFileModeEnum::ReadMode);
   imageIO->SetFileName(fn.c_str() );
   imageIO->ReadImageInformation();
 

--- a/Examples/SetDirectionByMatrix.cxx
+++ b/Examples/SetDirectionByMatrix.cxx
@@ -155,7 +155,7 @@ private:
   std::string               fn = std::string(argv[1]);
   itk::ImageIOBase::Pointer imageIO =
     itk::ImageIOFactory::CreateImageIO(
-      fn.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+            fn.c_str(), itk::IOFileModeEnum::ReadMode);
   imageIO->SetFileName(fn.c_str() );
   imageIO->ReadImageInformation();
 

--- a/Examples/StudentsTestOnImages.cxx
+++ b/Examples/StudentsTestOnImages.cxx
@@ -454,7 +454,7 @@ int StudentsTestOnImages(int argc, char *argv[])
   // Get the image dimension
   std::string               fn = std::string(argv[5]);
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(fn.c_str(), itk::IOFileModeEnum::ReadMode);
   imageIO->SetFileName(fn.c_str() );
   imageIO->ReadImageInformation();
   typename ImageType::SizeType size;

--- a/Examples/WarpImageMultiTransform.cxx
+++ b/Examples/WarpImageMultiTransform.cxx
@@ -798,7 +798,7 @@ private:
   if( is_parsing_ok )
     {
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(moving_image_filename,
-                                                                           itk::ImageIOFactory::FileModeEnum::ReadMode);
+                                                                           itk::IOFileModeEnum::ReadMode);
     imageIO->SetFileName(moving_image_filename);
     imageIO->ReadImageInformation();
     unsigned int ncomponents = imageIO->GetNumberOfComponents();

--- a/Examples/WarpTimeSeriesImageMultiTransform.cxx
+++ b/Examples/WarpTimeSeriesImageMultiTransform.cxx
@@ -469,7 +469,7 @@ void WarpImageMultiTransform(char *moving_image_filename, char *output_image_fil
 
   typename VectorImageType::Pointer img_mov;
   typename itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(moving_image_filename, itk::ImageIOFactory::FileModeEnum::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(moving_image_filename, itk::IOFileModeEnum::ReadMode);
   imageIO->SetFileName(moving_image_filename);
   imageIO->ReadImageInformation();
   //    std::cout << " Dimension " << imageIO->GetNumberOfDimensions()  << " Components "

--- a/Examples/antsAlignOrigin.cxx
+++ b/Examples/antsAlignOrigin.cxx
@@ -323,7 +323,7 @@ private:
     parser->GetOption( "input-image-type" );
 
   itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-      filename.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode );
+      filename.c_str(), itk::IOFileModeEnum::ReadMode );
   unsigned int dimension = imageIO->GetNumberOfDimensions();
 
   itk::ants::CommandLineParser::OptionType::Pointer dimOption =

--- a/Examples/antsJointFusion.cxx
+++ b/Examples/antsJointFusion.cxx
@@ -293,11 +293,11 @@ int antsJointFusion( itk::ants::CommandLineParser *parser )
     ConvertToLowerCase( metricString );
     if( metricString.compare( "pc" ) == 0 )
       {
-      fusionFilter->SetSimilarityMetric( FusionFilterType::PEARSON_CORRELATION );
+      fusionFilter->SetSimilarityMetric( itk::NonLocalPatchBasedImageFilterEnums::SimilarityMetric::PEARSON_CORRELATION );
       }
     else if( metricString.compare( "msq" ) == 0 )
       {
-      fusionFilter->SetSimilarityMetric( FusionFilterType::MEAN_SQUARES );
+      fusionFilter->SetSimilarityMetric( itk::NonLocalPatchBasedImageFilterEnums::SimilarityMetric::MEAN_SQUARES );
       }
     else
       {
@@ -1002,7 +1002,7 @@ private:
       return EXIT_FAILURE;
       }
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        filename.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode );
+        filename.c_str(), itk::IOFileModeEnum::ReadMode );
     dimension = imageIO->GetNumberOfDimensions();
     }
 

--- a/Examples/antsJointTensorFusion.cxx
+++ b/Examples/antsJointTensorFusion.cxx
@@ -974,7 +974,7 @@ private:
       return EXIT_FAILURE;
       }
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        filename.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode );
+        filename.c_str(), itk::IOFileModeEnum::ReadMode );
     dimension = imageIO->GetNumberOfDimensions();
     }
 

--- a/Examples/antsMotionCorr.cxx
+++ b/Examples/antsMotionCorr.cxx
@@ -959,14 +959,14 @@ int ants_motion( itk::ants::CommandLineParser *parser )
         samplingStrategy = metricOption->GetFunction( currentStage )->GetParameter(  4 );
         }
       ConvertToLowerCase( samplingStrategy );
-      typename AffineRegistrationType::MetricSamplingStrategyType metricSamplingStrategy = AffineRegistrationType::NONE;
+      typename AffineRegistrationType::MetricSamplingStrategyEnum metricSamplingStrategy = AffineRegistrationType::MetricSamplingStrategyEnum::NONE;
       if( std::strcmp( samplingStrategy.c_str(), "random" ) == 0 )
         {
         if( timedim == 0 )
           {
           if ( verbose ) std::cout << "  random sampling (percentage = " << samplingPercentage << ")" << std::endl;
           }
-        metricSamplingStrategy = AffineRegistrationType::RANDOM;
+        metricSamplingStrategy = AffineRegistrationType::MetricSamplingStrategyEnum::RANDOM;
         }
       if( std::strcmp( samplingStrategy.c_str(), "regular" ) == 0 )
         {
@@ -974,7 +974,7 @@ int ants_motion( itk::ants::CommandLineParser *parser )
           {
           if ( verbose ) std::cout << "  regular sampling (percentage = " << samplingPercentage << ")" << std::endl;
           }
-        metricSamplingStrategy = AffineRegistrationType::REGULAR;
+        metricSamplingStrategy = AffineRegistrationType::MetricSamplingStrategyEnum::REGULAR;
         }
 
       if( std::strcmp( whichMetric.c_str(), "cc" ) == 0 )
@@ -1232,7 +1232,7 @@ int ants_motion( itk::ants::CommandLineParser *parser )
         rigidRegistration->SetSmoothingSigmasPerLevel( smoothingSigmasPerLevel );
         rigidRegistration->SetMetric( metric );
         rigidRegistration->SetMetricSamplingStrategy(
-          static_cast<typename RigidRegistrationType::MetricSamplingStrategyType>( metricSamplingStrategy ) );
+          static_cast<typename RigidRegistrationType::MetricSamplingStrategyEnum>( metricSamplingStrategy ) );
         rigidRegistration->SetMetricSamplingPercentage( samplingPercentage );
         rigidRegistration->SetOptimizer( optimizer );
         if( compositeTransform->GetNumberOfTransforms() > 0 )
@@ -1332,7 +1332,7 @@ int ants_motion( itk::ants::CommandLineParser *parser )
         displacementFieldRegistration->SetSmoothingSigmasPerLevel( smoothingSigmasPerLevel );
         displacementFieldRegistration->SetSmoothingSigmasAreSpecifiedInPhysicalUnits( false );
         displacementFieldRegistration->SetMetricSamplingStrategy(
-          static_cast<typename DisplacementFieldRegistrationType::MetricSamplingStrategyType>( metricSamplingStrategy ) );
+          static_cast<typename DisplacementFieldRegistrationType::MetricSamplingStrategyEnum>( metricSamplingStrategy ) );
         displacementFieldRegistration->SetMetricSamplingPercentage( samplingPercentage );
         displacementFieldRegistration->SetOptimizer( optimizer );
         displacementFieldRegistration->SetTransformParametersAdaptorsPerLevel( adaptors );

--- a/Examples/antsMotionCorrDiffusionDirection.cxx
+++ b/Examples/antsMotionCorrDiffusionDirection.cxx
@@ -319,7 +319,7 @@ int ants_motion_directions( itk::ants::CommandLineParser *parser )
   // Therefore check reference image is 3D, and fail if not
   //
  itk::ImageIOBase::Pointer imageIO =
-   itk::ImageIOFactory::CreateImageIO(physicalName.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+   itk::ImageIOFactory::CreateImageIO(physicalName.c_str(), itk::IOFileModeEnum::ReadMode);
  imageIO->SetFileName(physicalName.c_str() );
  try
    {

--- a/Examples/antsSliceRegularizedRegistration.cxx
+++ b/Examples/antsSliceRegularizedRegistration.cxx
@@ -649,7 +649,7 @@ int ants_slice_regularized_registration( itk::ants::CommandLineParser *parser )
         samplingStrategy = metricOption->GetFunction( currentStage )->GetParameter(  4 );
         }
       ConvertToLowerCase( samplingStrategy );
-      typename TranslationRegistrationType::MetricSamplingStrategyType metricSamplingStrategy =
+      typename TranslationRegistrationType::MetricSamplingStrategyEnum metricSamplingStrategy =
         TranslationRegistrationType::NONE;
       if( std::strcmp( samplingStrategy.c_str(), "random" ) == 0 )
         {

--- a/Examples/antsSurf.cxx
+++ b/Examples/antsSurf.cxx
@@ -1100,7 +1100,7 @@ private:
       inputFile = imageOption->GetFunction( 0 )->GetParameter( 0 );
       }
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        inputFile.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode );
+        inputFile.c_str(), itk::IOFileModeEnum::ReadMode );
     unsigned int dimension = imageIO->GetNumberOfDimensions();
 
     if( dimension == 3 )

--- a/Examples/antsVol.cxx
+++ b/Examples/antsVol.cxx
@@ -563,7 +563,7 @@ private:
       inputFile = imageOption->GetFunction( 0 )->GetParameter( 0 );
       }
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        inputFile.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode );
+        inputFile.c_str(), itk::IOFileModeEnum::ReadMode );
     unsigned int dimension = imageIO->GetNumberOfDimensions();
 
     if( dimension == 3 )

--- a/Examples/iMathFunctions1.hxx
+++ b/Examples/iMathFunctions1.hxx
@@ -515,12 +515,12 @@ iMathPropagateLabelsThroughMask( typename ImageType::Pointer speedimage,      /*
     if( propagationMethod == 1 )  // Strict
       {
       // std::cout << " strict " << std::endl;
-      fastMarching->SetTopologyCheck( FastMarchingFilterType::Strict );
+      fastMarching->SetTopologyCheck( itk::FastMarchingTraitsEnums::TopologyCheck::Strict );
       }
     if( propagationMethod == 2 )  // No handles
       {
       // std::cout << " no handles " << std::endl;
-      fastMarching->SetTopologyCheck( FastMarchingFilterType::NoHandles );
+      fastMarching->SetTopologyCheck( itk::FastMarchingTraitsEnums::TopologyCheck::NoHandles );
       }
 
     typename NodeContainer::Pointer seeds = NodeContainer::New();

--- a/Examples/itkantsRegistrationHelper.h
+++ b/Examples/itkantsRegistrationHelper.h
@@ -815,7 +815,7 @@ private:
     ConjugateGradientDescentOptimizerType *optimizer, const unsigned int numberOfLevels,
     const std::vector<ShrinkFactorsPerDimensionContainerType> shrinkFactorsPerDimensionForAllLevels,
     const typename RegistrationMethodType::SmoothingSigmasArrayType smoothingSigmasPerLevel,
-    typename AffineRegistrationType::MetricSamplingStrategyType metricSamplingStrategy,
+    typename AffineRegistrationType::MetricSamplingStrategyEnum metricSamplingStrategy,
     const float samplingPercentage
     )
   {
@@ -860,7 +860,7 @@ private:
     registrationMethod->SetSmoothingSigmasAreSpecifiedInPhysicalUnits(
       this->m_SmoothingSigmasAreInPhysicalUnits[currentStageNumber] );
     registrationMethod->SetMetricSamplingStrategy(
-      static_cast<typename RegistrationMethodType::MetricSamplingStrategyType>( metricSamplingStrategy ) );
+      static_cast<typename RegistrationMethodType::MetricSamplingStrategyEnum>( metricSamplingStrategy ) );
     registrationMethod->SetMetricSamplingPercentage( samplingPercentage );
 
     if( this->m_RestrictDeformationOptimizerWeights.size() > currentStageNumber )
@@ -934,7 +934,7 @@ private:
     ConjugateGradientDescentOptimizerType *optimizer, const unsigned int numberOfLevels,
     const std::vector<ShrinkFactorsPerDimensionContainerType> shrinkFactorsPerDimensionForAllLevels,
     const typename RegistrationMethodType::SmoothingSigmasArrayType smoothingSigmasPerLevel,
-    typename AffineRegistrationType::MetricSamplingStrategyType metricSamplingStrategy,
+    typename AffineRegistrationType::MetricSamplingStrategyEnum metricSamplingStrategy,
     const float samplingPercentage
     )
   {

--- a/Examples/itkantsRegistrationHelper.hxx
+++ b/Examples/itkantsRegistrationHelper.hxx
@@ -441,7 +441,7 @@ RegistrationHelper<TComputeType, VImageDimension>
 {
   TransformMethod init;
 
-  init.m_XfrmMethod = TimeVaryingBSplineVelocityField;;
+  init.m_XfrmMethod = TimeVaryingBSplineVelocityField;
   init.m_GradientStep = GradientStep;
   init.m_VelocityFieldMeshSize = VelocityFieldMeshSize;
   init.m_NumberOfTimePointSamples = NumberOfTimePointSamples;
@@ -1266,16 +1266,16 @@ RegistrationHelper<TComputeType, VImageDimension>
     const float samplingPercentage = stageMetricList[0].m_SamplingPercentage;
 
     const SamplingStrategy samplingStrategy = stageMetricList[0].m_SamplingStrategy;
-    typename AffineRegistrationType::MetricSamplingStrategyType metricSamplingStrategy = AffineRegistrationType::NONE;
+    typename AffineRegistrationType::MetricSamplingStrategyEnum metricSamplingStrategy = AffineRegistrationType::MetricSamplingStrategyEnum::NONE;
     if( samplingStrategy == random )
       {
       this->Logger() << "  random sampling (percentage = " << samplingPercentage << ")" << std::endl;
-      metricSamplingStrategy = AffineRegistrationType::RANDOM;
+      metricSamplingStrategy = AffineRegistrationType::MetricSamplingStrategyEnum::RANDOM;
       }
     else if( samplingStrategy == regular )
       {
       this->Logger() << "  regular sampling (percentage = " << samplingPercentage << ")" << std::endl;
-      metricSamplingStrategy = AffineRegistrationType::REGULAR;
+      metricSamplingStrategy = AffineRegistrationType::MetricSamplingStrategyEnum::REGULAR;
       }
     else if( samplingStrategy == none )
       {
@@ -2373,7 +2373,7 @@ RegistrationHelper<TComputeType, VImageDimension>
           }
         velocityFieldRegistration->SetNumberOfLevels( numberOfLevels );
         velocityFieldRegistration->SetMetricSamplingStrategy(
-          static_cast<typename VelocityFieldRegistrationType::MetricSamplingStrategyType>( metricSamplingStrategy ) );
+          static_cast<typename VelocityFieldRegistrationType::MetricSamplingStrategyEnum>( metricSamplingStrategy ) );
         velocityFieldRegistration->SetMetricSamplingPercentage( samplingPercentage );
         velocityFieldRegistration->SetLearningRate( learningRate );
         velocityFieldRegistration->SetConvergenceThreshold( convergenceThreshold );
@@ -2934,7 +2934,7 @@ RegistrationHelper<TComputeType, VImageDimension>
           }
         displacementFieldRegistration->SetSmoothingSigmasPerLevel( smoothingSigmasPerLevel );
         displacementFieldRegistration->SetMetricSamplingStrategy(
-          static_cast<typename DisplacementFieldRegistrationType::MetricSamplingStrategyType>( metricSamplingStrategy ) );
+          static_cast<typename DisplacementFieldRegistrationType::MetricSamplingStrategyEnum>( metricSamplingStrategy ) );
         displacementFieldRegistration->SetMetricSamplingPercentage( samplingPercentage );
         displacementFieldRegistration->SetOptimizer( optimizer2 );
 
@@ -3120,7 +3120,7 @@ RegistrationHelper<TComputeType, VImageDimension>
           displacementFieldRegistration->SetFixedInitialTransform( this->m_FixedInitialTransform );
           }
         displacementFieldRegistration->SetMetricSamplingStrategy(
-          static_cast<typename DisplacementFieldRegistrationType::MetricSamplingStrategyType>( metricSamplingStrategy ) );
+          static_cast<typename DisplacementFieldRegistrationType::MetricSamplingStrategyEnum>( metricSamplingStrategy ) );
         displacementFieldRegistration->SetMetricSamplingPercentage( samplingPercentage );
         displacementFieldRegistration->SetOptimizer( optimizer2 );
         displacementFieldRegistration->SetTransformParametersAdaptorsPerLevel( adaptors );
@@ -3778,7 +3778,7 @@ RegistrationHelper<TComputeType, VImageDimension>
   typedef itk::TranslationTransform<RealType, VImageDimension> TranslationTransformType;
   typedef typename RigidTransformTraits<TComputeType, VImageDimension>::TransformType RigidTransformType;
 
-  std::string previousTxFileType = "";
+  std::string previousTxFileType;
   const typename TransformType::ConstPointer preTransform = compositeTransform->GetBackTransform();
   if( preTransform.IsNotNull() )
     {

--- a/Examples/sccan.cxx
+++ b/Examples/sccan.cxx
@@ -701,7 +701,7 @@ ConvertTimeSeriesImageToMatrix( std::string imagefn, std::string maskfn, std::st
     using dgf = itk::DiscreteGaussianImageFilter<ImageType, ImageType>;
     typename dgf::Pointer filter = dgf::New();
     filter->SetVariance(space_smoother);
-    filter->SetUseImageSpacingOn();
+    filter->SetUseImageSpacing(true);
     filter->SetMaximumError(.01f);
     filter->SetInput(image1);
     filter->Update();
@@ -722,7 +722,7 @@ ConvertTimeSeriesImageToMatrix( std::string imagefn, std::string maskfn, std::st
     using dgf = itk::DiscreteGaussianImageFilter<ImageType, ImageType>;
     typename dgf::Pointer filter = dgf::New();
     filter->SetVariance(time_smoother);
-    filter->SetUseImageSpacingOn();
+    filter->SetUseImageSpacing(true);
     filter->SetMaximumError(.01f);
     filter->SetInput(image1);
     filter->Update();

--- a/ImageRegistration/itkAvantsMutualInformationRegistrationFunction.cxx
+++ b/ImageRegistration/itkAvantsMutualInformationRegistrationFunction.cxx
@@ -408,14 +408,14 @@ AvantsMutualInformationRegistrationFunction<TFixedImage, TMovingImage, TDisplace
     jointPDFIterator.Value() /= static_cast<PDFValueType>( jointPDFSum );
     }
 
-  bool smoothjh = true;
+  constexpr bool smoothjh = true;
   if( smoothjh )
     {
     typedef DiscreteGaussianImageFilter<JointPDFType, JointPDFType> dgtype;
     typename dgtype::Pointer dg = dgtype::New();
     dg->SetInput(this->m_JointPDF);
     dg->SetVariance(1.5);
-    dg->SetUseImageSpacingOff();
+    dg->SetUseImageSpacing(false);
     dg->SetMaximumError(.01f);
     dg->Update();
     this->m_JointPDF = dg->GetOutput();

--- a/ImageRegistration/itkSpatialMutualInformationRegistrationFunction.cxx
+++ b/ImageRegistration/itkSpatialMutualInformationRegistrationFunction.cxx
@@ -604,14 +604,14 @@ SpatialMutualInformationRegistrationFunction<TFixedImage, TMovingImage, TDisplac
     jointPDFXuYrIterator.Value() /= static_cast<PDFValueType>( jointPDFSum );
     }
 
-  bool smoothjh = false;
+  constexpr bool smoothjh = false;
   if( smoothjh )
     {
     typedef DiscreteGaussianImageFilter<JointPDFType, JointPDFType> dgtype;
     typename dgtype::Pointer dg = dgtype::New();
     dg->SetInput(this->m_JointPDF);
     dg->SetVariance(1.);
-    dg->SetUseImageSpacingOff();
+    dg->SetUseImageSpacing(false);
     dg->SetMaximumError(.01f);
     dg->Update();
     this->m_JointPDF = dg->GetOutput();

--- a/ImageSegmentation/itkWeightedVotingFusionImageFilter.hxx
+++ b/ImageSegmentation/itkWeightedVotingFusionImageFilter.hxx
@@ -51,7 +51,7 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
 
   this->m_NeighborhoodSearchRadiusImage = nullptr;
 
-  this->SetSimilarityMetric( Superclass::PEARSON_CORRELATION );
+  this->SetSimilarityMetric( itk::NonLocalPatchBasedImageFilterEnums::SimilarityMetric::PEARSON_CORRELATION );
 }
 
 template <typename TInputImage, typename TOutputImage>

--- a/SuperBuild/External_ITKv5.cmake
+++ b/SuperBuild/External_ITKv5.cmake
@@ -152,7 +152,7 @@ if(NOT DEFINED ${extProjName}_DIR AND NOT ${USE_SYSTEM_${extProjName}})
   ### --- End Project specific additions
   set(${proj}_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITK.git)
   # set(${proj}_REPOSITORY ${git_protocol}://github.com/stnava/ITK.git)
-  set(${proj}_GIT_TAG e21a56d1227c5433066237060368cb4532b8a9d2)  # Adaptive denoising module 10/2/2020
+  set(${proj}_GIT_TAG ac080c97b1179f370ab15c8c2e8172f4479ecebd)  # Official ITK release version 5.2.0 2021-04-02
   set(ITK_VERSION_ID ITK-5.2) ### NOTE: When updating GIT_TAG, also update ITK_VERSION_ID
 
   ExternalProject_Add(${proj}

--- a/Temporary/antsFastMarchingImageFilter.h
+++ b/Temporary/antsFastMarchingImageFilter.h
@@ -276,7 +276,7 @@ private:
   itkGetConstReferenceMacro( CollectPoints, bool );
   itkBooleanMacro( CollectPoints );
 
-  enum TopologyCheckType { None, NoHandles, Strict };
+  using TopologyCheckType = itk::FastMarchingTraitsEnums::TopologyCheck;
 
   /** Set/Get boolean macro indicating whether the user wants to check topology. */
   itkSetMacro( TopologyCheck, TopologyCheckType );

--- a/Temporary/antsFastMarchingImageFilter.hxx
+++ b/Temporary/antsFastMarchingImageFilter.hxx
@@ -60,7 +60,7 @@ FMarchingImageFilter<TLevelSet, TSpeedImage>
   this->m_CollectPoints = false;
 
   this->m_NormalizationFactor = 1.0;
-  this->m_TopologyCheck = None;
+  this->m_TopologyCheck = itk::FastMarchingTraitsEnums::TopologyCheck::Nothing;
 }
 
 template <typename TLevelSet, typename TSpeedImage>
@@ -85,17 +85,17 @@ FMarchingImageFilter<TLevelSet, TSpeedImage>
 
   switch( this->m_TopologyCheck )
     {
-    case None:
+      case itk::FastMarchingTraitsEnums::TopologyCheck::Nothing:
       {
       os << "None" << std::endl;
       }
       break;
-    case NoHandles:
+    case itk::FastMarchingTraitsEnums::TopologyCheck::NoHandles:
       {
       os << "No handles" << std::endl;
       }
       break;
-    case Strict:
+    case itk::FastMarchingTraitsEnums::TopologyCheck::Strict:
       os << "Strict" << std::endl;
       break;
     default:
@@ -179,7 +179,7 @@ FMarchingImageFilter<TLevelSet, TSpeedImage>
 
   // Checking for handles only requires an image to keep track of
   // connected components.
-  if( this->m_TopologyCheck == NoHandles )
+  if( this->m_TopologyCheck == itk::FastMarchingTraitsEnums::TopologyCheck::NoHandles )
     {
     this->m_ConnectedComponentImage =
       AllocImage<ConnectedComponentImageType>(output->GetBufferedRegion(), 0);
@@ -233,7 +233,7 @@ FMarchingImageFilter<TLevelSet, TSpeedImage>
       this->m_LabelImage->SetPixel( node.GetIndex(), AlivePoint );
 
       //
-      if( this->m_TopologyCheck == NoHandles )
+      if( this->m_TopologyCheck == itk::FastMarchingTraitsEnums::TopologyCheck::NoHandles )
         {
         this->m_ConnectedComponentImage->SetPixel( node.GetIndex(),
                                                    NumericTraits<typename ConnectedComponentImageType::PixelType>::OneValue() );
@@ -244,7 +244,7 @@ FMarchingImageFilter<TLevelSet, TSpeedImage>
       }
     }
 
-  if( this->m_TopologyCheck == NoHandles )
+  if( this->m_TopologyCheck == itk::FastMarchingTraitsEnums::TopologyCheck::NoHandles )
     {
     // Now create the connected component image and relabel such that labels
     // are 1, 2, 3, ...
@@ -301,7 +301,7 @@ FMarchingImageFilter<TLevelSet, TSpeedImage>
     }
 
   // initialize indices if this->m_TopologyCheck is activated
-  if( this->m_TopologyCheck != None )
+  if( this->m_TopologyCheck != itk::FastMarchingTraitsEnums::TopologyCheck::Nothing )
     {
     if( SetDimension == 2 )
       {
@@ -365,20 +365,20 @@ FMarchingImageFilter<TLevelSet, TSpeedImage>
       continue;
       }
 
-    if( this->m_TopologyCheck != None )
+    if( this->m_TopologyCheck != itk::FastMarchingTraitsEnums::TopologyCheck::Nothing )
       {
       bool wellComposednessViolation
         = this->DoesVoxelChangeViolateWellComposedness( node.GetIndex() );
       bool strictTopologyViolation
         = this->DoesVoxelChangeViolateStrictTopology( node.GetIndex() );
-      if( this->m_TopologyCheck == Strict && ( wellComposednessViolation
+      if( this->m_TopologyCheck == itk::FastMarchingTraitsEnums::TopologyCheck::Strict && ( wellComposednessViolation
                                                || strictTopologyViolation ) )
         {
         output->SetPixel( node.GetIndex(), -0.00000001 );
         this->m_LabelImage->SetPixel( node.GetIndex(), TopologyPoint );
         continue;
         }
-      if( this->m_TopologyCheck == NoHandles )
+      if( this->m_TopologyCheck == itk::FastMarchingTraitsEnums::TopologyCheck::NoHandles )
         {
         if( wellComposednessViolation )
           {
@@ -457,7 +457,7 @@ FMarchingImageFilter<TLevelSet, TSpeedImage>
 
     // for topology handle checks, we need to update the connected
     // component image at the current node with the appropriate label.
-    if( this->m_TopologyCheck == NoHandles )
+    if( this->m_TopologyCheck == itk::FastMarchingTraitsEnums::TopologyCheck::NoHandles )
       {
       typename ConnectedComponentImageType::PixelType neighborhoodLabel
         = NumericTraits<typename ConnectedComponentImageType::PixelType>::ZeroValue();

--- a/Temporary/itkFEMDiscConformalMap.cxx
+++ b/Temporary/itkFEMDiscConformalMap.cxx
@@ -1220,7 +1220,7 @@ void  FEMDiscConformalMap<TSurface, TImage, TDimension>::MakeFlatImage()
     typedef itk::DiscreteGaussianImageFilter<FlatImageType, FlatImageType> dgf;
     typename dgf::Pointer filter = dgf::New();
     filter->SetVariance(1.0);
-    filter->SetUseImageSpacingOff();
+    filter->SetUseImageSpacing(false);
     filter->SetMaximumError(.01f);
     filter->SetInput(m_FlatImage);
     filter->Update();

--- a/Tensor/itkLogTensorImageFilter.h
+++ b/Tensor/itkLogTensorImageFilter.h
@@ -58,10 +58,10 @@ public:
   typedef SmartPointer<const Self>                            ConstPointer;
 
   /** Method for creation through the object factory. */
-  itkNewMacro(Self)
+  itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(LogTensorImageFilter, ImageToImageFilter)
+  itkTypeMacro(LogTensorImageFilter, ImageToImageFilter);
 
   /** Image typedef support. */
   typedef typename InputImageType::ConstPointer InputImagePointer;
@@ -85,10 +85,10 @@ public:
   typedef typename OutputImageType::IndexType OutputIndexType;
 
   /** Set the radius of the neighborhood used to compute the mean. */
-  // itkSetMacro(Radius, InputSizeType)
+  // itkSetMacro(Radius, InputSizeType);
 
   /** Get the radius of the neighborhood used to compute the mean */
-  // itkGetConstReferenceMacro(Radius, InputSizeType)
+  // itkGetConstReferenceMacro(Radius, InputSizeType);
 protected:
   LogTensorImageFilter();
   ~LogTensorImageFilter() override = default;

--- a/Utilities/antsCommandLineOption.h
+++ b/Utilities/antsCommandLineOption.h
@@ -59,21 +59,21 @@ public:
   typedef DataObject         Superclass;
   typedef SmartPointer<Self> Pointer;
 
-  itkNewMacro( Self )
+  itkNewMacro( Self );
 
-  itkTypeMacro( Option, DataObject )
+  itkTypeMacro( Option, DataObject );
 
   typedef std::deque<std::string> ParameterStackType;
 
-  itkSetStringMacro( Name )
-  itkGetStringMacro( Name )
-  itkGetMacro( Name, std::string )
+  itkSetStringMacro( Name );
+  itkGetStringMacro( Name );
+  itkGetMacro( Name, std::string );
 
-  itkSetMacro( ArgOrder, unsigned int )
-  itkGetConstMacro( ArgOrder, unsigned int )
+  itkSetMacro( ArgOrder, unsigned int );
+  itkGetConstMacro( ArgOrder, unsigned int );
 
-  itkSetMacro( StageID, unsigned int )
-  itkGetConstMacro( StageID, unsigned int )
+  itkSetMacro( StageID, unsigned int );
+  itkGetConstMacro( StageID, unsigned int );
 
   ParameterStackType GetParameters()
   {
@@ -119,9 +119,9 @@ public:
   typedef DataObject         Superclass;
   typedef SmartPointer<Self> Pointer;
 
-  itkNewMacro( Self )
+  itkNewMacro( Self );
 
-  itkTypeMacro( Option, DataObject )
+  itkTypeMacro( Option, DataObject );
 
   typedef OptionFunction OptionFunctionType;
 
@@ -172,14 +172,14 @@ public:
       }
   }
 
-  itkSetMacro( ShortName, char )
-  itkGetConstMacro( ShortName, char )
+  itkSetMacro( ShortName, char );
+  itkGetConstMacro( ShortName, char );
 
-  itkSetStringMacro( LongName )
-  itkGetConstMacro( LongName, std::string )
+  itkSetStringMacro( LongName );
+  itkGetConstMacro( LongName, std::string );
 
-  itkSetStringMacro( Description )
-  itkGetMacro( Description, std::string )
+  itkSetStringMacro( Description );
+  itkGetMacro( Description, std::string );
 
   void AddFunction( std::string, char, char, unsigned int order = 0 );
 

--- a/Utilities/antsCommandLineParser.cxx
+++ b/Utilities/antsCommandLineParser.cxx
@@ -254,7 +254,7 @@ CommandLineParser
         std::size_t leftDelimiterPosition = a.find( this->m_LeftDelimiter );
         if( leftDelimiterPosition != std::string::npos )
           {
-          itkExceptionMacro( "Incorrect command line specification. Missing leftDelimiterPosition? " << a )
+          itkExceptionMacro( "Incorrect command line specification. Missing leftDelimiterPosition? " << a );
           }
 
         std::size_t rightDelimiterPosition = a.find( this->m_RightDelimiter );
@@ -262,7 +262,7 @@ CommandLineParser
           {
           if( rightDelimiterPosition < a.length() - 1 )
             {
-            itkExceptionMacro( "Incorrect command line specification. Missing rightDelimiterPosition? " << a )
+            itkExceptionMacro( "Incorrect command line specification. Missing rightDelimiterPosition? " << a );
             }
           else
             {
@@ -292,7 +292,7 @@ CommandLineParser
             }
           else
             {
-            itkExceptionMacro( "Incorrect command line specification. " << a)
+            itkExceptionMacro( "Incorrect command line specification. " << a);
             }
           }
         else if( leftDelimiterPosition != std::string::npos &&
@@ -301,7 +301,7 @@ CommandLineParser
           {
           if( rightDelimiterPosition < a.length() - 1 )
             {
-            itkExceptionMacro( "Incorrect command line specification. " << a )
+            itkExceptionMacro( "Incorrect command line specification. " << a );
             }
           currentArg += a;
           arguments.push_back( currentArg );

--- a/Utilities/antsCommandLineParser.h
+++ b/Utilities/antsCommandLineParser.h
@@ -59,10 +59,10 @@ public:
   typedef SmartPointer<const Self> ConstPointer;
 
   /** Method for creation through the object factory. */
-  itkNewMacro( Self )
+  itkNewMacro( Self );
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro( CommandLineParser, DataObject )
+  itkTypeMacro( CommandLineParser, DataObject );
 
   typedef CommandLineOption              OptionType;
   typedef std::list<OptionType::Pointer> OptionListType;
@@ -84,11 +84,11 @@ public:
 
   void PrintMenu( std::ostream& os, Indent indent, bool printShortVersion = false ) const;
 
-  itkSetStringMacro( Command )
-  itkGetStringMacro( Command )
+  itkSetStringMacro( Command );
+  itkGetStringMacro( Command );
 
-  itkSetStringMacro( CommandDescription )
-  itkGetStringMacro( CommandDescription )
+  itkSetStringMacro( CommandDescription );
+  itkGetStringMacro( CommandDescription );
 
   OptionListType GetOptions() const
   {
@@ -123,7 +123,7 @@ public:
       std::string internalTypeName( typeid(value).name() );
       itkExceptionMacro( "ERROR: Parse error occured during command line argument processing\n"
         << "ERROR: Unable to convert '" << optionString
-        << "' to type '" << internalTypeName << "' as " << ConvertToHumanReadable(internalTypeName) << std::endl)
+        << "' to type '" << internalTypeName << "' as " << ConvertToHumanReadable(internalTypeName) << std::endl);
       }
     return value;
     }

--- a/Utilities/antsSCCANObject.hxx
+++ b/Utilities/antsSCCANObject.hxx
@@ -727,7 +727,7 @@ antsSCCANObject<TInputImage, TRealType>
     {
     typedef itk::DiscreteGaussianImageFilter<ImageType, ImageType> dgf;
     typename dgf::Pointer filter = dgf::New();
-    filter->SetUseImageSpacingOn();
+    filter->SetUseImageSpacing(true);
     filter->SetVariance(  this->m_Smoother * spacingsize );
     filter->SetMaximumError( .01f );
     filter->SetInput( image );

--- a/Utilities/itkDiReCTImageFilter.hxx
+++ b/Utilities/itkDiReCTImageFilter.hxx
@@ -931,7 +931,7 @@ DiReCTImageFilter<TInputImage, TOutputImage>
   using SmootherType = DiscreteGaussianImageFilter<RealImageType, RealImageType>;
   typename SmootherType::Pointer smoother = SmootherType::New();
   smoother->SetVariance( variance );
-  smoother->SetUseImageSpacingOff();
+  smoother->SetUseImageSpacing(false);
   smoother->SetMaximumError( 0.01 );
   smoother->SetInput( inputImage );
 

--- a/Utilities/itkImageIntensityAndGradientToPointSetFilter.h
+++ b/Utilities/itkImageIntensityAndGradientToPointSetFilter.h
@@ -39,14 +39,14 @@ public:
   typedef SmartPointer<const Self>                         ConstPointer;
 
   /** Method for creation through the object factory. */
-  itkNewMacro( Self )
+  itkNewMacro( Self );
 
   /** Extract dimension from the input image. */
   itkStaticConstMacro( Dimension, unsigned int,
                        TInputImage::ImageDimension );
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro( ImageIntensityAndGradientToPointSetFilter, MeshSource )
+  itkTypeMacro( ImageIntensityAndGradientToPointSetFilter, MeshSource );
 
   /** Hold on to the type information specified by the template parameters. */
   typedef TInputImage                         InputImageType;
@@ -107,20 +107,20 @@ public:
   /**
    * Set/Get sigma for the gradient recursive gaussian image filter
    */
-  itkSetMacro( Sigma, double )
-  itkGetConstMacro( Sigma, double )
+  itkSetMacro( Sigma, double );
+  itkGetConstMacro( Sigma, double );
 
   /**
    * Set/Get boolean for gradient calculation.
    */
-  itkSetMacro( UseCentralDifferenceFunction, bool )
-  itkGetConstMacro( UseCentralDifferenceFunction, bool )
+  itkSetMacro( UseCentralDifferenceFunction, bool );
+  itkGetConstMacro( UseCentralDifferenceFunction, bool );
 
   /**
    * Set/Get neighborhood radius
    */
-  itkSetMacro( NeighborhoodRadius, NeighborhoodRadiusType )
-  itkGetConstMacro( NeighborhoodRadius, NeighborhoodRadiusType )
+  itkSetMacro( NeighborhoodRadius, NeighborhoodRadiusType );
+  itkGetConstMacro( NeighborhoodRadius, NeighborhoodRadiusType );
 
 protected:
   ImageIntensityAndGradientToPointSetFilter();

--- a/Utilities/itkLabeledPointSetFileReader.h
+++ b/Utilities/itkLabeledPointSetFileReader.h
@@ -42,14 +42,14 @@ public:
   typedef SmartPointer<const Self>  ConstPointer;
 
   /** Method for creation through the object factory. */
-  itkNewMacro( Self )
+  itkNewMacro( Self );
 
   /** Extract dimension from the output mesh. */
   itkStaticConstMacro( Dimension, unsigned int,
                        TOutputMesh::PointType::Dimension );
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro( LabeledPointSetFileReader, MeshSource )
+  itkTypeMacro( LabeledPointSetFileReader, MeshSource );
 
   /** Hold on to the type information specified by the template parameters. */
   typedef TOutputMesh                         OutputMeshType;
@@ -69,18 +69,18 @@ public:
   typedef std::vector<PixelType> LabelSetType;
 
   /** Set/Get the name of the file to be read. */
-  itkSetStringMacro( FileName )
-  itkGetStringMacro( FileName )
+  itkSetStringMacro( FileName );
+  itkGetStringMacro( FileName );
 
-  itkSetMacro( ExtractBoundaryPoints, bool )
-  itkGetMacro( ExtractBoundaryPoints, bool )
-  itkBooleanMacro( ExtractBoundaryPoints )
+  itkSetMacro( ExtractBoundaryPoints, bool );
+  itkGetMacro( ExtractBoundaryPoints, bool );
+  itkBooleanMacro( ExtractBoundaryPoints );
 
   /**
    * Percentage of points selected randomnly
    */
-  itkSetClampMacro( RandomPercentage, double, 0.0, 1.0 )
-  itkGetConstMacro( RandomPercentage, double )
+  itkSetClampMacro( RandomPercentage, double, 0.0, 1.0 );
+  itkGetConstMacro( RandomPercentage, double );
 
   LabelSetType * GetLabelSet()
   {

--- a/Utilities/itkLabeledPointSetFileReader.hxx
+++ b/Utilities/itkLabeledPointSetFileReader.hxx
@@ -58,7 +58,7 @@ LabeledPointSetFileReader<TOutputMesh>
 {
   if( this->m_FileName == "" )
     {
-    itkExceptionMacro( "No input FileName" )
+    itkExceptionMacro( "No input FileName" );
     return;
     }
 
@@ -70,7 +70,7 @@ LabeledPointSetFileReader<TOutputMesh>
   if( !inputFile.is_open() )
     {
     itkExceptionMacro("Unable to open file\n"
-                      "inputFilename= " << m_FileName )
+                      "inputFilename= " << m_FileName );
     return;
     }
   else
@@ -255,7 +255,7 @@ LabeledPointSetFileReader<TOutputMesh>
   if( sscanf( pointLine.c_str(), "%d", &numberOfPoints ) != 1 )
     {
     itkExceptionMacro( "ERROR: Failed to read numberOfPoints\n"
-                       "       pointLine = " << pointLine )
+                       "       pointLine = " << pointLine );
     return;
     }
 
@@ -264,7 +264,7 @@ LabeledPointSetFileReader<TOutputMesh>
   if( numberOfPoints < 1 )
     {
     itkExceptionMacro( "numberOfPoints < 1"
-                       << "       numberOfPoints = " << numberOfPoints )
+                       << "       numberOfPoints = " << numberOfPoints );
     return;
     }
 
@@ -373,7 +373,7 @@ LabeledPointSetFileReader<TOutputMesh>
         {
         outputMesh->SetPointData( i, scalarData[i] );
         }
-      //    itkExceptionMacro( "Only single label components are readable" )
+      //    itkExceptionMacro( "Only single label components are readable" );
       }
     else
       {
@@ -403,7 +403,7 @@ LabeledPointSetFileReader<TOutputMesh>
         inputFile >> label;
         outputMesh->SetPointData( i, label );
         }
-      //    itkExceptionMacro( "Only single label components are readable" )
+      //    itkExceptionMacro( "Only single label components are readable" );
       }
     else
       {

--- a/Utilities/itkLabeledPointSetFileWriter.h
+++ b/Utilities/itkLabeledPointSetFileWriter.h
@@ -38,7 +38,7 @@ public:
   typedef SmartPointer<const Self>  ConstPointer;
 
   /** Method for creation through the object factory */
-  itkNewMacro( Self )
+  itkNewMacro( Self );
 
   /** Write the Input mesh to the Output file.
    * Use either Update() or Write(). */
@@ -51,7 +51,7 @@ public:
                        TInputMesh::PointType::Dimension );
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro( LabeledPointSetFileWriter, Object )
+  itkTypeMacro( LabeledPointSetFileWriter, Object );
 
   /** Hold on to the type information specified by the template parameters. */
   typedef TInputMesh                         InputMeshType;
@@ -80,27 +80,27 @@ public:
   void SetInput( InputMeshType * input );
 
   /** Set/Get the name of the file where data are written. */
-  itkSetStringMacro( FileName )
-  itkGetStringMacro( FileName )
+  itkSetStringMacro( FileName );
+  itkGetStringMacro( FileName );
 
   /** Specify other attributes */
-  itkSetMacro( Lines, typename LineSetType::Pointer )
+  itkSetMacro( Lines, typename LineSetType::Pointer );
 
   itkSetMacro( MultiComponentScalars,
-               typename MultiComponentScalarSetType::Pointer )
+               typename MultiComponentScalarSetType::Pointer );
 
   /** Specify image attributes if output is an image. */
-  itkSetMacro( ImageSize, ImageSizeType )
-  itkGetConstMacro( ImageSize, ImageSizeType )
+  itkSetMacro( ImageSize, ImageSizeType );
+  itkGetConstMacro( ImageSize, ImageSizeType );
 
-  itkSetMacro( ImageOrigin, ImageOriginType )
-  itkGetConstMacro( ImageOrigin, ImageOriginType )
+  itkSetMacro( ImageOrigin, ImageOriginType );
+  itkGetConstMacro( ImageOrigin, ImageOriginType );
 
-  itkSetMacro( ImageSpacing, ImageSpacingType )
-  itkGetConstMacro( ImageSpacing, ImageSpacingType )
+  itkSetMacro( ImageSpacing, ImageSpacingType );
+  itkGetConstMacro( ImageSpacing, ImageSpacingType );
 
-  itkSetMacro( ImageDirection, ImageDirectionType )
-  itkGetConstMacro( ImageDirection, ImageDirectionType )
+  itkSetMacro( ImageDirection, ImageDirectionType );
+  itkGetConstMacro( ImageDirection, ImageDirectionType );
 protected:
   LabeledPointSetFileWriter();
   ~LabeledPointSetFileWriter() override;

--- a/Utilities/itkLabeledPointSetFileWriter.hxx
+++ b/Utilities/itkLabeledPointSetFileWriter.hxx
@@ -84,7 +84,7 @@ LabeledPointSetFileWriter<TInputMesh>
 {
   if( this->m_FileName == "" )
     {
-    itkExceptionMacro( "No FileName" )
+    itkExceptionMacro( "No FileName" );
     return;
     }
 
@@ -113,7 +113,7 @@ LabeledPointSetFileWriter<TInputMesh>
   if( !outputFile.is_open() )
     {
     itkExceptionMacro( "Unable to open file\n"
-                       "outputFilename= " << m_FileName )
+                       "outputFilename= " << m_FileName );
     return;
     }
   else
@@ -144,7 +144,7 @@ LabeledPointSetFileWriter<TInputMesh>
       }
     catch( ... )
       {
-      itkExceptionMacro( "Unknown extension: " << extension )
+      itkExceptionMacro( "Unknown extension: " << extension );
       }
     }
 }

--- a/Utilities/itkN3BiasFieldCorrectionImageFilter.h
+++ b/Utilities/itkN3BiasFieldCorrectionImageFilter.h
@@ -82,7 +82,7 @@ template <typename TInputImage,
 class N3BiasFieldCorrectionImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(N3BiasFieldCorrectionImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(N3BiasFieldCorrectionImageFilter);
 
   /** Standard class type aliases. */
   using Self = N3BiasFieldCorrectionImageFilter;

--- a/Utilities/itkOptimalSharpeningImageFilter.h
+++ b/Utilities/itkOptimalSharpeningImageFilter.h
@@ -92,14 +92,14 @@ public:
 
   /** Use the image spacing information in calculations. Use this option if you
    *  want derivatives in physical space. Default is UseImageSpacingOn. */
-  void SetUseImageSpacingOn()
+  void UseImageSpacingOn()
   {
     this->SetUseImageSpacing(true);
   }
 
   /** Ignore the image spacing. Use this option if you want derivatives in
       isotropic pixel space.  Default is UseImageSpacingOn. */
-  void SetUseImageSpacingOff()
+  void UseImageSpacingOff()
   {
     this->SetUseImageSpacing(false);
   }

--- a/Utilities/itkSimulatedBSplineDisplacementFieldSource.h
+++ b/Utilities/itkSimulatedBSplineDisplacementFieldSource.h
@@ -40,7 +40,7 @@ class SimulatedBSplineDisplacementFieldSource final :
   public SimulatedDisplacementFieldSource<TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN( SimulatedBSplineDisplacementFieldSource );
+  ITK_DISALLOW_COPY_AND_MOVE( SimulatedBSplineDisplacementFieldSource );
 
   /** Standard class type aliases. */
   using Self = SimulatedBSplineDisplacementFieldSource;

--- a/Utilities/itkSimulatedDisplacementFieldSource.h
+++ b/Utilities/itkSimulatedDisplacementFieldSource.h
@@ -40,7 +40,7 @@ class SimulatedDisplacementFieldSource:
   public ImageSource<TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN( SimulatedDisplacementFieldSource );
+  ITK_DISALLOW_COPY_AND_MOVE( SimulatedDisplacementFieldSource );
 
   /** Standard class type aliases. */
   using Self = SimulatedDisplacementFieldSource;

--- a/Utilities/itkSimulatedExponentialDisplacementFieldSource.h
+++ b/Utilities/itkSimulatedExponentialDisplacementFieldSource.h
@@ -38,7 +38,7 @@ class SimulatedExponentialDisplacementFieldSource final:
   public SimulatedDisplacementFieldSource<TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN( SimulatedExponentialDisplacementFieldSource );
+  ITK_DISALLOW_COPY_AND_MOVE( SimulatedExponentialDisplacementFieldSource );
 
   /** Standard class type aliases. */
   using Self = SimulatedExponentialDisplacementFieldSource;

--- a/Utilities/itkSurfaceImageCurvature.hxx
+++ b/Utilities/itkSurfaceImageCurvature.hxx
@@ -497,7 +497,7 @@ void  SurfaceImageCurvature<TSurface>
       typedef itk::DiscreteGaussianImageFilter<TSurface, TSurface> dgf;
       typename dgf::Pointer filter = dgf::New();
       filter->SetVariance(0.5);
-      filter->SetUseImageSpacingOn();
+      filter->SetUseImageSpacing(true);
       filter->SetMaximumError(.01f);
       filter->SetInput(laplacian);
       filter->Update();

--- a/Utilities/itkVectorFieldGradientImageFunction.hxx
+++ b/Utilities/itkVectorFieldGradientImageFunction.hxx
@@ -402,7 +402,7 @@ VectorFieldGradientImageFunction<TInputImage, TRealType, TOutputImage>
   MatrixType E(ImageDimension, ImageDimension);
 
   typename MatrixType::InternalMatrixType ff
-    = vnl_matrix_inverse<RealType>( F.GetVnlMatrix() * F.GetTranspose()  );
+    = vnl_matrix_inverse<RealType>( F.GetVnlMatrix() * F.GetTranspose()  ).as_matrix();
   for( unsigned int i = 0; i < ff.rows(); i++ )
     {
     for( unsigned int j = 0; j < ff.columns(); j++ )


### PR DESCRIPTION
Future versions of ITK will deprecate and remove outdated coding
paradigms.  Replace deprecated code with modern coding recommendations.

Use official ITK5.2.0 release with improved backward/forward
compatibility syntax.