### PR TITLE
BUG: Bump ITK to fix random seeding for SyN

### DIFF
--- a/SuperBuild/External_ITKv5.cmake
+++ b/SuperBuild/External_ITKv5.cmake
@@ -154,8 +154,8 @@ if(NOT DEFINED ${extProjName}_DIR AND NOT ${USE_SYSTEM_${extProjName}})
 
   ### --- End Project specific additions
   set(${proj}_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITK.git)
-  set(${proj}_GIT_TAG 1fc47c7bec4ee133318c1892b7b745763a17d411)  # Release 5.3.0
-  set(ITK_VERSION_ID ITK-5.3) ### NOTE: When updating GIT_TAG, also update ITK_VERSION_ID if ITK version has changed
+  set(${proj}_GIT_TAG 490b5c6069a790c2bbc50ece3a578fe1c5cdd50b)  # Initialize random seeds for sparse sampling in SyN
+  set(ITK_VERSION_ID ITK-5.4) ### NOTE: When updating GIT_TAG, also update ITK_VERSION_ID if ITK version has changed
 
   ExternalProject_Add(${proj}
     GIT_REPOSITORY ${${proj}_REPOSITORY}


### PR DESCRIPTION
This only affects registration with metric sampling strategies in the SyN / BSplineSyN stages. Dense sampling is not randomized.

Fixes #1475 and #1470

