### PR TITLE
BUG: Template input overwritten when basename identical

### DIFF
--- a/Scripts/antsMultivariateTemplateConstruction.sh
+++ b/Scripts/antsMultivariateTemplateConstruction.sh
@@ -1349,6 +1349,7 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
             POO=${OUTPUTNAME}template${k}${IMGbase}
             OUTFN=${POO%.*.*}
             OUTFN=`basename ${OUTFN}`
+            OUTFN="${OUTFN}${j}"
             DEFORMED="${outdir}/${OUTFN}${l}WarpedToTemplate.nii.gz"
 
             IMGbase=`basename ${IMAGESETARRAY[$j]}`

--- a/Scripts/antsMultivariateTemplateConstruction2.sh
+++ b/Scripts/antsMultivariateTemplateConstruction2.sh
@@ -1471,6 +1471,7 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
             IMGbase=`basename ${IMAGESETARRAY[$l]}`
             OUTFN=${OUTPUTNAME}template${k}${IMGbase/%?(.nii.gz|.nii)}
             OUTFN=`basename ${OUTFN}`
+            OUTFN="${OUTFN}${j}"
             DEFORMED="${outdir}/${OUTFN}${l}WarpedToTemplate.nii.gz"
 
             IMGbase=`basename ${IMAGESETARRAY[$j]}`


### PR DESCRIPTION
As evidenced in #1634

This bug affects users who run `antsLongitudinalCorticalThickness.sh` or `antsMultivariateTemplateConstruction[2].sh`.

The bug only affects use cases where `-n 1` is passed to the template script **and** the input base names are identical. For example,

`antsLongitudinalCorticalThickness.sh [options] /data1/t1w.nii.gz /data2/t1w.nii.gz`

`antsMultivariateTemplateConstruction.sh [options] -n 1 /data1/t1w.nii.gz /data2/t1w.nii.gz`