### PR TITLE
BUG: Output correct number of iterations in parameter summary

### DIFF
--- a/Scripts/antsAtroposN4.sh
+++ b/Scripts/antsAtroposN4.sh
@@ -105,7 +105,8 @@ echoParameters() {
        prior weight           = ${ATROPOS_SEGMENTATION_PRIOR_WEIGHT}
        posterior formulation  = ${ATROPOS_SEGMENTATION_POSTERIOR_FORMULATION}
        mrf                    = ${ATROPOS_SEGMENTATION_MRF}
-       Max N4->Atropos iters. = ${ATROPOS_SEGMENTATION_NUMBER_OF_ITERATIONS}
+       Max N4->Atropos iters. = ${N4_ATROPOS_NUMBER_OF_ITERATIONS}
+       Max Atropos iters.     = ${ATROPOS_SEGMENTATION_NUMBER_OF_ITERATIONS}
        use clock random seed  = ${USE_RANDOM_SEEDING}
 
 PARAMETERS


### PR DESCRIPTION
Output Max N4->Atropos iters (-m) correctly. The internal iterations (-n) were being printed instead. Now output both