### PR TITLE
COMP: Update actions to resolve deprecation warnings

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -20,11 +20,11 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: antsx/ants
       -
@@ -36,7 +36,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -32,14 +32,6 @@ jobs:
             generators: "Ninja"
           }
         - {
-            name: "Ubuntu-18.04-GCC",
-            os: ubuntu-18.04,
-            cc: "gcc",
-            cxx: "g++",
-            build_type: "Release",
-            generators: "Ninja"
-          }
-        - {
             name: "Macos-12-clang",
             os: macos-12,
             cc: "clang",


### PR DESCRIPTION
There were a few deprecation warnings in the Docker CI workflow, which will hopefully be resolved by updating the included actions.

Also removed Ubuntu 18.04 from the release binaries, because the runner is being deprecated in April 2023. 

https://github.com/actions/runner-images/issues/6002

