### PR TITLE
ENH: Read Windows pointers

### DIFF
--- a/Utilities/ReadWriteData.h
+++ b/Utilities/ReadWriteData.h
@@ -225,11 +225,39 @@ ReadImage(itk::SmartPointer<TImageType> & target, const char * file)
     return false;
   }
 
+  bool fileIsPointer = false;
+
   std::string comparetype1 = std::string("0x");
   std::string comparetype2 = std::string(file);
   comparetype2 = comparetype2.substr(0, 2);
-  // Read the image files begin
+
   if (comparetype1 == comparetype2)
+  {
+    fileIsPointer = true;
+  }
+  else
+  {
+    std::string fileString = std::string(file);
+    // Also treat file as a pointer if it is composed entirely of hex characters, and has appropriate length
+    bool fileIsHexChars = true;
+
+    std::string::iterator fileIt;
+
+    for (fileIt = fileString.begin(); fileIt < fileString.end(); ++fileIt)
+    {
+      if (!std::isxdigit(*fileIt))
+      {
+        fileIsHexChars = false;
+      }
+    }
+
+    if (fileIsHexChars && fileString.length() == (1 + sizeof(int*) * 2))
+    {
+      fileIsPointer = true;
+    }
+  }
+
+  if (fileIsPointer)
   {
     typedef TImageType RImageType;
     void *             ptr;


### PR DESCRIPTION
Inspired by https://github.com/ANTsX/ANTsPy/issues/437

Notice from the exception thrown there:

```
file 0000018600E3C1C0 does not exist . 
Exception Object caught: 

itk::ExceptionObject (0000000A275EBBC0)
Location: "unknown" 
File: D:\a\ANTsPy\ANTsPy\itksource\Modules\Registration\Common\include\itkCenteredTransformInitializer.hxx
Line: 31
Description: ITK ERROR: CenteredTransformInitializer(000001867F47D310): Fixed Image has not been set
```

On Windows the address is "0000018600E3C1C0" not "0x000018600E3C1C0", so it won't match the "0x" pattern, and ANTs attempts to read as a file from disk.

I've tried to modify the logic so that a hex string of the appropriate length (17 chars here) gets treated as a pointer also. My hope is that this will allow ANTsPy to work on Windows, but I can't test that directly. 

The modified code does pass ANTs tests.