### PR TITLE
BUG: Atropos no longer segfaults when -i is missing, it reports an error msg instead

### DIFF
--- a/Examples/Atropos.cxx
+++ b/Examples/Atropos.cxx
@@ -121,6 +121,11 @@ AtroposSegmentation(itk::ants::CommandLineParser * parser)
    * Initialization
    */
   typename itk::ants::CommandLineParser::OptionType::Pointer initializationOption = parser->GetOption("initialization");
+  if (!initializationOption || !initializationOption->GetNumberOfFunctions())
+  {
+    std::cerr << "No initialization option specified." << std::endl;
+    return EXIT_FAILURE;
+  }
   if (initializationOption && initializationOption->GetNumberOfFunctions() &&
       initializationOption->GetFunction(0)->GetNumberOfParameters() < 1)
   {


### PR DESCRIPTION
bug can be reproduced by:

```
wget https://openneuro.org/crn/datasets/ds004288/snapshots/1.0.1/files/sub-0303:anat:sub-0303_T1w.nii.gz
mkdir tmp_test
Atropos -x sub-0303:anat:sub-0303_T1w.nii.gz -a sub-0303:anat:sub-0303_T1w.nii.gz -o [ tmp_test/Segmentation.nii.gz,tmp_test/SegmentationPosteriors%d.nii.gz ]
```

this currently segfaults, the patched code instead prints an error message to explain to the user what is wrong.
