### PR TITLE
ENH: Skip CI on the post-release commit

### DIFF
--- a/Utilities/tagRelease.pl
+++ b/Utilities/tagRelease.pl
@@ -105,6 +105,6 @@ print $outFH $versionDotCmake;
 close($outFH);
 
 system("git add Version.cmake");
-system("git commit -m \"Updating version for development post $tag\"");
+system("git commit -m \"[skip ci] Updating version for development post $tag\"");
 print("\nPushing changed Version.cmake\n");
 system("git push origin $masterBranchLabel") == 0


### PR DESCRIPTION
The post-release commit just resets a flag, no need to push a docker image