### PR TITLE
Template initialization to improve convergence

### DIFF
--- a/Examples/AverageImages.cxx
+++ b/Examples/AverageImages.cxx
@@ -84,7 +84,7 @@ int AverageImages1(unsigned int argc, char *argv[])
   reader->SetFileName(argv[bigimage]);
   reader->Update();
   typename ImageType::Pointer averageimage = reader->GetOutput();
-  std::cout << " Setting physcal space of output average image based on largest image " << std::endl;
+  std::cout << " Setting physical space of output average image based on largest image " << std::endl;
   unsigned int vectorlength = reader->GetImageIO()->GetNumberOfComponents();
   std::cout << " Averaging " << numberofimages << " images with dim = " << ImageDimension << " vector components "
            << vectorlength << std::endl;

--- a/Scripts/antsMultivariateTemplateConstruction.sh
+++ b/Scripts/antsMultivariateTemplateConstruction.sh
@@ -245,9 +245,15 @@ function shapeupdatetotemplate() {
     echo " shapeupdatetotemplate---voxel-wise averaging of the warped images to the current template"
     echo "--------------------------------------------------------------------------------------"
 
+    imagelist=(`ls ${outputname}template${whichtemplate}*WarpedToTemplate.nii.gz`)
+    if [[ ${#imagelist[@]} -ne ${IMAGESPERMODALITY} ]] ; then
+      echo "ERROR shapeupdatedtotemplate - imagelist length is ${#imagelist[@]}, expected ${IMAGESPERMODALITY}"
+      exit 1
+    fi
+
     case $summarizemethod in
     0) #mean
-      ${ANTSPATH}/AverageImages $dim ${template} 0 ${templatename}${whichtemplate}*WarpedToTemplate.nii.gz  
+      ${ANTSPATH}/AverageImages $dim ${template} 0 ${templatename}${whichtemplate}*WarpedToTemplate.nii.gz
       ;;
     1) #mean of normalized images
       ${ANTSPATH}/AverageImages $dim ${template} 2 ${templatename}${whichtemplate}*WarpedToTemplate.nii.gz
@@ -824,6 +830,9 @@ if [[ $NUMBEROFMODALITIES -gt 1 ]];
     echo "--------------------------------------------------------------------------------------"
 fi
 
+# Useful to check the right number of images exist for various ops
+IMAGESPERMODALITY=$(( ${#IMAGESETARRAY[@]} / ${NUMBEROFMODALITIES} ))
+
 # check for initial template images
 for (( i = 0; i < $NUMBEROFMODALITIES; i++ ))
     do
@@ -1209,7 +1218,7 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
     rm -f ${outdir}/job*.sh
     # Used to save time by only running coarse registration for the first couple of iterations
     # This may also help convergence, but because there's no way to turn it off, it makes it harder
-    # to refine templates with multiple calls to this script. 
+    # to refine templates with multiple calls to this script.
     # If you uncomment this, replace MAXITERATIONS with ITERATIONS in the call to ants below
     #
     # # For the first couple of iterations, use high-level registration only

--- a/Scripts/antsMultivariateTemplateConstruction2.sh
+++ b/Scripts/antsMultivariateTemplateConstruction2.sh
@@ -347,8 +347,8 @@ function shapeupdatetotemplate() {
     echo "--------------------------------------------------------------------------------------"
 
     imagelist=(`ls ${outputname}template${whichtemplate}*WarpedToTemplate.nii.gz`)
-    if [[ ${#imagelist[@]} -eq 0 ]] ; then
-      echo ERROR shapeupdatedtotemplate - imagelist length is 0
+    if [[ ${#imagelist[@]} -ne ${IMAGESPERMODALITY} ]] ; then
+      echo "ERROR shapeupdatedtotemplate - imagelist length is ${#imagelist[@]}, expected ${IMAGESPERMODALITY}"
       exit 1
     fi
 
@@ -989,6 +989,9 @@ if [[ $NUMBEROFMODALITIES -gt 1 ]];
       done
     echo "--------------------------------------------------------------------------------------"
 fi
+
+# Useful to check the right number of images exist for various ops
+IMAGESPERMODALITY=$(( ${#IMAGESETARRAY[@]} / ${NUMBEROFMODALITIES} ))
 
 # check for initial template images
 for (( i = 0; i < $NUMBEROFMODALITIES; i++ ))

--- a/Scripts/antsMultivariateTemplateConstruction2.sh
+++ b/Scripts/antsMultivariateTemplateConstruction2.sh
@@ -1348,9 +1348,18 @@ NUMLEVELS=${#ITERATLEVEL[@]}
 SHRINKLEVEL=( $(echo $SHRINKFACTORS | tr 'x' ' ') )
 NUMSHRINK=${#SHRINKLEVEL[@]}
 
+SMOOTHLEVEL=( $(echo $SMOOTHINGFACTORS | tr 'x' ' ') )
+NUMSMOOTH=${#SMOOTHLEVEL[@]}
+
 if [[ $NUMLEVELS -ne $NUMSHRINK ]]
   then
     echo "Number of shrink factors in [ $SHRINKFACTORS ] does not match number of iteration levels in [ $MAXITERATIONS ]"
+    exit 1
+  fi
+
+if [[ $NUMLEVELS -ne $NUMSMOOTH ]]
+  then
+    echo "Number of smoothing levels in [ $SMOOTHINGFACTORS ] does not match number of iteration levels in [ $MAXITERATIONS ]"
     exit 1
   fi
 


### PR DESCRIPTION
Fixes #1216. In addition to enforcing the use of AverageImages in population average templates, I made a few tweaks to help convergence:

* Use @gdevenyi 's idea to do a COM alignment of each image to the initial average
* Don't sharpen the population average, resulting in a smoother initial template 
* Also don't sharpen after the initial rigid alignment

After the population average + initial rigid stage, the statistic (mean, normalized mean, median) and sharpening options follow whatever the users specify on the command line.
 
In order to make the process more transparent to users, I added an output folder `intermediateTemplates/`, which contains each template and, if it exists, the template shape update. This will let users visually inspect their templates at every stage, and the update warps can be interrogated (eg, for magnitude or volume change) to assess convergence. 

Currently, the only way to retain intermediate output is to back up everything, which can take up a lot of disk space. 


Additionally, I made a few fixes to documentation and error checking, including:

* Check number of shrink factor levels is equal to number of iteration levels (2.sh only)
* Check the expected number of warped output images exist for each shape update. This prevents a quiet error when one or more registrations fail for whatever reason, and the template gets built from a subset of the input.

