### PR TITLE
WIP:  Remove unused estimate learning rate at each iteration.

### DIFF
--- a/Examples/antsMotionCorr.cxx
+++ b/Examples/antsMotionCorr.cxx
@@ -690,16 +690,16 @@ ants_motion(itk::ants::CommandLineParser * parser)
   }
 
   bool                doEstimateLearningRateOnce(false);
-  OptionType::Pointer rateOption = parser->GetOption("use-estimate-learning-rate-once");
-  if (rateOption && rateOption->GetNumberOfFunctions())
-  {
-    std::string rateFunction = rateOption->GetFunction(0)->GetName();
-    ConvertToLowerCase(rateFunction);
-    if (rateFunction.compare("1") == 0 || rateFunction.compare("true") == 0)
-    {
-      doEstimateLearningRateOnce = true;
-    }
-  }
+  // OptionType::Pointer rateOption = parser->GetOption("use-estimate-learning-rate-once");
+  // if (rateOption && rateOption->GetNumberOfFunctions())
+  // {
+  //   std::string rateFunction = rateOption->GetFunction(0)->GetName();
+  //   ConvertToLowerCase(rateFunction);
+  //   if (rateFunction.compare("1") == 0 || rateFunction.compare("true") == 0)
+  //   {
+  //     doEstimateLearningRateOnce = true;
+  //   }
+  // }
 
   bool                doHistogramMatch(true);
   OptionType::Pointer histogramMatchOption = parser->GetOption("use-histogram-matching");
@@ -1813,17 +1813,17 @@ antsMotionCorrInitializeCommandLineOptions(itk::ants::CommandLineParser * parser
     parser->AddOption(option);
   }
 
-  {
-    std::string description =
-      std::string("turn on the option that lets you estimate the learning rate step size only at the beginning of each "
-                  "level.  * useful as a second stage of fine-scale registration.");
+  // {
+  //   std::string description =
+  //     std::string("turn on the option that lets you estimate the learning rate step size only at the beginning of each "
+  //                 "level.  * useful as a second stage of fine-scale registration.");
 
-    OptionType::Pointer option = OptionType::New();
-    option->SetLongName("use-estimate-learning-rate-once");
-    option->SetShortName('l');
-    option->SetDescription(description);
-    parser->AddOption(option);
-  }
+  //   OptionType::Pointer option = OptionType::New();
+  //   option->SetLongName("use-estimate-learning-rate-once");
+  //   option->SetShortName('l');
+  //   option->SetDescription(description);
+  //   parser->AddOption(option);
+  // }
 
   {
     std::string description =

--- a/Examples/antsRegistration.cxx
+++ b/Examples/antsRegistration.cxx
@@ -193,7 +193,6 @@ antsRegistrationInitializeCommandLineOptions(itk::ants::CommandLineParser * pars
     option->SetShortName('z');
     option->SetUsageOption(0, "(1)/0");
     option->SetDescription(description);
-    option->AddFunction(std::string("1"));
     parser->AddOption(option);
   }
 
@@ -445,17 +444,16 @@ antsRegistrationInitializeCommandLineOptions(itk::ants::CommandLineParser * pars
     parser->AddOption(option);
   }
 
-  {
-    std::string description =
-      std::string("turn on the option that lets you estimate the learning rate step size only at the beginning of each "
-                  "level.  * useful as a second stage of fine-scale registration.");
-
-    OptionType::Pointer option = OptionType::New();
-    option->SetLongName("use-estimate-learning-rate-once");
-    option->SetShortName('l');
-    option->SetDescription(description);
-    parser->AddOption(option);
-  }
+  // {
+  //   std::string description =
+  //     std::string("Turn on the option that lets you estimate the learning rate step size only at the beginning of each "
+  //                 "level.  This is useful as a second stage of fine-scale registration.");
+  //   OptionType::Pointer option = OptionType::New();
+  //   option->SetLongName("use-estimate-learning-rate-once");
+  //   option->SetShortName('l');
+  //   option->SetDescription(description);
+  //   parser->AddOption(option);
+  // }
 
   {
     std::string description = std::string("Winsorize data based on specified quantiles.");
@@ -491,7 +489,6 @@ antsRegistrationInitializeCommandLineOptions(itk::ants::CommandLineParser * pars
     OptionType::Pointer option = OptionType::New();
     option->SetLongName("float");
     option->SetDescription(description);
-    option->AddFunction(std::string("0"));
     parser->AddOption(option);
   }
 

--- a/Examples/antsRegistration.cxx
+++ b/Examples/antsRegistration.cxx
@@ -193,6 +193,7 @@ antsRegistrationInitializeCommandLineOptions(itk::ants::CommandLineParser * pars
     option->SetShortName('z');
     option->SetUsageOption(0, "(1)/0");
     option->SetDescription(description);
+    option->AddFunction(std::string("1"));
     parser->AddOption(option);
   }
 

--- a/Examples/antsRegistrationTemplateHeader.h
+++ b/Examples/antsRegistrationTemplateHeader.h
@@ -439,19 +439,19 @@ DoRegistration(typename ParserType::Pointer & parser)
   }
   regHelper->SetUseHistogramMatching(doHistogramMatch);
 
-  bool doEstimateLearningRateAtEachIteration = true;
+  // bool doEstimateLearningRateAtEachIteration = true;
 
-  OptionType::Pointer rateOption = parser->GetOption("use-estimate-learning-rate-once");
-  if (rateOption && rateOption->GetNumberOfFunctions())
-  {
-    std::string rateFunction = rateOption->GetFunction(0)->GetName();
-    ConvertToLowerCase(rateFunction);
-    if (rateFunction.compare("1") == 0 || rateFunction.compare("true") == 0)
-    {
-      doEstimateLearningRateAtEachIteration = false;
-    }
-  }
-  regHelper->SetDoEstimateLearningRateAtEachIteration(doEstimateLearningRateAtEachIteration);
+  // OptionType::Pointer rateOption = parser->GetOption("use-estimate-learning-rate-once");
+  // if (rateOption && rateOption->GetNumberOfFunctions())
+  // {
+  //   std::string rateFunction = rateOption->GetFunction(0)->GetName();
+  //   ConvertToLowerCase(rateFunction);
+  //   if (rateFunction.compare("1") == 0 || rateFunction.compare("true") == 0)
+  //   {
+  //     doEstimateLearningRateAtEachIteration = false;
+  //   }
+  // }
+  // regHelper->SetDoEstimateLearningRateAtEachIteration(doEstimateLearningRateAtEachIteration);
 
   // We find both the number of transforms and the number of metrics
 

--- a/Examples/itkantsRegistrationHelper.hxx
+++ b/Examples/itkantsRegistrationHelper.hxx
@@ -1394,7 +1394,7 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
     //    optimizer2->SetLowerLimit( 0 );
     //    optimizer2->SetUpperLimit( 2 );
     //    optimizer2->SetEpsilon( 0.2 );
-    //    optimizer->SetMaximumLineSearchIterations( 20 );
+    //    optimizer2->SetMaximumLineSearchIterations( 20 );
     optimizer2->SetLearningRate(learningRate);
     optimizer2->SetMaximumStepSizeInPhysicalUnits(learningRate);
     optimizer2->SetNumberOfIterations(currentStageIterations[0]);
@@ -4191,7 +4191,7 @@ RegistrationHelper<TComputeType, VImageDimension>::InitializeWithPreviousLinearT
     return false;
   }
   /////
-  return true; // This function only returns flase or true (NOT FAILURE or SUCCESS).
+  return true; // This function only returns false or true (NOT FAILURE or SUCCESS).
                // If direct intialization fails, the program should NOT be stopped,
                // because the initial transform will be kept in the composite transform,
                // and the final results will be still correct.
@@ -4203,11 +4203,13 @@ RegistrationHelper<TComputeType, VImageDimension>::PrintState() const
 {
   this->Logger() << "Dimension = " << Self::ImageDimension << std::endl
                  << "Number of stages = " << this->m_NumberOfStages << std::endl
-                 << "Use Histogram Matching " << (this->m_UseHistogramMatching ? "true" : "false") << std::endl
-                 << "Winsorize image intensities " << (this->m_WinsorizeImageIntensities ? "true" : "false")
+                 << "Use histogram matching = " << (this->m_UseHistogramMatching ? "true" : "false") << std::endl
+                 << "Winsorize image intensities = " << (this->m_WinsorizeImageIntensities ? "true" : "false")
                  << std::endl
-                 << "Lower quantile = " << this->m_LowerQuantile << std::endl
-                 << "Upper quantile = " << this->m_UpperQuantile << std::endl;
+                 << "  Lower quantile = " << this->m_LowerQuantile << std::endl
+                 << "  Upper quantile = " << this->m_UpperQuantile << std::endl
+                 << std::endl
+                 << std::endl;
 
   for (unsigned i = 0; i < this->m_NumberOfStages; i++)
   {


### PR DESCRIPTION
# Description

I'm guessing this is a legacy option before we switched to the conjugate gradient descent optimizers for everything but the exponential transforms.   But even those don't use this flag as no scales estimator is applied in these two cases (B-spline and Gaussian).

Addresses #1405


