### PR TITLE
ENH: Use docker to build Centos binaries

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -16,44 +16,64 @@ jobs:
       matrix:
         config:
         - {
-            name: "Ubuntu_20.04-GCC",
+            name: "Ubuntu-22.04-GCC",
+            os: ubuntu-22.04,
+            cc: "gcc",
+            cxx: "g++",
+            build_type: "Release",
+            generators: "Ninja"
+          }
+        - {
+            name: "Ubuntu-20.04-GCC",
             os: ubuntu-20.04,
-            artifact: "ubuntu-20.04-gcc.zip",
-            build_type: "Release",
             cc: "gcc",
             cxx: "g++",
+            build_type: "Release",
             generators: "Ninja"
           }
         - {
-            name: "Ubuntu_18.04-GCC",
+            name: "Ubuntu-18.04-GCC",
             os: ubuntu-18.04,
-            artifact: "ubuntu-18.04-gcc.zip",
-            build_type: "Release",
             cc: "gcc",
             cxx: "g++",
+            build_type: "Release",
             generators: "Ninja"
           }
         - {
-            name: "macos-11-clang",
-            os: macos-11,
-            artifact: "macos-11-clang.zip",
-            build_type: "Release",
+            name: "Macos-12-clang",
+            os: macos-12,
             cc: "clang",
             cxx: "clang++",
+            build_type: "Release",
             generators: "Ninja"
           }
-
+        - {
+            name: "Macos-11-clang",
+            os: macos-11,
+            cc: "clang",
+            cxx: "clang++",
+            build_type: "Release",
+            generators: "Ninja"
+          }
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
-      - name: Print env
+      - name: Get ANTs version
+        run:
+          echo "ANTS_VERSION=${ANTS_TAG#v}" >> $GITHUB_ENV
+        env:
+          ANTS_TAG: ${{ github.ref_name }}
+      - name: Define env
         run: |
           echo github.event.action: ${{ github.event.action }}
           echo github.event_name: ${{ github.event_name }}
+          echo "CC=${{ matrix.config.cc }}" >> $GITHUB_ENV
+          echo "CXX=${{ matrix.config.cxx }}" >> $GITHUB_ENV
+          echo "ARTIFACT=${{ runner.temp }}/ants-${{ env.ANTS_VERSION }}-${{ matrix.config.os }}-${{ runner.arch }}-${{ matrix.config.cc }}.zip" >> $GITHUB_ENV
       - name: Install dependencies on ubuntu
-        if: startsWith(matrix.config.name, 'Ubuntu_')
+        if: startsWith(matrix.config.name, 'Ubuntu-')
         run: |
           sudo apt-get update
           sudo apt-get install ninja-build cmake
@@ -61,8 +81,9 @@ jobs:
           cmake --version
           gcc --version
       - name: Install dependencies on macos
-        if: startsWith(matrix.config.os, 'macos-11')
+        if: startsWith(matrix.config.os, 'Macos')
         run: |
+          brew update
           brew install cmake ninja
           ninja --version
           cmake --version
@@ -75,7 +96,7 @@ jobs:
           cmake \
             -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
             -G "${{ matrix.config.generators }}" \
-            -DCMAKE_INSTALL_PREFIX:PATH=${{ runner.temp }}/install/ants-${{ github.ref_name }} \
+            -DCMAKE_INSTALL_PREFIX:PATH=${{ runner.temp }}/install/ants-${{ env.ANTS_VERSION }} \
             ${GITHUB_WORKSPACE}
       - name: Build
         shell: bash
@@ -94,13 +115,13 @@ jobs:
         working-directory: ${{ runner.temp }}
         run: |
           cd install
-          zip -r ${{ runner.temp }}/ants-${{ github.ref_name }}-${{ matrix.config.artifact }} .
+          zip -r ${ARTIFACT} .
       - name: Upload release asset
         # Previously was using actions/upload-release-asset@v1 , but this had some
         # errors with large files
         uses: ncipollo/release-action@v1.10.0
         with:
           allowUpdates: true
-          artifacts: "${{ runner.temp }}/ants-${{ github.ref_name }}-${{ matrix.config.artifact }}"
+          artifacts: "${{ env.ARTIFACT }}"
           artifactContentType: application/zip
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,10 +1,11 @@
 # Workflow adapted from https://gist.github.com/NickNaso/0d478f1481686d5bcc868cac06620a60
-name: CMake Build Matrix
+# build directly on supported runners: Ubuntu 18, Ubuntu 20, Mac OS 11
+name: Native release binaries
 
 # Controls when the action will run. Triggers the workflow on push
 on:
   release:
-    types: [created, edited]
+    types: [created]
 
 jobs:
   build:
@@ -67,36 +68,39 @@ jobs:
           cmake --version
       - name: Configure
         shell: bash
+        working-directory: ${{ runner.temp }}
         run: |
-          mkdir ../build
-          cd ../build
+          mkdir build
+          cd build
           cmake \
-            -S ../ANTs \
-            -B . \
             -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
             -G "${{ matrix.config.generators }}" \
-            -DCMAKE_INSTALL_PREFIX:PATH=../install/ants-${{ github.ref_name }}
+            -DCMAKE_INSTALL_PREFIX:PATH=${{ runner.temp }}/install/ants-${{ github.ref_name }} \
+            ${GITHUB_WORKSPACE}
       - name: Build
         shell: bash
+        working-directory: ${{ runner.temp }}
         run: |
-          cd ../build
+          cd build
           cmake --build . --config ${{ matrix.config.build_type }} --parallel
       - name: Install
         shell: bash
+        working-directory: ${{ runner.temp }}
         run: |
-          cd ../build/ANTS-build
+          cd build/ANTS-build
           cmake --install .
       - name: Pack
         shell: bash
+        working-directory: ${{ runner.temp }}
         run: |
-          cd ../build/install
-          zip -r ../../ants-${{ github.ref_name }}-${{ matrix.config.artifact }} .
+          cd install
+          zip -r ${{ runner.temp }}/ants-${{ github.ref_name }}-${{ matrix.config.artifact }} .
       - name: Upload release asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Previously was using actions/upload-release-asset@v1 , but this had some
+        # errors with large files
+        uses: ncipollo/release-action@v1.10.0
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ../ants-${{ github.ref_name }}-${{ matrix.config.artifact }}
-          asset_name: ants-${{ github.ref_name }}-${{ matrix.config.artifact }}
-          asset_content_type: application/zip
+          allowUpdates: true
+          artifacts: "${{ runner.temp }}/ants-${{ github.ref_name }}-${{ matrix.config.artifact }}"
+          artifactContentType: application/zip
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-docker-binaries.yml
+++ b/.github/workflows/release-docker-binaries.yml
@@ -18,10 +18,11 @@ jobs:
         config:
         - {
             name: "Centos7-GCC",
+            # os_desc used to name output
+            os_desc: centos7,
             # Use image that already has gcc installed
             image: "centos/devtoolset-7-toolchain-centos7:7",
             container_options: "--user root",
-            artifact: "centos7-gcc.zip",
             build_type: "Release",
             cc: "gcc",
             cxx: "g++",
@@ -31,10 +32,18 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
-      - name: Print env
+      - name: Get ANTs version
+        run:
+          echo "ANTS_VERSION=${ANTS_TAG#v}" >> $GITHUB_ENV
+        env:
+          ANTS_TAG: ${{ github.ref_name }}
+      - name: Define env
         run: |
           echo github.event.action: ${{ github.event.action }}
           echo github.event_name: ${{ github.event_name }}
+          echo "CC=${{ matrix.config.cc }}" >> $GITHUB_ENV
+          echo "CXX=${{ matrix.config.cxx }}" >> $GITHUB_ENV
+          echo "ARTIFACT=${{ runner.temp }}/ants-${{ env.ANTS_VERSION }}-${{ matrix.config.os_desc }}-${{ runner.arch }}-${{ matrix.config.cc }}.zip" >> $GITHUB_ENV
       - name: Install dependencies on Centos
         if: startsWith(matrix.config.image, 'centos')
         run: |
@@ -53,7 +62,7 @@ jobs:
           cmake \
             -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
             -G "${{ matrix.config.generators }}" \
-            -DCMAKE_INSTALL_PREFIX:PATH=/opt/install/ants-${{ github.ref_name }} \
+            -DCMAKE_INSTALL_PREFIX:PATH=/opt/install/ants-${{ env.ANTS_VERSION }} \
             ${GITHUB_WORKSPACE}
       - name: Build
         shell: bash
@@ -69,13 +78,13 @@ jobs:
         shell: bash
         run: |
           cd /opt/install
-          zip -r /opt/ants-${{ github.ref_name }}-${{ matrix.config.artifact }} .
+          zip -r ${ARTIFACT} .
       - name: Upload release asset
         # softprops giving ECONNRESET error
         # uses: softprops/action-gh-release@v0.1.14
         uses: ncipollo/release-action@v1.10.0
         with:
           allowUpdates: true
-          artifacts: "/opt/ants-${{ github.ref_name }}-${{ matrix.config.artifact }}"
+          artifacts: "${{ env.ARTIFACT }}"
           artifactContentType: application/zip
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-docker-binaries.yml
+++ b/.github/workflows/release-docker-binaries.yml
@@ -1,0 +1,81 @@
+name: Cross-platform release binaries
+# Use Docker to build on platforms other than Ubuntu
+on:
+  release:
+    types: [created]
+env:
+  CMAKE_VERSION: 3.23.1
+jobs:
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.config.image }}
+      options: ${{ matrix.config.container_options }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {
+            name: "Centos7-GCC",
+            # Use image that already has gcc installed
+            image: "centos/devtoolset-7-toolchain-centos7:7",
+            container_options: "--user root",
+            artifact: "centos7-gcc.zip",
+            build_type: "Release",
+            cc: "gcc",
+            cxx: "g++",
+            generators: "Unix Makefiles"
+          }
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+      - name: Print env
+        run: |
+          echo github.event.action: ${{ github.event.action }}
+          echo github.event_name: ${{ github.event_name }}
+      - name: Install dependencies on Centos
+        if: startsWith(matrix.config.image, 'centos')
+        run: |
+          yum -y update && yum clean all
+          yum -y install devtoolset-7 git zlib-devel
+          curl -OL https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh
+          chmod +x cmake-${CMAKE_VERSION}-linux-x86_64.sh
+          mkdir -p /opt/cmake/bin
+          ./cmake-${CMAKE_VERSION}-linux-x86_64.sh --skip-license --prefix="/opt/cmake"
+          echo "/opt/cmake/bin" >> $GITHUB_PATH
+      - name: Configure
+        shell: bash
+        run: |
+          mkdir -p /opt/build
+          cd /opt/build
+          cmake \
+            -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
+            -G "${{ matrix.config.generators }}" \
+            -DCMAKE_INSTALL_PREFIX:PATH=/opt/install/ants-${{ github.ref_name }} \
+            ${GITHUB_WORKSPACE}
+      - name: Build
+        shell: bash
+        run: |
+          cd /opt/build
+          cmake --build . --config ${{ matrix.config.build_type }} --parallel 1
+      - name: Install
+        shell: bash
+        run: |
+          cd /opt/build/ANTS-build
+          cmake --install .
+      - name: Pack
+        shell: bash
+        run: |
+          cd /opt/install
+          zip -r /opt/ants-${{ github.ref_name }}-${{ matrix.config.artifact }} .
+      - name: Upload release asset
+        # softprops giving ECONNRESET error
+        # uses: softprops/action-gh-release@v0.1.14
+        uses: ncipollo/release-action@v1.10.0
+        with:
+          allowUpdates: true
+          artifacts: "/opt/ants-${{ github.ref_name }}-${{ matrix.config.artifact }}"
+          artifactContentType: application/zip
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This can be extended to other platforms that aren't supported by native runners.

Also made some improvements for readability to the native release binary build

Swapped out the artifact uploader to one that retries if there's a network error


