### PR TITLE
COMP: Update ITK and VTK to avoid compiler warnings

### DIFF
--- a/SuperBuild/External_ITKv5.cmake
+++ b/SuperBuild/External_ITKv5.cmake
@@ -153,8 +153,8 @@ if(NOT DEFINED ${extProjName}_DIR AND NOT ${USE_SYSTEM_${extProjName}})
   ### --- End Project specific additions
   set(${proj}_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITK.git)
   # set(${proj}_REPOSITORY ${git_protocol}://github.com/stnava/ITK.git)
-  set(${proj}_GIT_TAG ac080c97b1179f370ab15c8c2e8172f4479ecebd)  # Official ITK release version 5.2.0 2021-04-02
-  set(ITK_VERSION_ID ITK-5.2) ### NOTE: When updating GIT_TAG, also update ITK_VERSION_ID
+  set(${proj}_GIT_TAG v5.3rc03)  # Official ITK release version 5.3.0 rc 03 # Many modern code updates for performance
+  set(ITK_VERSION_ID ITK-5.3) ### NOTE: When updating GIT_TAG, also update ITK_VERSION_ID
 
   ExternalProject_Add(${proj}
     GIT_REPOSITORY ${${proj}_REPOSITORY}

--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -161,7 +161,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" 
     )
   ### --- End Project specific additions
   set(${proj}_REPOSITORY ${git_protocol}://github.com/Kitware/VTK.git)
-  set(${proj}_GIT_TAG v8.2.0 )
+  set(${proj}_GIT_TAG v9.1.0 ) # using modern stable VTK version to avoid modern compiler warnings
   ExternalProject_Add(${proj}
     GIT_REPOSITORY ${${proj}_REPOSITORY}
     GIT_TAG ${${proj}_GIT_TAG}


### PR DESCRIPTION
Older versions of ITK and VTK introduced compiler warnings
with new more pedantic compilers.  VTK warned of duplicate
symbols, and ITK warned of empty statements.

Code built and tests passed:

100% tests passed, 0 tests failed out of 130
