### PR TITLE
STYLE: Catch exceptions by _const_ reference

### DIFF
--- a/Examples/ANTS.cxx
+++ b/Examples/ANTS.cxx
@@ -87,7 +87,7 @@ ANTSex(int argc, char * argv[])
   {
     registration->RunRegistration();
   }
-  catch (std::exception const & e)
+  catch (const std::exception const & e)
   {
     std::cerr << "Exception caught in ANTS: " << std::endl << e.what() << std::endl;
     return EXIT_FAILURE;
@@ -163,12 +163,12 @@ ANTS(std::vector<std::string> args, std::ostream * /*out_stream = nullptr*/)
     {
       dim = std::stoi(argv[1]);
     }
-    catch (std::invalid_argument & itkNotUsed(e))
+    catch (const std::invalid_argument & itkNotUsed(e))
     {
       // if no conversion could be performed
       // assume --help is requested
     }
-    catch (std::out_of_range & itkNotUsed(e))
+    catch (const std::out_of_range & itkNotUsed(e))
     {
       // if the converted value would fall out of the range of the result type
       // or if the underlying function (std::strtol or std::strtoull) sets errno

--- a/Examples/ANTSUseDeformationFieldToGetAffineTransform.cxx
+++ b/Examples/ANTSUseDeformationFieldToGetAffineTransform.cxx
@@ -39,7 +39,7 @@ WriteAffineTransformFile(typename TransformType::Pointer & transform, const std:
   {
     transform_writer->Update();
   }
-  catch (itk::ExceptionObject & itkNotUsed(err))
+  catch (const itk::ExceptionObject & itkNotUsed(err))
   {
     std::cerr << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl
               << "Exception in writing transform file: " << std::endl

--- a/Examples/ANTSUseLandmarkImagesToGetAffineTransform.cxx
+++ b/Examples/ANTSUseLandmarkImagesToGetAffineTransform.cxx
@@ -36,7 +36,7 @@ WriteAffineTransformFile(typename TransformType::Pointer & transform, const std:
   {
     transform_writer->Update();
   }
-  catch (itk::ExceptionObject & itkNotUsed(err))
+  catch (const itk::ExceptionObject & itkNotUsed(err))
   {
     std::cerr << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl
               << "Exception in writing transform file: " << std::endl

--- a/Examples/Atropos.cxx
+++ b/Examples/Atropos.cxx
@@ -994,7 +994,7 @@ AtroposSegmentation(itk::ants::CommandLineParser * parser)
     //    segmenter->DebugOn();
     segmenter->Update();
   }
-  catch (itk::ExceptionObject & exp)
+  catch (const itk::ExceptionObject & exp)
   {
     if (verbose)
     {

--- a/Examples/AverageTensorImages.cxx
+++ b/Examples/AverageTensorImages.cxx
@@ -172,7 +172,7 @@ AverageTensorImages(std::vector<std::string> args, std::ostream * /*out_stream =
 
     return EXIT_SUCCESS;
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "ExceptionObject caught !" << std::endl;
     std::cerr << err << std::endl;

--- a/Examples/CheckTopology.cxx
+++ b/Examples/CheckTopology.cxx
@@ -189,7 +189,7 @@ GetLargestComponent(typename TImage::Pointer image)
   {
     relabel->Update();
   }
-  catch (itk::ExceptionObject & excep)
+  catch (const itk::ExceptionObject & excep)
   {
     std::cerr << "Relabel: exception caught !" << std::endl;
     std::cerr << excep << std::endl;

--- a/Examples/ClusterImageStatistics.cxx
+++ b/Examples/ClusterImageStatistics.cxx
@@ -117,7 +117,7 @@ ClusterStatistics(unsigned int argc, char * argv[])
     {
       relabel->Update();
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cerr << "Relabel: exception caught !" << std::endl;
       std::cerr << excep << std::endl;

--- a/Examples/ConformalMapping.cxx
+++ b/Examples/ConformalMapping.cxx
@@ -190,7 +190,7 @@ MapToSphere(typename TImage::Pointer image, int fixdir, float e)
   {
     meshSource->Update();
   }
-  catch (itk::ExceptionObject & exp)
+  catch (const itk::ExceptionObject & exp)
   {
     std::cout << "Exception thrown during Update() " << std::endl;
     std::cout << exp << std::endl;
@@ -981,7 +981,7 @@ ConformalMapping(std::vector<std::string> args, std::ostream * out_stream = null
     {
       readfilter->Update();
     }
-    catch (itk::ExceptionObject & e)
+    catch (const itk::ExceptionObject & e)
     {
       std::cout << "Exception caught during reference file reading " << std::endl;
       std::cout << e << std::endl;
@@ -1006,7 +1006,7 @@ ConformalMapping(std::vector<std::string> args, std::ostream * out_stream = null
     {
       readfilter->Update();
     }
-    catch (itk::ExceptionObject & e)
+    catch (const itk::ExceptionObject & e)
     {
       std::cout << "Exception caught during reference file reading " << std::endl;
       std::cout << e << std::endl;

--- a/Examples/DenoiseImage.cxx
+++ b/Examples/DenoiseImage.cxx
@@ -294,7 +294,7 @@ Denoise(itk::ants::CommandLineParser * parser)
     // denoiser->DebugOn();
     denoiser->Update();
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     if (verbose)
     {

--- a/Examples/ImageCompare.cxx
+++ b/Examples/ImageCompare.cxx
@@ -157,7 +157,7 @@ RegressionTestImage(const char * testImageFilename,
   {
     baselineReader->UpdateLargestPossibleRegion();
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cout << "Exception detected while reading " << baselineImageFilename << " : " << e.GetDescription();
     return 1000;
@@ -170,7 +170,7 @@ RegressionTestImage(const char * testImageFilename,
   {
     testReader->UpdateLargestPossibleRegion();
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cout << "Exception detected while reading " << testImageFilename << " : " << e.GetDescription() << std::endl;
     return 1000;

--- a/Examples/ImageMath_Templates.hxx
+++ b/Examples/ImageMath_Templates.hxx
@@ -260,7 +260,7 @@ FrobeniusNormOfMatrixDifference(int argc, char * argv[])
   {
     transformReader1->Update();
   }
-  catch (itk::ExceptionObject & /* excp */)
+  catch (const itk::ExceptionObject & /* excp */)
   {
     std::cout << "no transformation1 that can be read" << fn1 << std::endl;
     return 0;
@@ -271,7 +271,7 @@ FrobeniusNormOfMatrixDifference(int argc, char * argv[])
   {
     transformReader2->Update();
   }
-  catch (itk::ExceptionObject & /* excp */)
+  catch (const itk::ExceptionObject & /* excp */)
   {
     std::cout << "no transformation2 that can be read" << fn2 << std::endl;
     return 0;
@@ -485,7 +485,7 @@ GetLargestComponent(int argc, char * argv[])
   {
     relabel->Update();
   }
-  catch (itk::ExceptionObject & /* excep */)
+  catch (const itk::ExceptionObject & /* excep */)
   {
     // std::cout << "Relabel: exception caught !" << std::endl;
     // std::cout << excep << std::endl;
@@ -603,7 +603,7 @@ ClusterThresholdVariate(int argc, char * argv[])
   {
     relabel->Update();
   }
-  catch (itk::ExceptionObject & /* excep */)
+  catch (const itk::ExceptionObject & /* excep */)
   {
     // std::cout << "Relabel: exception caught !" << std::endl;
     // std::cout << excep << std::endl;
@@ -2959,7 +2959,7 @@ SliceTimingCorrection(int argc, char * argv[])
   {
     filter->Update();
   }
-  catch (itk::ExceptionObject & /* exp */)
+  catch (const itk::ExceptionObject & /* exp */)
   {
     // std::cout << "Exception caught!" << std::endl;
     // std::cout << exp << std::endl;
@@ -3781,7 +3781,7 @@ TimeSeriesToMatrix(int argc, char * argv[])
     {
       writer->Write();
     }
-    catch (itk::ExceptionObject & /* exp */)
+    catch (const itk::ExceptionObject & /* exp */)
     {
       // std::cout << "Exception caught!" << std::endl;
       // std::cout << exp << std::endl;
@@ -4498,7 +4498,7 @@ CompCorrAuto(int argc, char * argv[])
   {
     writer->Write();
   }
-  catch (itk::ExceptionObject & /* exp */)
+  catch (const itk::ExceptionObject & /* exp */)
   {
     // std::cout << "Exception caught!" << std::endl;
     // std::cout << exp << std::endl;
@@ -4840,7 +4840,7 @@ ThreeTissueConfounds(int argc, char * argv[])
   {
     writer->Write();
   }
-  catch (itk::ExceptionObject & /* exp */)
+  catch (const itk::ExceptionObject & /* exp */)
   {
     // std::cout << "Exception caught!" << std::endl;
     // std::cout << exp << std::endl;
@@ -6222,7 +6222,7 @@ TensorFunctions(int argc, char * argv[])
     {
       whichvec = std::stoi(fn2.c_str());
     }
-    catch (std::invalid_argument & itkNotUsed(e))
+    catch (const std::invalid_argument & itkNotUsed(e))
     {
       // arg is not whichvec
     }
@@ -8680,7 +8680,7 @@ FillHoles(int argc, char * argv[])
   {
     relabel->Update();
   }
-  catch (itk::ExceptionObject & /* excep */)
+  catch (const itk::ExceptionObject & /* excep */)
   {
     // std::cout << "Relabel: exception caught !" << std::endl;
     // std::cout << excep << std::endl;
@@ -9903,7 +9903,7 @@ DiceAndMinDistSum(int argc, char * argv[])
     {
       OutputCSV->Write();
     }
-    catch (itk::ExceptionObject & /* exp */)
+    catch (const itk::ExceptionObject & /* exp */)
     {
       // std::cout << "Exception caught!" << std::endl;
       // std::cout << exp << std::endl;
@@ -9945,7 +9945,7 @@ DiceAndMinDistSum(int argc, char * argv[])
       OutputCSV->Write();
       // std::cout << "Output written to " << outname.c_str() << ".csv." << std::endl;
     }
-    catch (itk::ExceptionObject & /* exp */)
+    catch (const itk::ExceptionObject & /* exp */)
     {
       // std::cout << "Exception caught!" << std::endl;
       // std::cout << exp << std::endl;
@@ -11441,7 +11441,7 @@ ConvertImageSetToMatrix(unsigned int argc, char * argv[])
     {
       writer->Write();
     }
-    catch (itk::ExceptionObject & /* exp */)
+    catch (const itk::ExceptionObject & /* exp */)
     {
       // std::cout << "Exception caught!" << std::endl;
       // std::cout << exp << std::endl;
@@ -11577,7 +11577,7 @@ RandomlySampleImageSetToCSV(unsigned int argc, char * argv[])
     {
       writer->Write();
     }
-    catch (itk::ExceptionObject & /* exp */)
+    catch (const itk::ExceptionObject & /* exp */)
     {
       // std::cout << "Exception caught!" << std::endl;
       // std::cout << exp << std::endl;
@@ -11757,7 +11757,7 @@ ConvertImageSetToEigenvectors(unsigned int argc, char * argv[])
       {
         writer->Write();
       }
-      catch (itk::ExceptionObject & /* exp */)
+      catch (const itk::ExceptionObject & /* exp */)
       {
         // std::cout << "Exception caught!" << std::endl;
         // std::cout << exp << std::endl;
@@ -11782,7 +11782,7 @@ ConvertImageSetToEigenvectors(unsigned int argc, char * argv[])
     {
       writer->Write();
     }
-    catch (itk::ExceptionObject & /* exp */)
+    catch (const itk::ExceptionObject & /* exp */)
     {
       // std::cout << "Exception caught!" << std::endl;
       // std::cout << exp << std::endl;

--- a/Examples/ImageSetStatistics.cxx
+++ b/Examples/ImageSetStatistics.cxx
@@ -284,7 +284,7 @@ GetClusterStat(typename TImage::Pointer image,
   {
     relabel->Update();
   }
-  catch (itk::ExceptionObject & excep)
+  catch (const itk::ExceptionObject & excep)
   {
     std::cout << "Relabel: exception caught !" << std::endl;
     std::cout << excep << std::endl;

--- a/Examples/KellyKapowski.cxx
+++ b/Examples/KellyKapowski.cxx
@@ -372,7 +372,7 @@ DiReCT(itk::ants::CommandLineParser * parser)
   {
     direct->Update(); // causes problems with ANTsR , unknown reason
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     if (verbose)
     {

--- a/Examples/LabelClustersUniquely.cxx
+++ b/Examples/LabelClustersUniquely.cxx
@@ -99,7 +99,7 @@ LabelUniquely(int argc, char * argv[])
   {
     relabel->Update();
   }
-  catch (itk::ExceptionObject & excep)
+  catch (const itk::ExceptionObject & excep)
   {
     std::cout << "Relabel: exception caught !" << std::endl;
     std::cout << excep << std::endl;

--- a/Examples/LabelGeometryMeasures.cxx
+++ b/Examples/LabelGeometryMeasures.cxx
@@ -230,7 +230,7 @@ LabelGeometryMeasures(int argc, char * argv[])
     {
       writer->Write();
     }
-    catch (itk::ExceptionObject & exp)
+    catch (const itk::ExceptionObject & exp)
     {
       std::cerr << "Exception caught!" << std::endl;
       std::cerr << exp << std::endl;

--- a/Examples/LabelOverlapMeasures.cxx
+++ b/Examples/LabelOverlapMeasures.cxx
@@ -120,7 +120,7 @@ LabelOverlapMeasures(int argc, char * argv[])
     {
       writer->Write();
     }
-    catch (itk::ExceptionObject & exp)
+    catch (const itk::ExceptionObject & exp)
     {
       std::cerr << "Exception caught!" << std::endl;
       std::cerr << exp << std::endl;

--- a/Examples/LesionFilling.cxx
+++ b/Examples/LesionFilling.cxx
@@ -53,7 +53,7 @@ LesionFilling(int argc, char * argv[])
   {
     LesionReader->Update();
   }
-  catch (itk::ExceptionObject & itkNotUsed(excp))
+  catch (const itk::ExceptionObject & itkNotUsed(excp))
   {
     std::cout << "no lesion mask that can be read" << std::endl;
     return 0;
@@ -64,7 +64,7 @@ LesionFilling(int argc, char * argv[])
   {
     T1Reader->Update();
   }
-  catch (itk::ExceptionObject & itkNotUsed(excp))
+  catch (const itk::ExceptionObject & itkNotUsed(excp))
   {
     std::cout << "no T1 image that can be read" << std::endl;
     return 0;
@@ -222,7 +222,7 @@ LesionFilling(int argc, char * argv[])
   {
     writer->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "ExceptionObject caught !" << std::endl;
     std::cerr << err << std::endl;

--- a/Examples/N3BiasFieldCorrection.cxx
+++ b/Examples/N3BiasFieldCorrection.cxx
@@ -550,7 +550,7 @@ N3(itk::ants::CommandLineParser * parser)
     // correcter->DebugOn();
     correcter->Update();
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     if (verbose)
     {

--- a/Examples/N4BiasFieldCorrection.cxx
+++ b/Examples/N4BiasFieldCorrection.cxx
@@ -411,7 +411,7 @@ N4(itk::ants::CommandLineParser * parser)
     // correcter->DebugOn();
     correcter->Update();
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     if (verbose)
     {

--- a/Examples/NonLocalSuperResolution.cxx
+++ b/Examples/NonLocalSuperResolution.cxx
@@ -353,7 +353,7 @@ NonLocalSuperResolution(itk::ants::CommandLineParser * parser)
     // superresoluter->DebugOn();
     superresoluter->Update();
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     if (verbose)
     {

--- a/Examples/ResampleImageBySpacing.cxx
+++ b/Examples/ResampleImageBySpacing.cxx
@@ -152,7 +152,7 @@ ResampleImageBySpacing(std::vector<std::string> args, std::ostream * /*out_strea
           {
             smootherX->Update();
           }
-          catch (itk::ExceptionObject & excep)
+          catch (const itk::ExceptionObject & excep)
           {
             std::cout << "Exception catched !" << std::endl;
             std::cout << excep << std::endl;
@@ -285,7 +285,7 @@ ResampleImageBySpacing(std::vector<std::string> args, std::ostream * /*out_strea
           {
             smootherX->Update();
           }
-          catch (itk::ExceptionObject & excep)
+          catch (const itk::ExceptionObject & excep)
           {
             std::cout << "Exception catched !" << std::endl;
             std::cout << excep << std::endl;
@@ -414,7 +414,7 @@ ResampleImageBySpacing(std::vector<std::string> args, std::ostream * /*out_strea
           {
             smootherX->Update();
           }
-          catch (itk::ExceptionObject & excep)
+          catch (const itk::ExceptionObject & excep)
           {
             std::cout << "Exception catched !" << std::endl;
             std::cout << excep << std::endl;

--- a/Examples/WarpImageMultiTransform.cxx
+++ b/Examples/WarpImageMultiTransform.cxx
@@ -865,7 +865,7 @@ WarpImageMultiTransform(std::vector<std::string> args, std::ostream * /*out_stre
           return EXIT_FAILURE;
       }
     }
-    catch (itk::ExceptionObject & e)
+    catch (const itk::ExceptionObject & e)
     {
       std::cout << "Exception caught during WarpImageMultiTransform." << std::endl;
       std::cout << e << std::endl;

--- a/Examples/antsApplyTransforms.cxx
+++ b/Examples/antsApplyTransforms.cxx
@@ -792,7 +792,7 @@ antsApplyTransforms(itk::ants::CommandLineParser::Pointer & parser, unsigned int
 
           ANTs::WriteImage<OutputImageType>(caster->GetOutput(), (outputFileName).c_str());
         }
-        catch (itk::ExceptionObject & err)
+        catch (const itk::ExceptionObject & err)
         {
           if (verbose)
           {

--- a/Examples/antsApplyTransformsToPoints.cxx
+++ b/Examples/antsApplyTransformsToPoints.cxx
@@ -67,7 +67,7 @@ antsApplyTransformsToPoints(itk::ants::CommandLineParser::Pointer & parser)
       {
         reader->Update();
       }
-      catch (itk::ExceptionObject & exp)
+      catch (const itk::ExceptionObject & exp)
       {
         std::cerr << "Exception caught!" << std::endl;
         std::cerr << exp << std::endl;
@@ -212,7 +212,7 @@ antsApplyTransformsToPoints(itk::ants::CommandLineParser::Pointer & parser)
         {
           writer->Write();
         }
-        catch (itk::ExceptionObject & exp)
+        catch (const itk::ExceptionObject & exp)
         {
           std::cerr << "Exception caught!" << std::endl;
           std::cerr << exp << std::endl;

--- a/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
+++ b/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
@@ -480,7 +480,7 @@ public:
     {
       writer->Update();
     }
-    catch (itk::ExceptionObject & err)
+    catch (const itk::ExceptionObject & err)
     {
       std::cout << "Can't write warped image " << currentFileName.str().c_str() << std::endl;
       std::cout << "Exception Object caught: " << std::endl;

--- a/Examples/antsJointFusion.cxx
+++ b/Examples/antsJointFusion.cxx
@@ -497,7 +497,7 @@ antsJointFusion(itk::ants::CommandLineParser * parser)
   {
     fusionFilter->Update();
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     if (verbose)
     {

--- a/Examples/antsJointTensorFusion.cxx
+++ b/Examples/antsJointTensorFusion.cxx
@@ -441,7 +441,7 @@ antsJointTensorFusion(itk::ants::CommandLineParser * parser)
   {
     fusionFilter->Update();
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     if (verbose)
     {

--- a/Examples/antsLandmarkBasedTransformInitializer.cxx
+++ b/Examples/antsLandmarkBasedTransformInitializer.cxx
@@ -183,7 +183,7 @@ InitializeLinearTransform(int itkNotUsed(argc), char * argv[])
   {
     transformWriter->Update();
   }
-  catch (itk::ExceptionObject & itkNotUsed(err))
+  catch (const itk::ExceptionObject & itkNotUsed(err))
   {
     std::cerr << "Exception in writing transform file: " << argv[5] << std::endl;
     return EXIT_FAILURE;

--- a/Examples/antsMotionCorr.cxx
+++ b/Examples/antsMotionCorr.cxx
@@ -1269,7 +1269,7 @@ ants_motion(itk::ants::CommandLineParser * parser)
             std::cout << std::endl << "*** Running affine registration ***" << timedim << std::endl << std::endl;
           affineRegistration->Update();
         }
-        catch (itk::ExceptionObject & e)
+        catch (const itk::ExceptionObject & e)
         {
           std::cerr << "Exception caught: " << e << std::endl;
           return EXIT_FAILURE;
@@ -1347,7 +1347,7 @@ ants_motion(itk::ants::CommandLineParser * parser)
             std::cout << std::endl << "*** Running rigid registration ***" << timedim << std::endl << std::endl;
           rigidRegistration->Update();
         }
-        catch (itk::ExceptionObject & e)
+        catch (const itk::ExceptionObject & e)
         {
           std::cerr << "Exception caught: " << e << std::endl;
           return EXIT_FAILURE;
@@ -1446,7 +1446,7 @@ ants_motion(itk::ants::CommandLineParser * parser)
         {
           displacementFieldRegistration->Update();
         }
-        catch (itk::ExceptionObject & e)
+        catch (const itk::ExceptionObject & e)
         {
           std::cerr << "Exception caught: " << e << std::endl;
           return EXIT_FAILURE;
@@ -1567,7 +1567,7 @@ ants_motion(itk::ants::CommandLineParser * parser)
         {
           displacementFieldRegistration->Update();
         }
-        catch (itk::ExceptionObject & e)
+        catch (const itk::ExceptionObject & e)
         {
           std::cerr << "Exception caught: " << e << std::endl;
           return EXIT_FAILURE;

--- a/Examples/antsRegistration.cxx
+++ b/Examples/antsRegistration.cxx
@@ -769,7 +769,7 @@ antsRegistration(std::vector<std::string> args, std::ostream * /*out_stream = nu
       }
     }
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "Exception Object caught: " << std::endl;
     std::cerr << err << std::endl;

--- a/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
+++ b/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
@@ -419,7 +419,7 @@ public:
     {
       writer->Update();
     }
-    catch (itk::ExceptionObject & err)
+    catch (const itk::ExceptionObject & err)
     {
       std::cout << "Can't write warped image " << currentFileName.str().c_str() << std::endl;
       std::cout << "Exception Object caught: " << std::endl;

--- a/Examples/antsRegistrationTemplateHeader.h
+++ b/Examples/antsRegistrationTemplateHeader.h
@@ -1445,7 +1445,7 @@ DoRegistration(typename ParserType::Pointer & parser)
             velocityFieldWriter->Update();
           }
         }
-        catch (itk::ExceptionObject & err)
+        catch (const itk::ExceptionObject & err)
         {
           if (verbose)
           {

--- a/Examples/antsSliceRegularizedRegistration.cxx
+++ b/Examples/antsSliceRegularizedRegistration.cxx
@@ -781,7 +781,7 @@ ants_slice_regularized_registration(itk::ants::CommandLineParser * parser)
             {
               translationRegistration->Update();
             }
-            catch (itk::ExceptionObject & e)
+            catch (const itk::ExceptionObject & e)
             {
               std::cerr << "Exception caught: " << e << std::endl;
               return EXIT_FAILURE;

--- a/Examples/iMath.cxx
+++ b/Examples/iMath.cxx
@@ -152,7 +152,7 @@ iMathHelperAll(int argc, char ** argv)
     {
       output = iMathBlobDetector<ImageType>(input, nBlobs);
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cout << "BlobDetector: exception caught !" << std::endl;
       std::cout << excep << std::endl;
@@ -188,7 +188,7 @@ iMathHelperAll(int argc, char ** argv)
     {
       output = iMathCanny<ImageType>(input, sigma, lower, upper);
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cout << "Canny: exception caught !" << std::endl;
       std::cout << excep << std::endl;
@@ -222,7 +222,7 @@ iMathHelperAll(int argc, char ** argv)
     {
       output = iMathDistanceMap<ImageType>(input, useSpacing);
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cout << "DistanceMap: exception caught !" << std::endl;
       std::cout << excep << std::endl;
@@ -256,7 +256,7 @@ iMathHelperAll(int argc, char ** argv)
     {
       output = iMathFillHoles<ImageType>(input, holeType);
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cout << "FillHoles: exception caught !" << std::endl;
       std::cout << excep << std::endl;
@@ -289,7 +289,7 @@ iMathHelperAll(int argc, char ** argv)
     {
       output = iMathGC<ImageType>(input, radius);
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cout << "GC: exception caught !" << std::endl;
       std::cout << excep << std::endl;
@@ -322,7 +322,7 @@ iMathHelperAll(int argc, char ** argv)
     {
       output = iMathGD<ImageType>(input, radius);
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cout << "GD: exception caught !" << std::endl;
       std::cout << excep << std::endl;
@@ -355,7 +355,7 @@ iMathHelperAll(int argc, char ** argv)
     {
       output = iMathGE<ImageType>(input, radius);
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cout << "GE: exception caught !" << std::endl;
       std::cout << excep << std::endl;
@@ -388,7 +388,7 @@ iMathHelperAll(int argc, char ** argv)
     {
       output = iMathGO<ImageType>(input, radius);
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cout << "GO: exception caught !" << std::endl;
       std::cout << excep << std::endl;
@@ -420,7 +420,7 @@ iMathHelperAll(int argc, char ** argv)
     {
       output = iMathGetLargestComponent<ImageType>(input, minSize);
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cout << "GetLargestComponents: exception caught !" << std::endl;
       std::cout << excep << std::endl;
@@ -458,7 +458,7 @@ iMathHelperAll(int argc, char ** argv)
     {
       output = iMathGrad<ImageType>(input, sigma, normalize);
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cout << "Grad: exception caught !" << std::endl;
       std::cout << excep << std::endl;
@@ -495,7 +495,7 @@ iMathHelperAll(int argc, char ** argv)
       std::cout << " a " << alpha << " b " << beta << std::endl;
       output = iMathHistogramEqualization<ImageType>(input, alpha, beta, 1);
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cout << "HistogramEqualization: exception caught !" << std::endl;
       std::cout << excep << std::endl;
@@ -533,7 +533,7 @@ iMathHelperAll(int argc, char ** argv)
     {
       output = iMathLaplacian<ImageType>(input, sigma, normalize);
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cout << "Laplacian: exception caught !" << std::endl;
       std::cout << excep << std::endl;
@@ -601,7 +601,7 @@ iMathHelperAll(int argc, char ** argv)
     {
       output = iMathMC<ImageType>(input, radius, value, shape, parametric, lines, thickness, includeCenter);
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cout << "MC: exception caught !" << std::endl;
       std::cout << excep << std::endl;
@@ -668,7 +668,7 @@ iMathHelperAll(int argc, char ** argv)
     {
       output = iMathMD<ImageType>(input, radius, value, shape, parametric, lines, thickness, includeCenter);
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cout << "MD: exception caught !" << std::endl;
       std::cout << excep << std::endl;
@@ -734,7 +734,7 @@ iMathHelperAll(int argc, char ** argv)
     {
       output = iMathME<ImageType>(input, radius, value, shape, parametric, lines, thickness, includeCenter);
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cout << "ME: exception caught !" << std::endl;
       std::cout << excep << std::endl;
@@ -800,7 +800,7 @@ iMathHelperAll(int argc, char ** argv)
     {
       output = iMathMO<ImageType>(input, radius, value, shape, parametric, lines, thickness, includeCenter);
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cout << "MO: exception caught !" << std::endl;
       std::cout << excep << std::endl;
@@ -833,7 +833,7 @@ iMathHelperAll(int argc, char ** argv)
     {
       output = iMathMaurerDistance<ImageType>(input, foreground);
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cout << "MaurerDistance: exception caught !" << std::endl;
       std::cout << excep << std::endl;
@@ -859,7 +859,7 @@ iMathHelperAll(int argc, char ** argv)
     {
       output = iMathNormalize<ImageType>(input);
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cout << "Normalize: exception caught !" << std::endl;
       std::cout << excep << std::endl;
@@ -888,7 +888,7 @@ iMathHelperAll(int argc, char ** argv)
     {
       output = iMathPad<ImageType>(input, padding);
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cout << "Pad: exception caught !" << std::endl;
       std::cout << excep << std::endl;
@@ -926,7 +926,7 @@ iMathHelperAll(int argc, char ** argv)
     {
       output = iMathPeronaMalik<ImageType>(input, nIterations, conductance);
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cout << "PeronaMalik: exception caught !" << std::endl;
       std::cout << excep << std::endl;
@@ -952,7 +952,7 @@ iMathHelperAll(int argc, char ** argv)
     {
       output = iMathSharpen<ImageType>(input);
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cout << "Sharpen: exception caught !" << std::endl;
       std::cout << excep << std::endl;
@@ -1042,7 +1042,7 @@ iMathHelperAll(int argc, char ** argv)
     {
       output = iMathTruncateIntensity<ImageType>(input, lowerQ, upperQ, nBins, mask);
     }
-    catch (itk::ExceptionObject & excep)
+    catch (const itk::ExceptionObject & excep)
     {
       std::cout << "TruncateIntensity: exception caught !" << std::endl;
       std::cout << excep << std::endl;

--- a/Examples/iMathFunctions2.hxx
+++ b/Examples/iMathFunctions2.hxx
@@ -175,7 +175,7 @@ iMathGetLargestComponent(typename ImageType::Pointer image, /*3*/
   {
     relabel->Update();
   }
-  catch (itk::ExceptionObject & itkNotUsed(excep))
+  catch (const itk::ExceptionObject & itkNotUsed(excep))
   {
     // std::cout << "Relabel: exception caught !" << std::endl;
     // std::cout << excep << std::endl;

--- a/Examples/itkTestMain.h
+++ b/Examples/itkTestMain.h
@@ -270,7 +270,7 @@ RegressionTestImage(const char * testImageFilename,
   {
     baselineReader->UpdateLargestPossibleRegion();
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << "Exception detected while reading " << baselineImageFilename << " : " << e.GetDescription();
     return 1000;
@@ -283,7 +283,7 @@ RegressionTestImage(const char * testImageFilename,
   {
     testReader->UpdateLargestPossibleRegion();
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << "Exception detected while reading " << testImageFilename << " : " << e.GetDescription() << std::endl;
     return 1000;

--- a/Examples/itkantsRegistrationHelper.h
+++ b/Examples/itkantsRegistrationHelper.h
@@ -1077,7 +1077,7 @@ private:
       transformObserver->Execute(registrationMethod, itk::StartEvent());
       registrationMethod->Update();
     }
-    catch (itk::ExceptionObject & e)
+    catch (const itk::ExceptionObject & e)
     {
       this->Logger() << "Exception caught: " << e << std::endl;
       return EXIT_FAILURE;

--- a/Examples/itkantsRegistrationHelper.hxx
+++ b/Examples/itkantsRegistrationHelper.hxx
@@ -1817,7 +1817,7 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
           displacementFieldRegistrationObserver->Execute(registrationMethod, itk::StartEvent());
           registrationMethod->Update();
         }
-        catch (itk::ExceptionObject & e)
+        catch (const itk::ExceptionObject & e)
         {
           this->Logger() << "Exception caught: " << e << std::endl;
           return EXIT_FAILURE;
@@ -1950,7 +1950,7 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
           displacementFieldRegistrationObserver->Execute(registrationMethod, itk::StartEvent());
           registrationMethod->Update();
         }
-        catch (itk::ExceptionObject & e)
+        catch (const itk::ExceptionObject & e)
         {
           this->Logger() << "Exception caught: " << e << std::endl;
           return EXIT_FAILURE;
@@ -2172,7 +2172,7 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
           displacementFieldRegistrationObserver2->Execute(displacementFieldRegistration, itk::StartEvent());
           displacementFieldRegistration->Update();
         }
-        catch (itk::ExceptionObject & e)
+        catch (const itk::ExceptionObject & e)
         {
           this->Logger() << "Exception caught: " << e << std::endl;
           return EXIT_FAILURE;
@@ -2332,7 +2332,7 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
             displacementFieldRegistrationObserver->Execute(registrationMethod, itk::StartEvent());
             registrationMethod->Update();
           }
-          catch (itk::ExceptionObject & e)
+          catch (const itk::ExceptionObject & e)
           {
             this->Logger() << "Exception caught: " << e << std::endl;
             return EXIT_FAILURE;
@@ -2447,7 +2447,7 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
             displacementFieldRegistrationObserver->Execute(registrationMethod, itk::StartEvent());
             registrationMethod->Update();
           }
-          catch (itk::ExceptionObject & e)
+          catch (const itk::ExceptionObject & e)
           {
             this->Logger() << "Exception caught: " << e << std::endl;
             return EXIT_FAILURE;
@@ -2683,7 +2683,7 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
           velocityFieldRegistrationObserver->Execute(velocityFieldRegistration, itk::StartEvent());
           velocityFieldRegistration->Update();
         }
-        catch (itk::ExceptionObject & e)
+        catch (const itk::ExceptionObject & e)
         {
           this->Logger() << "Exception caught: " << e << std::endl;
           return EXIT_FAILURE;
@@ -2903,7 +2903,7 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
             velocityFieldRegistrationObserver->Execute(velocityFieldRegistration, itk::StartEvent());
             velocityFieldRegistration->Update();
           }
-          catch (itk::ExceptionObject & e)
+          catch (const itk::ExceptionObject & e)
           {
             this->Logger() << "Exception caught: " << e << std::endl;
             return EXIT_FAILURE;
@@ -3062,7 +3062,7 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
             velocityFieldRegistrationObserver->Execute(velocityFieldRegistration, itk::StartEvent());
             velocityFieldRegistration->Update();
           }
-          catch (itk::ExceptionObject & e)
+          catch (const itk::ExceptionObject & e)
           {
             this->Logger() << "Exception caught: " << e << std::endl;
             return EXIT_FAILURE;
@@ -3226,7 +3226,7 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
           displacementFieldRegistrationObserver->Execute(displacementFieldRegistration, itk::StartEvent());
           displacementFieldRegistration->Update();
         }
-        catch (itk::ExceptionObject & e)
+        catch (const itk::ExceptionObject & e)
         {
           this->Logger() << "Exception caught: " << e << std::endl;
           return EXIT_FAILURE;
@@ -3408,7 +3408,7 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
           displacementFieldRegistrationObserver->Execute(displacementFieldRegistration, itk::StartEvent());
           displacementFieldRegistration->Update();
         }
-        catch (itk::ExceptionObject & e)
+        catch (const itk::ExceptionObject & e)
         {
           this->Logger() << "Exception caught: " << e << std::endl;
           return EXIT_FAILURE;
@@ -3513,7 +3513,7 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
           bsplineObserver->Execute(registrationMethod, itk::StartEvent());
           registrationMethod->Update();
         }
-        catch (itk::ExceptionObject & e)
+        catch (const itk::ExceptionObject & e)
         {
           this->Logger() << "Exception caught: " << e << std::endl;
           return EXIT_FAILURE;

--- a/Examples/sccan.cxx
+++ b/Examples/sccan.cxx
@@ -157,7 +157,7 @@ WriteSortedVariatesToSpatialImage(std::string              filename,
   {
     writer1->Write();
   }
-  catch (itk::ExceptionObject & exp)
+  catch (const itk::ExceptionObject & exp)
   {
     // std::cerr << "Exception caught!" << std::endl;
     // std::cerr << exp << std::endl;
@@ -199,7 +199,7 @@ WriteSortedVariatesToSpatialImage(std::string              filename,
   {
     writerROI->Write();
   }
-  catch (itk::ExceptionObject & exp)
+  catch (const itk::ExceptionObject & exp)
   {
     // std::cerr << "Exception caught!" << std::endl;
     // std::cerr << exp << std::endl;
@@ -235,7 +235,7 @@ WriteSortedVariatesToSpatialImage(std::string              filename,
     {
       writer->Write();
     }
-    catch (itk::ExceptionObject & exp)
+    catch (const itk::ExceptionObject & exp)
     {
       // std::cerr << "Exception caught!" << std::endl;
       // std::cerr << exp << std::endl;
@@ -286,7 +286,7 @@ WriteVariatesToSpatialImage(std::string              filename,
   {
     writer->Write();
   }
-  catch (itk::ExceptionObject & itkNotUsed(exp))
+  catch (const itk::ExceptionObject & itkNotUsed(exp))
   {
     // std::cerr << "Exception caught!" << std::endl;
     // std::cerr << exp << std::endl;
@@ -320,7 +320,7 @@ WriteVariatesToSpatialImage(std::string              filename,
     {
       writer->Write();
     }
-    catch (itk::ExceptionObject & itkNotUsed(exp))
+    catch (const itk::ExceptionObject & itkNotUsed(exp))
     {
       // std::cerr << "Exception caught!" << std::endl;
       // std::cerr << exp << std::endl;
@@ -346,7 +346,7 @@ WriteVariatesToSpatialImage(std::string              filename,
     {
       writer->Write();
     }
-    catch (itk::ExceptionObject & itkNotUsed(exp))
+    catch (const itk::ExceptionObject & itkNotUsed(exp))
     {
       // std::cerr << "Exception caught!" << std::endl;
       // std::cerr << exp << std::endl;
@@ -508,7 +508,7 @@ ReadMatrixFromCSVorImageSet(std::string matname, vnl_matrix<PixelType> & p)
     {
       reader->Update();
     }
-    catch (itk::ExceptionObject & itkNotUsed(exp))
+    catch (const itk::ExceptionObject & itkNotUsed(exp))
     {
       // std::cerr << "Exception caught!" << std::endl;
       // std::cerr << exp << std::endl;
@@ -628,7 +628,7 @@ ConvertImageListToMatrix(std::string imagelist, std::string maskfn, std::string 
     {
       writer->Write();
     }
-    catch (itk::ExceptionObject & itkNotUsed(exp))
+    catch (const itk::ExceptionObject & itkNotUsed(exp))
     {
       // std::cerr << "Exception caught!" << std::endl;
       // std::cerr << exp << std::endl;
@@ -863,7 +863,7 @@ ConvertTimeSeriesImageToMatrix(std::string imagefn,
     {
       writer->Write();
     }
-    catch (itk::ExceptionObject & itkNotUsed(exp))
+    catch (const itk::ExceptionObject & itkNotUsed(exp))
     {
       // std::cerr << "Exception caught!" << std::endl;
       // std::cerr << exp << std::endl;
@@ -909,7 +909,7 @@ ConvertTimeSeriesImageToMatrix(std::string imagefn,
   {
     writer->Write();
   }
-  catch (itk::ExceptionObject & itkNotUsed(exp))
+  catch (const itk::ExceptionObject & itkNotUsed(exp))
   {
     // std::cerr << "Exception caught!" << std::endl;
     // std::cerr << exp << std::endl;

--- a/Examples/simpleSynRegistration.cxx
+++ b/Examples/simpleSynRegistration.cxx
@@ -134,7 +134,7 @@ simpleSynRegistration(std::vector<std::string> args, std::ostream * /*out_stream
   {
     fixedImage->Update();
   }
-  catch (itk::ExceptionObject & excp)
+  catch (const itk::ExceptionObject & excp)
   {
     std::cerr << excp << std::endl;
     return EXIT_FAILURE;
@@ -148,7 +148,7 @@ simpleSynRegistration(std::vector<std::string> args, std::ostream * /*out_stream
   {
     movingImage->Update();
   }
-  catch (itk::ExceptionObject & excp)
+  catch (const itk::ExceptionObject & excp)
   {
     std::cerr << excp << std::endl;
     return EXIT_FAILURE;

--- a/ImageRegistration/ANTS_affine_registration.h
+++ b/ImageRegistration/ANTS_affine_registration.h
@@ -111,7 +111,7 @@ write_transform_file(TransformPointerType & transform, StringType filename)
   {
     transform_writer->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl
               << "Exception in writing transform file: " << std::endl
@@ -141,7 +141,7 @@ read_transform_file(StringType filename, CastTransformPointerType & transform)
   {
     tran_reader->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cout << err << std::endl;
     std::cout << "Exception caught in reading tran para file: " << filename << std::endl;
@@ -623,7 +623,7 @@ get_cost_value_mmi(ImagePointerType     fixedImage,
   {
     rval = mattesMutualInfo->GetValue(para);
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl
               << "Exception caught in computing mattesMutualInfo after registration" << std::endl
@@ -643,7 +643,7 @@ get_cost_value_mmi(ImagePointerType     fixedImage,
   {
     rval0 = mattesMutualInfo->GetValue(para0);
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl
               << "Exception caught in computing mattesMutualInfo before registration" << std::endl
@@ -682,7 +682,7 @@ register_image_cxy(ImagePointerType fixed_image, ImagePointerType moving_image, 
     initializer->InitializeTransform();
     transform->SetAngle(0.0);
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!1" << std::endl << "Exception in InitializeTransform" << std::endl;
     return false;
@@ -720,7 +720,7 @@ register_image_cxyz(ImagePointerType fixed_image, ImagePointerType moving_image,
     initializer->MomentsOn();
     initializer->InitializeTransform();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!1" << std::endl << "Exception in InitializeTransform" << std::endl;
     return false;
@@ -854,7 +854,7 @@ register_image_affine3d_mres_mask(ImagePointerType                  fixed_image,
   {
     registration->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cout << "ExceptionObject caught !" << std::endl;
     std::cout << err << std::endl;
@@ -1006,7 +1006,7 @@ register_image_affine2d_mres_mask(ImagePointerType                  fixed_image,
   {
     registration->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cout << "ExceptionObject caught !" << std::endl;
     std::cout << err << std::endl;

--- a/ImageRegistration/ANTS_affine_registration2.h
+++ b/ImageRegistration/ANTS_affine_registration2.h
@@ -183,7 +183,7 @@ WriteAffineTransformFile(typename TransformType::Pointer & transform, const std:
   {
     transform_writer->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << err << std::endl
               << "Exception in writing transform file: " << std::endl
@@ -212,7 +212,7 @@ ReadAffineTransformFile(const std::string & filename, typename CastTransformType
   {
     tran_reader->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cout << err << std::endl;
     std::cout << "Exception caught in reading tran para file: " << filename << std::endl;
@@ -859,7 +859,7 @@ TestCostValueMMI(ImagePointerType fixedImage,
   {
     rval = mattesMutualInfo->GetValue(para);
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << err << std::endl
               << "Exception caught in computing mattesMutualInfo after registration" << std::endl
@@ -1124,7 +1124,7 @@ SymmRegisterImageAffineMutualInformationMultiResolution(RunningAffineCacheType &
         metric->GetValueAndDerivative(current_para, value, original_gradient);
         invmetric->GetValueAndDerivative(invtransform->GetParameters(), invvalue, invoriginal_gradient);
       }
-      catch (itk::ExceptionObject & err)
+      catch (const itk::ExceptionObject & err)
       {
         std::cout << "ExceptionObject caught !" << std::endl;
         std::cout << err << std::endl;
@@ -1327,7 +1327,7 @@ RegisterImageAffineMutualInformationMultiResolution(RunningAffineCacheType & run
       {
         metric->GetValueAndDerivative(current_para, value, original_gradient);
       }
-      catch (itk::ExceptionObject & err)
+      catch (const itk::ExceptionObject & err)
       {
         std::cout << "ExceptionObject caught !" << std::endl;
         std::cout << err << std::endl;
@@ -1473,7 +1473,7 @@ RegisterImageAffineMutualInformationMultiResolution(RunningAffineCacheType & run
         {
           metric->GetValueAndDerivative(current_para2, value, original_gradient);
         }
-        catch (itk::ExceptionObject & err)
+        catch (const itk::ExceptionObject & err)
         {
           std::cout << "ExceptionObject caught !" << std::endl;
           std::cout << err << std::endl;

--- a/Temporary/itkFEMConformalMap.cxx
+++ b/Temporary/itkFEMConformalMap.cxx
@@ -1011,7 +1011,7 @@ FEMConformalMap<TSurface, TImage, TDimension>::ConformalMap()
     {
       m_Solver.Read(f);
     }
-    catch (::itk::fem::FEMException & e)
+    catch (const ::itk::fem::FEMException & e)
     {
       ::std::cout << "Error reading FEM problem: " << filename << "!\n";
       e.Print(::std::cout);

--- a/Temporary/itkFEMDiscConformalMap.cxx
+++ b/Temporary/itkFEMDiscConformalMap.cxx
@@ -1403,7 +1403,7 @@ FEMDiscConformalMap<TSurface, TImage, TDimension>::ConformalMap()
     {
       m_Solver.Read(f);
     }
-    catch (::itk::fem::FEMException & e)
+    catch (const ::itk::fem::FEMException & e)
     {
       std::cout << "Error reading FEM problem: " << filename << "!\n";
       e.Print(std::cout);

--- a/Temporary/itkFEMElement3DMembrane1DOF.hxx
+++ b/Temporary/itkFEMElement3DMembrane1DOF.hxx
@@ -99,7 +99,7 @@ Element3DMembrane1DOF<TBaseClass>::Read(std::istream & f, void * info)
     }
     m_mat = dynamic_cast<const MaterialLinearElasticity *>(&*mats->Find(n));
   }
-  catch (FEMExceptionObjectNotFound & e)
+  catch (const FEMExceptionObjectNotFound & e)
   {
     throw FEMExceptionObjectNotFound(__FILE__, __LINE__, "Element3DMembrane1DOF::Read()", e.m_baseClassName, e.m_GN);
   }

--- a/Utilities/ReadWriteData.h
+++ b/Utilities/ReadWriteData.h
@@ -177,7 +177,7 @@ ReadTensorImage(itk::SmartPointer<TImageType> & target, const char * file, bool 
     {
       reffilter->Update();
     }
-    catch (itk::ExceptionObject & e)
+    catch (const itk::ExceptionObject & e)
     {
       std::cerr << "Exception caught during reference file reading " << std::endl;
       std::cerr << e << " file " << file << std::endl;
@@ -198,7 +198,7 @@ ReadTensorImage(itk::SmartPointer<TImageType> & target, const char * file, bool 
     {
       logFilter->Update();
     }
-    catch (itk::ExceptionObject & e)
+    catch (const itk::ExceptionObject & e)
     {
       std::cerr << "Exception caught during log tensor filter " << std::endl;
       std::cerr << e << " file " << file << std::endl;
@@ -259,7 +259,7 @@ ReadImage(itk::SmartPointer<TImageType> & target, const char * file)
     {
       reffilter->Update();
     }
-    catch (itk::ExceptionObject & e)
+    catch (const itk::ExceptionObject & e)
     {
       std::cerr << "Exception caught during reference file reading " << std::endl;
       std::cerr << e << " file " << file << std::endl;
@@ -291,7 +291,7 @@ ReadImage(char * fn)
   {
     reffilter->Update();
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << "Exception caught during image reference file reading " << std::endl;
     std::cerr << e << std::endl;
@@ -323,7 +323,7 @@ ReadTensorImage(char * fn, bool takelog = true)
   {
     reffilter->Update();
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << "Exception caught during tensor image reference file reading " << std::endl;
     std::cerr << e << std::endl;
@@ -375,7 +375,7 @@ ReadLabeledPointSet(itk::SmartPointer<TPointSet> & target,
   {
     reffilter->Update();
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << "Exception caught during point set reference file reading " << std::endl;
     std::cerr << e << std::endl;
@@ -471,7 +471,7 @@ ReadLabeledPointSet(char * fn)
   {
     reffilter->Update();
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << "Exception caught during point set reference file reading " << std::endl;
     std::cerr << e << std::endl;

--- a/Utilities/antsSCCANObject.hxx
+++ b/Utilities/antsSCCANObject.hxx
@@ -354,7 +354,7 @@ antsSCCANObject<TInputImage, TRealType>::ClusterThresholdVariate(
   {
     relabel->Update();
   }
-  catch (itk::ExceptionObject & excep)
+  catch (const itk::ExceptionObject & excep)
   {
     if (!this->m_Silent)
       std::cout << "Relabel: exception caught !" << std::endl;
@@ -480,7 +480,7 @@ antsSCCANObject<TInputImage, TRealType>::ClusterThresholdVariate4D(
   {
     relabel->Update();
   }
-  catch (itk::ExceptionObject & excep)
+  catch (const itk::ExceptionObject & excep)
   {
     if (!this->m_Silent)
       std::cout << "Relabel: exception caught !" << std::endl;

--- a/Utilities/itkSimulatedExponentialDisplacementFieldSource.hxx
+++ b/Utilities/itkSimulatedExponentialDisplacementFieldSource.hxx
@@ -164,7 +164,7 @@ SimulatedExponentialDisplacementFieldSource<TOutputImage>::GenerateData()
       {
         smoother->Update();
       }
-      catch (ExceptionObject & exc)
+      catch (const ExceptionObject & exc)
       {
         std::string msg("Caught exception: ");
         msg += exc.what();

--- a/Utilities/itkVectorImageFileReader.hxx
+++ b/Utilities/itkVectorImageFileReader.hxx
@@ -104,7 +104,7 @@ VectorImageFileReader<TImage, TVectorImage, ConvertPixelTraits>::GenerateOutputI
     m_ExceptionMessage = "";
     this->TestFileExistanceAndReadability();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     m_ExceptionMessage = err.GetDescription();
   }
@@ -431,7 +431,7 @@ VectorImageFileReader<TImage, TVectorImage, ConvertPixelTraits>::GenerateData()
     m_ExceptionMessage = "";
     this->TestFileExistanceAndReadability();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     m_ExceptionMessage = err.GetDescription();
   }

--- a/Utilities/itkantsReadWriteTransform.h
+++ b/Utilities/itkantsReadWriteTransform.h
@@ -209,7 +209,7 @@ WriteTransform(typename itk::Transform<T, VImageDimension, VImageDimension>::Poi
       transformWriter->Update();
     }
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "Can't write transform file " << filename << std::endl;
     std::cerr << "Exception Object caught: " << std::endl;
@@ -254,7 +254,7 @@ WriteInverseTransform(typename itk::DisplacementFieldTransform<T, VImageDimensio
       transformWriter->Update();
     }
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "Can't write transform file " << filename << std::endl;
     std::cerr << "Exception Object caught: " << std::endl;


### PR DESCRIPTION
Following C++ Core Guidelines, April 10, 2022, which says that it is "typically
better" to catch by const reference than to catch by non-const reference. At
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#e15-throw-by-value-catch-exceptions-from-a-hierarchy-by-reference

Discussed at C++ Core Guidelines issue isocpp/CppCoreGuidelines#518 "Catch
exceptions by const reference?", from February 3, 2016.

find . -type f | egrep '\.[it]?(cc|hh|[ch](\+\+|pp?|xx)?)$' | fgrep -v ThirdParty |     xargs sed -r -i         -e 's/catch \((const )?/catch (const /g'         -e 's/catch \(const \.\.\.\)/catch (...)/g'
