### PR TITLE
BUG - antsIntermodalityIntrasubject.sh - fixed a typo and incorrect running summary

### DIFF
--- a/Scripts/antsIntermodalityIntrasubject.sh
+++ b/Scripts/antsIntermodalityIntrasubject.sh
@@ -14,7 +14,7 @@ fi
 function Usage {
     cat <<USAGE
 
-`basename $0` performs restration between a scalar image and a T1 image:
+`basename $0` performs registration between a scalar image and a T1 image:
 
 Usage:
 
@@ -53,7 +53,7 @@ echoParameters() {
       image dimension         = ${DIMENSION}
       anatomical image        = ${BRAIN}
       t1 subject brain        = ${ANATOMICAL_BRAIN}
-      t1 subject brain mask   = ${TEMPLATE_BRAIN}
+      t1 subject brain mask   = ${TEMPLATE_MASK}
       output prefix           = ${OUTPUT_PREFIX}
       template labels         = ${TEMPLATE_LABELS}
       auxiliary images        = ${AUX_IMAGES[@]}


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your
pull request.

We welcome contributions to ANTs. Pull requests will be reviewed by the
developers and if accepted, become part of ANTs, distributed under the license
terms in COPYING.txt.

Please title your PR according to what it does:
ENH: new or improved functionality
PERF: performance enhancements to existing functionality
BUG: fixing a run time bug
COMP: relating to compilation
DOC: documentation changes
WIP: work in progress, needs further commits to be ready
-->

Hi!

I've been running antsIntermodalityIntrasubject.sh and noticed that even though I am providing the brain mask, it is not included in the running "summary". While confusing at first, I then found the issue and the wrong parameter is being used in the summary.

You can see the differences here.
Before:
![Snip20211003_12](https://user-images.githubusercontent.com/22886918/135769894-3b9ff06d-f602-461d-aec6-ebba44c21c35.png)


After:
![Snip20211003_13](https://user-images.githubusercontent.com/22886918/135769875-f0629dcd-b7ab-4b6c-ac96-f4a42fe6bbf4.png)


Also, I fixed a small typo.

Thanks!

