### PR TITLE
ENH:  Expose UseGradientFilter variable for image metrics.

### DIFF
--- a/Examples/antsRegistration.cxx
+++ b/Examples/antsRegistration.cxx
@@ -309,7 +309,8 @@ antsRegistrationInitializeCommandLineOptions(itk::ants::CommandLineParser * pars
       std::string("one sample per voxel), otherwise it defines a point set over which to optimize the metric. ") +
       std::string("The point set can be on a regular lattice or a random lattice of points slightly ") +
       std::string("perturbed to minimize aliasing artifacts. samplingPercentage defines the ") +
-      std::string("fraction of points to select from the domain. ") +
+      std::string("fraction of points to select from the domain. useGradientFilter specifies whether a smoothing") +
+      std::string("filter is applied when estimating the metric gradient.") +
       std::string("In addition, three point set metrics are available:  Euclidean ") +
       std::string("(ICP), Point-set expectation (PSE), and Jensen-Havrda-Charvet-Tsallis (JHCT).");
 
@@ -318,22 +319,22 @@ antsRegistrationInitializeCommandLineOptions(itk::ants::CommandLineParser * pars
     option->SetShortName('m');
     option->SetUsageOption(0,
                            "CC[fixedImage,movingImage,metricWeight,radius,<samplingStrategy={None,Regular,Random}>,<"
-                           "samplingPercentage=[0,1]>]");
+                           "samplingPercentage=[0,1]>,<useGradientFilter=false>]");
     option->SetUsageOption(1,
                            "MI[fixedImage,movingImage,metricWeight,numberOfBins,<samplingStrategy={None,Regular,Random}"
-                           ">,<samplingPercentage=[0,1]>]");
+                           ">,<samplingPercentage=[0,1]>,<useGradientFilter=false>]");
     option->SetUsageOption(2,
                            "Mattes[fixedImage,movingImage,metricWeight,numberOfBins,<samplingStrategy={None,Regular,"
-                           "Random}>,<samplingPercentage=[0,1]>]");
+                           "Random}>,<samplingPercentage=[0,1]>,<useGradientFilter=false>]");
     option->SetUsageOption(3,
                            "MeanSquares[fixedImage,movingImage,metricWeight,radius=NA,<samplingStrategy={None,Regular,"
-                           "Random}>,<samplingPercentage=[0,1]>]");
+                           "Random}>,<samplingPercentage=[0,1]>,<useGradientFilter=false>]");
     option->SetUsageOption(4,
                            "Demons[fixedImage,movingImage,metricWeight,radius=NA,<samplingStrategy={None,Regular,"
-                           "Random}>,<samplingPercentage=[0,1]>]");
+                           "Random}>,<samplingPercentage=[0,1]>,<useGradientFilter=false>]");
     option->SetUsageOption(5,
                            "GC[fixedImage,movingImage,metricWeight,radius=NA,<samplingStrategy={None,Regular,Random}>,<"
-                           "samplingPercentage=[0,1]>]");
+                           "samplingPercentage=[0,1]>,<useGradientFilter=false>]");
     option->SetUsageOption(
       6, "ICP[fixedPointSet,movingPointSet,metricWeight,<samplingPercentage=[0,1]>,<boundaryPointsOnly=0>]");
     option->SetUsageOption(7,

--- a/Examples/antsRegistrationTemplateHeader.h
+++ b/Examples/antsRegistrationTemplateHeader.h
@@ -973,6 +973,7 @@ DoRegistration(typename ParserType::Pointer & parser)
     typename RegistrationHelperType::SamplingStrategy samplingStrategy = RegistrationHelperType::none;
     unsigned int                                      numberOfBins = 32;
     unsigned int                                      radius = 4;
+    bool                                              useGradientFilter = false;
 
     // assign default point-set variables
 
@@ -993,6 +994,12 @@ DoRegistration(typename ParserType::Pointer & parser)
       {
         samplingPercentage = parser->Convert<float>(metricOption->GetFunction(currentMetricNumber)->GetParameter(5));
       }
+
+      if (metricOption->GetFunction(currentMetricNumber)->GetNumberOfParameters() > 6)
+      {
+        useGradientFilter = parser->Convert<bool>(metricOption->GetFunction(currentMetricNumber)->GetParameter(6));
+      }
+
       std::string fixedFileName = metricOption->GetFunction(currentMetricNumber)->GetParameter(0);
       std::string movingFileName = metricOption->GetFunction(currentMetricNumber)->GetParameter(1);
 
@@ -1196,6 +1203,7 @@ DoRegistration(typename ParserType::Pointer & parser)
                          samplingStrategy,
                          numberOfBins,
                          radius,
+                         useGradientFilter,
                          useBoundaryPointsOnly,
                          pointSetSigma,
                          evaluationKNeighborhood,

--- a/Examples/itkantsRegistrationHelper.h
+++ b/Examples/itkantsRegistrationHelper.h
@@ -208,6 +208,7 @@ public:
            SamplingStrategy        samplingStrategy,
            int                     numberOfBins,
            unsigned int            radius,
+           bool                    useGradientFilter,
            bool                    useBoundaryPointsOnly,
            RealType                pointSetSigma,
            unsigned int            evaluationKNeighborhood,
@@ -215,7 +216,8 @@ public:
            bool                    useAnisotropicCovariances,
            RealType                samplingPercentage,
            RealType                intensityDistanceSigma,
-           RealType                euclideanDistanceSigma)
+           RealType                euclideanDistanceSigma
+           )
       : m_MetricType(metricType)
       , m_FixedImage(fixedImage)
       , m_MovingImage(movingImage)
@@ -224,6 +226,7 @@ public:
       , m_SamplingStrategy(samplingStrategy)
       , m_NumberOfBins(numberOfBins)
       , m_Radius(radius)
+      , m_UseGradientFilter(useGradientFilter)
       , m_FixedLabeledPointSet(fixedLabeledPointSet)
       , m_MovingLabeledPointSet(movingLabeledPointSet)
       , m_FixedIntensityPointSet(fixedIntensityPointSet)
@@ -302,6 +305,7 @@ public:
     SamplingStrategy m_SamplingStrategy;
     int              m_NumberOfBins;
     unsigned int     m_Radius; // Only for CC metric
+    bool             m_UseGradientFilter;
 
     // Variables for point-set metrics
 
@@ -481,6 +485,7 @@ public:
             SamplingStrategy        samplingStrategy,
             int                     numberOfBins,
             unsigned int            radius,
+            bool                    useGradientFilter,
             bool                    useBoundaryPointsOnly,
             RealType                pointSetSigma,
             unsigned int            evaluationKNeighborhood,
@@ -500,6 +505,7 @@ public:
             SamplingStrategy  samplingStrategy,
             int               numberOfBins,
             unsigned int      radius,
+            bool              useGradientFilter,
             RealType          samplingPercentage)
   {
     this->AddMetric(metricType,
@@ -514,6 +520,7 @@ public:
                     samplingStrategy,
                     numberOfBins,
                     radius,
+                    useGradientFilter,
                     false,
                     1.0,
                     50,

--- a/Examples/simpleSynRegistration.cxx
+++ b/Examples/simpleSynRegistration.cxx
@@ -75,7 +75,8 @@ simpleSynReg(ImageType::Pointer &                  fixedImage,
   constexpr float                          samplingPercentage = 1.0;
   RegistrationHelperType::SamplingStrategy samplingStrategy = RegistrationHelperType::none;
   constexpr unsigned int                   binOption = 200;
-  regHelper->AddMetric(curMetric, fixedImage, movingImage, 0, 1.0, samplingStrategy, binOption, 1, samplingPercentage);
+  bool                                     useGradientFilter = false;
+  regHelper->AddMetric(curMetric, fixedImage, movingImage, 0, 1.0, samplingStrategy, binOption, 1, useGradientFilter, samplingPercentage);
 
   const float learningRate(0.25F);
   const float varianceForUpdateField(3.0F);


### PR DESCRIPTION

Partially an attempt to address [this issue](https://github.com/ANTsX/ANTs/issues/1348) but might be more generally useful.  Allows users to specify using gradient filter for image metric gradient calculation.  Should be backwards compatible.


