### PR TITLE
BUG: fixed Scripts/antsAtroposN4.sh not stopping when subcommands exit with exitcode>0

### DIFF
--- a/Scripts/antsAtroposN4.sh
+++ b/Scripts/antsAtroposN4.sh
@@ -193,8 +193,8 @@ function logCmd() {
       if [[ ! $DEBUG_MODE -gt 0 ]];
         then
           exit 1
-        fi
-    fi
+      fi
+  fi
 
   echo "END   <<<<<<<<<<<<<<<<<<<<"
   echo

--- a/Scripts/antsAtroposN4.sh
+++ b/Scripts/antsAtroposN4.sh
@@ -181,9 +181,9 @@ function logCmd() {
   echo $cmd
 
   exec 5>&1
-  logCmdOutput=$( "$@" | tee >(cat - >&5) )
+  logCmdOutput=$( "$@" | tee >(cat - >&5); exit ${PIPESTATUS[0]} )
 
-  cmdExit=${PIPESTATUS[0]}
+  cmdExit=$?
 
   if [[ $cmdExit -gt 0 ]];
     then


### PR DESCRIPTION
Scripts/antsAtroposN4.sh was not stopping as "${PIPESTATUS[0]}" was always 0, this happened because of "logCmdOutput=" which I this starts a subshell which have the PIPESTATUS variable inside it, but this variable is not visable outside the subshell. The PIPESTATUS is now instead return by the subshell and its exitcode is inserted into cmdExit.

commands use to reproduce the problem:
```
wget https://openneuro.org/crn/datasets/ds004288/snapshots/1.0.1/files/sub-0303:anat:sub-0303_T1w.nii.gz
mkdir tmp_antsAtroposN4
ANTSPATH=/usr/bin/ time ./deps/ANTs/Scripts/antsAtroposN4.sh -d 3 -c 3 -m 3 -n 3 -a sub-0303\:anat\:sub-0303_T1w.nii.gz -o tmp_antsAtroposN4/ -u 0 -e "[35x35x35x35,0]" -f 4
```
which should fail because of the missing -x parameter.