### PR TITLE
ENH: Output extra info at the end of registration

### DIFF
--- a/Scripts/antsRegistrationSyN.sh
+++ b/Scripts/antsRegistrationSyN.sh
@@ -669,6 +669,14 @@ echo "--------------------------------------------------------------------------
 
 $COMMAND
 
+echo " Registration finished. The antsRegistration call was:"
+echo "--------------------------------------------------------------------------------------"
+echo ${COMMAND}
+echo "--------------------------------------------------------------------------------------"
+echo "Moving image resampled into fixed space: ${OUTPUTNAME}Warped.nii.gz"
+echo "Fixed image resampled into moving space: ${OUTPUTNAME}InverseWarped.nii.gz"
+echo "--------------------------------------------------------------------------------------"
+
 ###############################
 #
 # Restore original number of threads

--- a/Scripts/antsRegistrationSyNQuick.sh
+++ b/Scripts/antsRegistrationSyNQuick.sh
@@ -678,6 +678,14 @@ echo "--------------------------------------------------------------------------
 
 $COMMAND
 
+echo " Registration finished. The antsRegistration call was:"
+echo "--------------------------------------------------------------------------------------"
+echo ${COMMAND}
+echo "--------------------------------------------------------------------------------------"
+echo "Moving image resampled into fixed space: ${OUTPUTNAME}Warped.nii.gz"
+echo "Fixed image resampled into moving space: ${OUTPUTNAME}InverseWarped.nii.gz"
+echo "--------------------------------------------------------------------------------------"
+
 ###############################
 #
 # Restore original number of threads


### PR DESCRIPTION
It's easy to miss the printout of the antsRegistration call when using the scripts, because it gets scrolled off the screen. So I repeated it at the end.

