### PR TITLE
COMP: Fix some compile errors when legacy functionality is removed

### DIFF
--- a/Examples/ImageMath_Templates.hxx
+++ b/Examples/ImageMath_Templates.hxx
@@ -1703,7 +1703,7 @@ SetOrGetPixel(int argc, char * argv[])
     {
       porig[2] = indz;
     }
-    image1->TransformPhysicalPointToIndex(porig, index);
+    index = image1->TransformPhysicalPointToIndex(porig);
   }
   // std::cout << " use phy " << usephyspace << " " << indx << " " << indy << " " << indz << std::endl;
   // std::cout << " Ind " << index << std::endl;
@@ -5906,7 +5906,7 @@ VImageMath(int argc, char * argv[])
     PixelType pix2;
     if (isfloat)
     {
-      pix2 = floatval;
+      pix2.Fill(floatval);
     }
     else
     {

--- a/Utilities/antsCommandLineOption.h
+++ b/Utilities/antsCommandLineOption.h
@@ -59,7 +59,7 @@ public:
 
   itkNewMacro(Self);
 
-  itkTypeMacro(Option, DataObject);
+  itkTypeMacro(OptionFunction, DataObject);
 
   typedef std::deque<std::string> ParameterStackType;
 
@@ -122,7 +122,7 @@ public:
 
   itkNewMacro(Self);
 
-  itkTypeMacro(Option, DataObject);
+  itkTypeMacro(CommandLineOption, DataObject);
 
   typedef OptionFunction OptionFunctionType;
 


### PR DESCRIPTION
Legacy removal is forced to ON [when wrapping is enabled](https://github.com/InsightSoftwareConsortium/ITK/blob/c8ec91c826898838f5f1a1a2a53849dd3efc9c88/CMakeLists.txt#L305-L310). Prepare ANTs for building in such a scenario. We will need it soon in https://github.com/thewtex/ANTsWasm.