### PR TITLE
ENH: Use ITK ZLIB, test release builds, Windows binaries (#1)

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -96,6 +96,9 @@ jobs:
           cmake \
             -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
             -G "${{ matrix.config.generators }}" \
+            -DBUILD_TESTING=ON \
+            -DRUN_SHORT_TESTS=ON \
+            -DRUN_LONG_TESTS=OFF \
             -DCMAKE_INSTALL_PREFIX:PATH=${{ runner.temp }}/install/ants-${{ env.ANTS_VERSION }} \
             ${GITHUB_WORKSPACE}
       - name: Build
@@ -104,6 +107,12 @@ jobs:
         run: |
           cd build
           cmake --build . --config ${{ matrix.config.build_type }} --parallel
+      - name: Test
+        shell: bash
+        working-directory: ${{ runner.temp }}
+        run: |
+          cd build/ANTS-build
+          ctest
       - name: Install
         shell: bash
         working-directory: ${{ runner.temp }}

--- a/.github/workflows/release-docker-binaries.yml
+++ b/.github/workflows/release-docker-binaries.yml
@@ -64,6 +64,9 @@ jobs:
           cmake \
             -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} \
             -G "${{ matrix.config.generators }}" \
+            -DBUILD_TESTING=ON \
+            -DRUN_SHORT_TESTS=ON \
+            -DRUN_LONG_TESTS=OFF \
             -DCMAKE_INSTALL_PREFIX:PATH=/opt/install/ants-${{ env.ANTS_VERSION }} \
             ${GITHUB_WORKSPACE}
       - name: Build
@@ -71,6 +74,12 @@ jobs:
         run: |
           cd /opt/build
           cmake --build . --config ${{ matrix.config.build_type }} --parallel 1
+      - name: Test
+        shell: bash
+        working-directory: ${{ runner.temp }}
+        run: |
+          cd /opt/build/ANTS-build
+          ctest
       - name: Install
         shell: bash
         run: |

--- a/.github/workflows/release-win-binaries.yml
+++ b/.github/workflows/release-win-binaries.yml
@@ -1,0 +1,86 @@
+# Build for Windows using visual studio
+name: Native Windows release binaries
+
+# Controls when the action will run. Triggers the workflow on push
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {
+            name: "Windows-22",
+            os: "windows-2022",
+            vs: "2019",
+            build_type: "Release"
+          }
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+      # Set up vs studio. Use default windows shell (powershell) not bash,
+      # to avoid conflicts with link executable
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ runner.arch }}
+          vsversion: ${{ matrix.vs }}
+      - name: Get ANTs version
+        run: |
+         $antsVersion="${{ env.ANTS_TAG }}"
+         $antsVersion=$antsVersion.Substring(1)
+         echo "ANTS_VERSION=$antsVersion" | Out-File -FilePath $env:GITHUB_ENV -Append
+        env:
+          ANTS_TAG: ${{ github.ref_name }}
+      - name: Define env
+        run: |
+          echo github.event.action: ${{ github.event.action }}
+          echo "ARTIFACT=${{ runner.temp }}/ants-${{ env.ANTS_VERSION }}-${{ matrix.config.os }}-${{ runner.arch }}-VS${{ matrix.config.vs }}.zip" | Out-File -FilePath $env:GITHUB_ENV -Append
+      - name: Configure
+        working-directory: ${{ runner.temp }}
+        run: |
+          mkdir build
+          cd build
+          cmake `
+            -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} `
+            -DBUILD_TESTING=ON `
+            -DRUN_SHORT_TESTS=ON `
+            -DRUN_LONG_TESTS=OFF `
+            -DCMAKE_INSTALL_PREFIX:PATH=${{ runner.temp }}/install/ants-${{ env.ANTS_VERSION }} `
+            ${{ github.workspace }}
+      - name: Build
+        working-directory: ${{ runner.temp }}
+        run: |
+          cd build
+          cmake --build . --config ${{ matrix.config.build_type }} --parallel
+      - name: Test
+        working-directory: ${{ runner.temp }}
+        run: |
+          cd build/ANTS-build
+          ctest -C release
+      - name: Install
+        working-directory: ${{ runner.temp }}
+        run: |
+          cd build/ANTS-build
+          cmake --install .
+      - name: Pack
+        working-directory: ${{ runner.temp }}
+        run: |
+          cd install
+          7z a ${{ env.ARTIFACT }} .
+      - name: Upload release asset
+        # Previously was using actions/upload-release-asset@v1 , but this had some
+        # errors with large files
+        uses: ncipollo/release-action@v1.11.1
+        with:
+          allowUpdates: true
+          omitBodyDuringUpdate: true
+          omitNameDuringUpdate: true
+          artifacts: "${{ env.ARTIFACT }}"
+          artifactContentType: application/zip
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/SuperBuild/External_ITKv5.cmake
+++ b/SuperBuild/External_ITKv5.cmake
@@ -109,7 +109,8 @@ if(NOT DEFINED ${extProjName}_DIR AND NOT ${USE_SYSTEM_${extProjName}})
   string(REPLACE "-fopenmp" "" ITK_CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
   string(REPLACE "-fopenmp" "" ITK_CMAKE_CXX_FLAGS "${CMAKE_CX_FLAGS}")
 
-  find_package(ZLIB REQUIRED)
+ # ITK now has zlib-ng, so we no longer depend on system zlib
+ # find_package(ZLIB REQUIRED)
 
   set(${proj}_CMAKE_OPTIONS
       -DBUILD_TESTING:BOOL=OFF
@@ -129,6 +130,7 @@ if(NOT DEFINED ${extProjName}_DIR AND NOT ${USE_SYSTEM_${extProjName}})
       #-DITK_INSTALL_NO_DEVELOPMENT:BOOL=ON
       -DKWSYS_USE_MD5:BOOL=ON # Required by SlicerExecutionModel
       -DITK_WRAPPING:BOOL=OFF #${BUILD_SHARED_LIBS} ## HACK:  QUICK CHANGE
+      -DITKZLIB:BOOL=ON
       -DModule_MGHIO:BOOL=ON
       -DModule_ITKReview:BOOL=ON
       -DModule_GenericLabelInterpolator:BOOL=ON


### PR DESCRIPTION
* COMP: Switch to ITK zlib

Using ITK zlib avoids having to build zlib on Windows. Appears to build fine on other platforms also. Fixes #1481

* ENH: Build windows binaries for releases

* ENH: Run tests on release

