### PR TITLE
BUG: Needed to exit immediately if mask is missing

### DIFF
--- a/Scripts/antsAtroposN4.sh
+++ b/Scripts/antsAtroposN4.sh
@@ -356,6 +356,7 @@ for (( i = 0; i < ${#ANATOMICAL_IMAGES[@]}; i++ ))
 if [[ ! -f "${ATROPOS_SEGMENTATION_MASK}" ]];
   then
     echo "Required mask image \"${ATROPOS_SEGMENTATION_MASK}\" does not exist."
+    exit 1
   fi
 
 FORMAT=${ATROPOS_SEGMENTATION_PRIORS}


### PR DESCRIPTION
Thanks to #1456, the script will now exit after failing to run Atropos if the mask is missing, but it can be several minutes until it gets to that command. Now exit immediately after explicitly checking the mask.