### PR TITLE
ENH: Version info from a config file for releases

### DIFF
--- a/ANTS.cmake
+++ b/ANTS.cmake
@@ -31,18 +31,10 @@ if( NOT ${PROJECT_NAME}_BUILD_DISTRIBUTE AND NOT ${PROJECT_NAME}_VERSION_HASH ST
   set(${PROJECT_NAME}_VERSION "${${PROJECT_NAME}_VERSION}-g${${PROJECT_NAME}_VERSION_HASH}")
 endif()
 
-# When building from a snapshot, the git version information does not get populated 
-# Allow the user to specify a hash or version tag on the command line
-if( ${PROJECT_NAME}_VERSION_HASH STREQUAL "GITDIR-NOTFOUND" AND NOT "${ANTS_SNAPSHOT_VERSION}" STREQUAL "" )
-  set(${PROJECT_NAME}_VERSION_MAJOR 0)
-  set(${PROJECT_NAME}_VERSION_MINOR 0)
-  set(${PROJECT_NAME}_VERSION_PATCH 0)
-  set(${PROJECT_NAME}_VERSION_TWEAK 0)
-  set(${PROJECT_NAME}_VERSION "snapshot-${ANTS_SNAPSHOT_VERSION}")
-endif()
-
 # If no version information exists and the user has not passed version info to cmake, set defaults
-if("${${PROJECT_NAME}_VERSION_MAJOR}" STREQUAL "") 
+# This should only happen for development snapshots, releases should have a cmake file describing
+# the version
+if("${${PROJECT_NAME}_VERSION_MAJOR}" STREQUAL "")
   set(${PROJECT_NAME}_VERSION_MAJOR 0)
   set(${PROJECT_NAME}_VERSION_MINOR 0)
   set(${PROJECT_NAME}_VERSION_PATCH 0)
@@ -164,7 +156,7 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/ANTsVersionConfig.h.in"
 
 add_subdirectory(Examples)
 
-if (NOT ANTS_INSTALL_LIBS_ONLY) 
+if (NOT ANTS_INSTALL_LIBS_ONLY)
   install(PROGRAMS Scripts/ANTSpexec.sh
      Scripts/antsASLProcessing.sh
      Scripts/antsAtroposN4.sh

--- a/ANTS.cmake
+++ b/ANTS.cmake
@@ -12,35 +12,8 @@ set(CMAKE_MODULE_PATH
 
 set (CMAKE_INCLUDE_DIRECTORIES_BEFORE ON)
 #-----------------------------------------------------------------------------
-# Version information
+# ANTs version information
 include(Version.cmake)
-
-if(DEFINED ${PROJECT_NAME}_VERSION_RC)
-  set(${PROJECT_NAME}_VERSION "${${PROJECT_NAME}_VERSION}${${PROJECT_NAME}_VERSION_RC}")
-endif()
-if(DEFINED ${PROJECT_NAME}_VERSION_POST)
-  set(${PROJECT_NAME}_VERSION "${${PROJECT_NAME}_VERSION}.post${${PROJECT_NAME}_VERSION_POST}")
-elseif(DEFINED ${PROJECT_NAME}_VERSION_DEV)
-  set(${PROJECT_NAME}_VERSION "${${PROJECT_NAME}_VERSION}.dev${${PROJECT_NAME}_VERSION_DEV}")
-endif()
-
-
-option( ${PROJECT_NAME}_BUILD_DISTRIBUTE "Remove '-g#####' from version. ( for official distribution only )" OFF )
-mark_as_advanced( ${PROJECT_NAME}_BUILD_DISTRIBUTE )
-if( NOT ${PROJECT_NAME}_BUILD_DISTRIBUTE AND NOT ${PROJECT_NAME}_VERSION_HASH STREQUAL "GITDIR-NOTFOUND" )
-  set(${PROJECT_NAME}_VERSION "${${PROJECT_NAME}_VERSION}-g${${PROJECT_NAME}_VERSION_HASH}")
-endif()
-
-# If no version information exists and the user has not passed version info to cmake, set defaults
-# This should only happen for development snapshots, releases should have a cmake file describing
-# the version
-if("${${PROJECT_NAME}_VERSION_MAJOR}" STREQUAL "")
-  set(${PROJECT_NAME}_VERSION_MAJOR 0)
-  set(${PROJECT_NAME}_VERSION_MINOR 0)
-  set(${PROJECT_NAME}_VERSION_PATCH 0)
-  set(${PROJECT_NAME}_VERSION_TWEAK 0)
-  set(${PROJECT_NAME}_VERSION "0.0.0.0")
-endif()
 
 #-----------------------------------------------------------------------------
 # CPACK Version

--- a/CMake/ProjectSourceVersion.cmake
+++ b/CMake/ProjectSourceVersion.cmake
@@ -32,13 +32,17 @@ include(GetGitRevisionDescription)
 get_git_head_revision(GIT_REFVAR _GIT_VERSION_HASH)
 
 # if there is not git directory we should be in a distributed package
-# we will use version provided in Version.cmake
+# we will use version info in the file ProjectSourceVersionVars.cmake.
+# This file should be included in tagged source distributions
 if(_GIT_VERSION_HASH STREQUAL "GITDIR-NOTFOUND")
+  include("${CMAKE_CURRENT_SOURCE_DIR}/CMake/ProjectSourceVersionVars.cmake")
   return()
 endif()
 
 if(_GIT_VERSION_HASH MATCHES "[a-fA-F0-9]+")
-  string(SUBSTRING "${_GIT_VERSION_HASH}" 0 5 _GIT_VERSION_HASH)
+  # Get first seven chars of hash, following git convention
+  # https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection
+  string(SUBSTRING "${_GIT_VERSION_HASH}" 0 7 _GIT_VERSION_HASH)
 endif()
 
 # find the closest anotated tag with the v prefix for version

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -112,6 +112,9 @@ option(RUN_SHORT_TESTS    "Run the quick unit tests."                           
 option(RUN_LONG_TESTS     "Run the time consuming tests. i.e. real world registrations" ON  )
 option(OLD_BASELINE_TESTS "Use reported metrics from old tests"                         OFF )
 
+option( ANTS_BUILD_DISTRIBUTE "Remove '-g#####' from version. ( for official distribution only )" OFF )
+mark_as_advanced( ANTS_BUILD_DISTRIBUTE )
+
 option(ANTS_INSTALL_LIBS_ONLY "Do not install binaries" OFF)
 mark_as_advanced(ANTS_INSTALL_LIBS_ONLY)
 
@@ -249,7 +252,7 @@ list(APPEND ${CMAKE_PROJECT_NAME}_SUPERBUILD_EP_VARS
   RUN_SHORT_TESTS:BOOL
   RUN_LONG_TESTS:BOOL
   OLD_BASELINE_TESTS:BOOL
-  ANTS_SNAPSHOT_VERSION:STRING
+  ANTS_BUILD_DISTRIBUTE:BOOL
   ANTS_INSTALL_LIBS_ONLY:BOOL
 
   ${LOCAL_PROJECT_NAME}_CLI_LIBRARY_OUTPUT_DIRECTORY:PATH

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -112,9 +112,6 @@ option(RUN_SHORT_TESTS    "Run the quick unit tests."                           
 option(RUN_LONG_TESTS     "Run the time consuming tests. i.e. real world registrations" ON  )
 option(OLD_BASELINE_TESTS "Use reported metrics from old tests"                         OFF )
 
-set(ANTS_SNAPSHOT_VERSION "" CACHE STRING "Version info for binaries. Only used if source is not a git repo. Identify source snapshot by commit hash or release tag")
-mark_as_advanced(ANTS_SNAPSHOT_VERSION)
-
 option(ANTS_INSTALL_LIBS_ONLY "Do not install binaries" OFF)
 mark_as_advanced(ANTS_INSTALL_LIBS_ONLY)
 

--- a/Version.cmake
+++ b/Version.cmake
@@ -1,13 +1,13 @@
-#
-# ONLY MODIFY TO CHANGE VERSION
-#
-# The number of commits since last this file has changed it used to
-# define "dev" and "post", modification of this file will reset that
-# version.
-#
-
 # Version info
 include(ProjectSourceVersion)
+
+set(_GIT_VERSION "${_GIT_VERSION_MAJOR}.${_GIT_VERSION_MINOR}")
+if(DEFINED _GIT_VERSION_PATCH)
+  set(_GIT_VERSION "${_GIT_VERSION}.${_GIT_VERSION_PATCH}")
+  if(DEFINED _GIT_VERSION_TWEAK)
+    set(_GIT_VERSION "${_GIT_VERSION}.${_GIT_VERSION_TWEAK}")
+  endif()
+endif()
 
 # pre-release codes are defined based on suffix of most recent tags.
 
@@ -21,18 +21,32 @@ set(${PROJECT_NAME}_VERSION_MAJOR "${_GIT_VERSION_MAJOR}")
 set(${PROJECT_NAME}_VERSION_MINOR "${_GIT_VERSION_MINOR}")
 set(${PROJECT_NAME}_VERSION_PATCH "${_GIT_VERSION_PATCH}")
 set(${PROJECT_NAME}_VERSION_TWEAK "${_GIT_VERSION_TWEAK}")
-
-# The hash is the current git sha1 hash tag of the HEAD.
 set(${PROJECT_NAME}_VERSION_HASH "${_GIT_VERSION_HASH}")
 
-
-# DEV or POST is set to the number of commits since this file has been
-# changed. If the MAJOR.MINOR.[PATCH[.TWEAK]] matches "closest"
-# version tag then its consider in the release branch and POST is set
-# while DEV is undefined, otherwise we are considered under
-# development and DEV is set and POST is undefined.
 if(DEFINED _GIT_VERSION_POST)
   set(${PROJECT_NAME}_VERSION_POST "${_GIT_VERSION_POST}")
-elseif(DEFINED _GIT_VERSION_DEV)
-  set(${PROJECT_NAME}_VERSION_DEV "${_GIT_VERSION_DEV}")
+endif()
+
+if(DEFINED ${PROJECT_NAME}_VERSION_RC)
+  set(${PROJECT_NAME}_VERSION "${${PROJECT_NAME}_VERSION}${${PROJECT_NAME}_VERSION_RC}")
+endif()
+
+if(DEFINED ${PROJECT_NAME}_VERSION_POST)
+  set(${PROJECT_NAME}_VERSION "${${PROJECT_NAME}_VERSION}.post${${PROJECT_NAME}_VERSION_POST}")
+endif()
+
+if( (NOT ANTS_BUILD_DISTRIBUTE) AND (NOT ${PROJECT_NAME}_VERSION_HASH STREQUAL "GITDIR-NOTFOUND") )
+  set(${PROJECT_NAME}_VERSION "${${PROJECT_NAME}_VERSION}-g${${PROJECT_NAME}_VERSION_HASH}")
+endif()
+
+# If no version information exists and the user has not passed version info to cmake, set defaults
+# This should only happen for development snapshots, releases should have a cmake file describing
+# the version
+if("${${PROJECT_NAME}_VERSION_MAJOR}" STREQUAL "")
+  set(${PROJECT_NAME}_VERSION_MAJOR 0)
+  set(${PROJECT_NAME}_VERSION_MINOR 0)
+  set(${PROJECT_NAME}_VERSION_PATCH 0)
+  set(${PROJECT_NAME}_VERSION_TWEAK 0)
+  set(${PROJECT_NAME}_VERSION "0.0.0.0")
+  message(status "No version information found - using placeholder ${PROJECT_NAME}_VERSION")
 endif()


### PR DESCRIPTION
Did a bunch of refactoring of version handling, consolidating the work
into ProjectSourceVersion.cmake (handling the git side and setting
_GIT_VERSION_MAJOR etc) and Version.cmake (deciding the final form of
the version info).
    
The version string should now match git-describe more closely. The old
behavior was to look for commits since Version.cmake was changed, but
since that is entirely auto-populated, it is not a very useful metric.
Now use post-X, where X is the number of commits since the last
release.
    
For releases, we need to provide a file
ANTs/CMake/ReleaseSourceVersionVars.cmake
which should contain, eg:
    
set( _GIT_VERSION_MAJOR "2" )
set( _GIT_VERSION_MINOR "3" )
set( _GIT_VERSION_PATCH "6" )
