### PR TITLE
BUG: Stop segmentation fault when Atropos is multi-threaded

### DIFF
--- a/ImageSegmentation/antsHistogramParzenWindowsListSampleFunction.h
+++ b/ImageSegmentation/antsHistogramParzenWindowsListSampleFunction.h
@@ -93,7 +93,7 @@ private:
 
   unsigned int                                      m_NumberOfHistogramBins;
   RealType                                          m_Sigma;
-  InterpolatorPointer                               m_Interpolator;
+  std::vector<InterpolatorPointer>                  m_Interpolators;
   std::vector<typename HistogramImageType::Pointer> m_HistogramImages;
 };
 } // end of namespace Statistics

--- a/ImageSegmentation/antsHistogramParzenWindowsListSampleFunction.hxx
+++ b/ImageSegmentation/antsHistogramParzenWindowsListSampleFunction.hxx
@@ -32,9 +32,6 @@ namespace Statistics
 template <typename TListSample, typename TOutput, typename TCoordRep>
 HistogramParzenWindowsListSampleFunction<TListSample, TOutput, TCoordRep>::HistogramParzenWindowsListSampleFunction()
 {
-  this->m_Interpolator = InterpolatorType::New();
-  this->m_Interpolator->SetSplineOrder(3);
-
   this->m_NumberOfHistogramBins = 32;
   this->m_Sigma = 1.0;
 }
@@ -187,6 +184,15 @@ HistogramParzenWindowsListSampleFunction<TListSample, TOutput, TCoordRep>::SetIn
     divider->Update();
     this->m_HistogramImages[d] = divider->GetOutput();
   }
+
+  this->m_Interpolators.clear();
+  this->m_Interpolators.resize(this->m_HistogramImages.size());
+    for (size_t d = 0; d < m_HistogramImages.size(); ++d)
+    {
+        this->m_Interpolators[d] = InterpolatorType::New();
+        this->m_Interpolators[d]->SetSplineOrder(3);
+        this->m_Interpolators[d]->SetInputImage(m_HistogramImages[d]);
+    }
 }
 
 template <typename TListSample, typename TOutput, typename TCoordRep>
@@ -202,10 +208,9 @@ HistogramParzenWindowsListSampleFunction<TListSample, TOutput, TCoordRep>::Evalu
       typename HistogramImageType::PointType point;
       point[0] = measurement[d];
 
-      this->m_Interpolator->SetInputImage(this->m_HistogramImages[d]);
-      if (this->m_Interpolator->IsInsideBuffer(point))
+      if (this->m_Interpolators[d]->IsInsideBuffer(point))
       {
-        probability *= static_cast<RealType>(this->m_Interpolator->Evaluate(point));
+        probability *= static_cast<RealType>(this->m_Interpolators[d]->Evaluate(point));
       }
       else
       {


### PR DESCRIPTION
Partial fix for #1627.

@ntustison, I tried replacing the local interpolator with a vector of interpolators for each bin at the class level. It improves the performance issue. I initialize the interpolators in the `SetInputListSample` function, which I think will cause them to stay up to date with respect to the m_HistogramImages, but I'm not sure.