### PR TITLE
Enable MINC support by default

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -92,7 +92,7 @@ CMAKE_DEPENDENT_OPTION(
   "BUILD_STYLE_UTILS" OFF
   )
 
-option(ITK_BUILD_MINC_SUPPORT "Build support for MINC2" OFF)
+option(ITK_BUILD_MINC_SUPPORT "Build support for MINC2" ON)
 
 set(EXTERNAL_PROJECT_BUILD_TYPE "Release" CACHE STRING "Default build type for support libraries")
 


### PR DESCRIPTION
This is a minimal dependency change for the build (just libminc2 in ITK) and the ANTs tools show `--minc` regardless of this switch so I think its better to enable by default.