### PR TITLE
ENH: Display debugging parameters only when verbose flag is turned on

### DIFF
--- a/ImageRegistration/itkANTSAffine3DTransform.hxx
+++ b/ImageRegistration/itkANTSAffine3DTransform.hxx
@@ -708,14 +708,17 @@ ANTSAffine3DTransform<TScalarType>::ComputeMatrixParameters()
     r = static_cast<double>(Q(0, 1) - Q(1, 0)) / s;
   }
 
-  std::cout << "A=" << A << std::endl;
-  std::cout << "rotation R" << Q << std::endl;
-  std::cout << "upper R" << R << std::endl;
-  std::cout << "s=" << s << " u=" << u << " v=" << v << " w" << w << " r=" << r << std::endl;
-
   m_Rotation = VnlQuaternionType(u, v, w, r);
 
-  std::cout << "m_Rotation from vnl" << VnlQuaternionType(u, v, w, r) << std::endl;
+  if (this->GetDebug())
+  {
+    std::cout << "A=\n" << A << std::endl;
+    std::cout << "rotation R\n" << Q << std::endl;
+    std::cout << "upper R\n" << R << std::endl;
+    std::cout << "s=" << s << " u=" << u << " v=" << v << " w" << w << " r=" << r << std::endl;
+
+    std::cout << "m_Rotation from vnl: " << VnlQuaternionType(u, v, w, r) << std::endl;
+  }
 
   m_S1 = R(0, 0);
   m_S2 = R(1, 1);

--- a/Utilities/itkAverageAffineTransformFunction.hxx
+++ b/Utilities/itkAverageAffineTransformFunction.hxx
@@ -86,12 +86,20 @@ AverageAffineTransformFunction<TTransform>::AverageMultipleAffineTransform(
   typename TransformListType::iterator it = m_TransformList.begin();
 
   typename InternalAffineTransformType::Pointer average_iaff = InternalAffineTransformType::New();
+  if (verbose)
+  {
+    average_iaff->DebugOn();
+  }
 
   typename InternalAffineTransformType::ParametersType average_parameters = average_iaff->GetParameters();
   for (; it != m_TransformList.end(); it++)
   {
     SingleInternalTransformItemType internal_item;
     internal_item.aff = InternalAffineTransformType::New();
+    if (verbose)
+    {
+      internal_item.aff->DebugOn();
+    }
     ConvertGenericAffineToInternalAffineByFixingCenter(it->aff, internal_item.aff, reference_center);
     internal_item.weight = it->weight;
     m_InternalTransformList.push_back(internal_item);


### PR DESCRIPTION
3D case outputs more debug parameters from within the transform itself. This is a follow-up to #1684.

