### PR TITLE
ENH: Retain docker image from PRs

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -35,10 +35,24 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Build and push
+        name: Build and load (PR) or push (commit/tag)
         uses: docker/build-push-action@v3
         with:
-          context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+            context: .
+            push: ${{ github.event_name != 'pull_request' }}
+            load: ${{ github.event_name == 'pull_request' }}
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}
+      -
+        name: Export Docker image for PR
+        if: github.event_name == 'pull_request'
+        run: |
+          docker save antsx/ants:${{ steps.meta.outputs.version }} | gzip > ants_image.tar.gz
+      -
+        name: Upload PR Docker image as artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v3
+        with:
+            name: ants-docker-image
+            path: ants_image.tar.gz
+            retention-days: 7


### PR DESCRIPTION
This will make it easier to quickly download and test PRs, using temporary Github artifacts that expire after 7 days.
