### PR TITLE
COMP: Add missing include headers

### DIFF
--- a/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
+++ b/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
@@ -1,6 +1,8 @@
 #ifndef antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate__h_
 #define antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate__h_
 
+#include "itkImageDuplicator.h"
+
 namespace ants
 {
 /*

--- a/Utilities/itkantsReadWriteTransform.h
+++ b/Utilities/itkantsReadWriteTransform.h
@@ -7,7 +7,7 @@
 #include "itkImageFileWriter.h"
 #include "itkTransformFileReader.h"
 #include "itkTransformFileWriter.h"
-
+#include "itksys/SystemTools.hxx"
 #include "itkCompositeTransform.h"
 
 namespace itk


### PR DESCRIPTION
This happens when these files are used directly,
and not through default ANTs build system.


