### PR TITLE
COMP: Github windows runners were attempting to use deprecated

### DIFF
--- a/Examples/sccan.cxx
+++ b/Examples/sccan.cxx
@@ -419,11 +419,15 @@ PermuteMatrix(vnl_matrix<TComp> q, bool doperm = true)
   }
 // std::random_shuffle is deprecated since C++14,
 // see: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4190.htm
-#if __cplusplus >= 201402L
-  std::shuffle(permvec.begin(), permvec.end(), std::random_device());
-#else
-  std::random_shuffle(permvec.begin(), permvec.end(), sccanRandom);
-#endif
+// 2023-08-30: MSVC 2019 on Github Actions runners having problems detecting C++ version,
+// so use new std::shuffle
+// #if __cplusplus >= 201402L
+//  std::shuffle(permvec.begin(), permvec.end(), std::random_device());
+// #else
+//   std::random_shuffle(permvec.begin(), permvec.end(), sccanRandom);
+// #endif
+std::shuffle(permvec.begin(), permvec.end(), std::random_device());
+
   //    for (unsigned long i=0; i < q.rows(); i++)
   //  // std::cout << " permv " << i << " is " << permvec[i] << std::endl;
   // for (unsigned long i=0; i < q.rows(); i++)


### PR DESCRIPTION
functions in sccan.cxx

There was an if statement in the code that should have used the new `random_shuffle` and not the old `std:shuffle` that has been removed in c++-17.

I don't know why this stopped working, but the Windows runner would not build the latest release, so I removed the if statement and just used the updated function `random_shuffle`.

Fixes #1593