### PR TITLE
ENH:  Add spacing option for laplacian sharpening.

### DIFF
--- a/Examples/ImageMath.cxx
+++ b/Examples/ImageMath.cxx
@@ -593,7 +593,7 @@ ImageMath(std::vector<std::string> args, std::ostream * itkNotUsed(out_stream))
     std::cout << "      Usage        : SigmoidImage ImageIn [alpha=1.0] [beta=0.0]" << std::endl;
 
     std::cout << "\n  Sharpen        : Apply a Laplacian sharpening filter" << std::endl;
-    std::cout << "      Usage        : Sharpen ImageIn" << std::endl;
+    std::cout << "      Usage        : Sharpen ImageIn [useImageSpacing=(1)/0]" << std::endl;
 
     std::cout << "\n  UnsharpMask     Apply an Unsharp Mask filter" << std::endl;
     std::cout

--- a/Examples/ImageMath_Templates.hxx
+++ b/Examples/ImageMath_Templates.hxx
@@ -2164,12 +2164,19 @@ SharpenImage(int argc, char * argv[])
   const std::string outputFilename = std::string(argv[2]);
   const std::string inputFilename = std::string(argv[4]);
 
+  bool useImageSpacing = true;
+  if(argc > 5)
+  {
+  useImageSpacing = static_cast<bool>(std::stoi(argv[5]));
+  }
+
   typename ImageType::Pointer inputImage = nullptr;
   ReadImage<ImageType>(inputImage, inputFilename.c_str());
 
   typedef itk::LaplacianSharpeningImageFilter<ImageType, ImageType> FilterType;
   typename FilterType::Pointer                                      filter = FilterType::New();
   filter->SetInput(inputImage);
+  filter->SetUseImageSpacing(useImageSpacing);
   filter->Update();
 
   ANTs::WriteImage<ImageType>(filter->GetOutput(), outputFilename.c_str());

--- a/Examples/antsVol.cxx
+++ b/Examples/antsVol.cxx
@@ -19,7 +19,6 @@
 #include "vtkRenderer.h"
 #include "vtkRenderWindow.h"
 #include "vtkRenderWindowInteractor.h"
-#include "vtkSampleFunction.h"
 #include "vtkSmartPointer.h"
 #include "vtkSmartVolumeMapper.h"
 #include "vtkSphere.h"

--- a/Scripts/antsMultivariateTemplateConstruction.sh
+++ b/Scripts/antsMultivariateTemplateConstruction.sh
@@ -305,7 +305,7 @@ function summarizeimageset() {
       ;;
     1)
       echo "Laplacian sharpening"
-      ${ANTSPATH}/ImageMath $dim $output Sharpen $output
+      ${ANTSPATH}/ImageMath $dim $output Sharpen $output 0
       ;;
     2)
       echo "Unsharp mask sharpening"

--- a/Scripts/antsMultivariateTemplateConstruction2.sh
+++ b/Scripts/antsMultivariateTemplateConstruction2.sh
@@ -369,7 +369,7 @@ function summarizeimageset() {
       ;;
     1)
       echo "Laplacian sharpening"
-      ${ANTSPATH}/ImageMath $dim $output Sharpen $output
+      ${ANTSPATH}/ImageMath $dim $output Sharpen $output 0
       ;;
     2)
       echo "Unsharp mask sharpening"


### PR DESCRIPTION
Add option to sharpen without using the image spacing.  Explicitly turn off in template building.  Addresses https://github.com/ANTsX/ANTs/issues/1540.




