### PR TITLE
ENH: Use a bigger VM to attempt to stop CircleCI timeouts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ jobs:
   build_docker:
     docker:
       - image: docker:18.06.1-ce-git
+    resource_class: large
     working_directory: /tmp/src/ANTs
     steps:
       - checkout


### PR DESCRIPTION
CircleCI jobs timeout after one hour. The recent ITK upgrades push the build time over the limit, but perhaps a larger resource will be faster.