### PR TITLE
ENH: Check input for antsApplyTransforms matches dimensionality

### DIFF
--- a/Examples/antsApplyTransforms.cxx
+++ b/Examples/antsApplyTransforms.cxx
@@ -266,9 +266,9 @@ antsApplyTransforms(itk::ants::CommandLineParser::Pointer & parser, unsigned int
       // can only check files, so skip checks if using a pointer in ANTsR / ANTsPy
       if (verbose)
       {
-        std::cout << "Could not create ImageIO for the input file, cannot check pixel type" << std::endl;
+        std::cout << "Could not create ImageIO for the input file, assuming dimension = " << Dimension <<
+            " and scalar pixel type" << std::endl;
       }
-      return EXIT_FAILURE;
     }
     else
     {

--- a/Examples/antsApplyTransforms.cxx
+++ b/Examples/antsApplyTransforms.cxx
@@ -261,9 +261,13 @@ antsApplyTransforms(itk::ants::CommandLineParser::Pointer & parser, unsigned int
     itk::ImageIOBase::Pointer imageIO =
         itk::ImageIOFactory::CreateImageIO(inputFN.c_str(), itk::IOFileModeEnum::ReadMode);
 
-    if (!imageIO) {
-        std::cerr << "Could not create ImageIO for the input file: " << inputFN << std::endl;
-        return EXIT_FAILURE;
+    if (!imageIO)
+    {
+      if (verbose)
+      {
+        std::cout << "Could not create ImageIO for the input file: " << inputFN << std::endl;
+      }
+      return EXIT_FAILURE;
     }
 
     imageIO->SetFileName(inputFN.c_str());
@@ -272,17 +276,25 @@ antsApplyTransforms(itk::ants::CommandLineParser::Pointer & parser, unsigned int
     const size_t inputDimension = imageIO->GetNumberOfDimensions();
 
     // Check if the dimension matches
-    if (inputDimension != Dimension) {
-        std::cerr << "Input image dimension does not match. Expected: " << Dimension
-                  << ", but got: " << inputDimension << std::endl << "See -e option for available input types."
-                  << std::endl;
+    if (inputDimension != Dimension)
+    {
+        if (verbose)
+        {
+          std::cout << "Input image dimension does not match. Expected: " << Dimension
+                << ", but got: " << inputDimension << std::endl << "See -e option for available input types."
+                << std::endl;
+        }
         return EXIT_FAILURE;
     }
 
     // Check if the pixel type is scalar
-    if (imageIO->GetPixelType() != itk::IOPixelEnum::SCALAR) {
-        std::cerr << "Image pixel type is not scalar." << std::endl << "See -e option for available input types."
-                  << std::endl;
+    if (imageIO->GetPixelType() != itk::IOPixelEnum::SCALAR)
+    {
+        if (verbose)
+        {
+          std::cout << "Image pixel type is not scalar." << std::endl << "See -e option for available input types."
+                << std::endl;
+        }
         return EXIT_FAILURE;
     }
 
@@ -858,9 +870,10 @@ static void
 antsApplyTransformsInitializeCommandLineOptions(itk::ants::CommandLineParser * parser)
 {
   {
-    std::string description = std::string("This option forces the image to be treated as a specified-") +
-                              std::string("dimensional image.  If not specified, antsWarp tries to ") +
-                              std::string("infer the dimensionality from the input image.");
+    std::string description = std::string("Sets the dimensionality of transforms and scalar inputs.") +
+                              std::string("dimensional image.  This will be the same dimension as used in ") +
+                              std::string("antsRegistration. This does not change for multi-valued inputs, use ") +
+                              std::string("the -e option for time series and other multi-component images.");
 
     OptionType::Pointer option = OptionType::New();
     option->SetLongName("dimensionality");

--- a/Examples/antsApplyTransforms.cxx
+++ b/Examples/antsApplyTransforms.cxx
@@ -263,41 +263,43 @@ antsApplyTransforms(itk::ants::CommandLineParser::Pointer & parser, unsigned int
 
     if (!imageIO)
     {
+      // can only check files, so skip checks if using a pointer in ANTsR / ANTsPy
       if (verbose)
       {
-        std::cout << "Could not create ImageIO for the input file: " << inputFN << std::endl;
+        std::cout << "Could not create ImageIO for the input file, cannot check pixel type" << std::endl;
       }
       return EXIT_FAILURE;
     }
-
-    imageIO->SetFileName(inputFN.c_str());
-    imageIO->ReadImageInformation();
-
-    const size_t inputDimension = imageIO->GetNumberOfDimensions();
-
-    // Check if the dimension matches
-    if (inputDimension != Dimension)
+    else
     {
+      imageIO->SetFileName(inputFN.c_str());
+      imageIO->ReadImageInformation();
+
+      const size_t inputDimension = imageIO->GetNumberOfDimensions();
+
+      // Check if the dimension matches
+      if (inputDimension != Dimension)
+      {
         if (verbose)
-        {
-          std::cout << "Input image dimension does not match. Expected: " << Dimension
-                << ", but got: " << inputDimension << std::endl << "See -e option for available input types."
-                << std::endl;
-        }
-        return EXIT_FAILURE;
-    }
+          {
+            std::cout << "Input image dimension does not match. Expected: " << Dimension
+                    << ", but got: " << inputDimension << std::endl << "See -e option for available input types."
+                    << std::endl;
+          }
+          return EXIT_FAILURE;
+      }
 
-    // Check if the pixel type is scalar
-    if (imageIO->GetPixelType() != itk::IOPixelEnum::SCALAR)
-    {
+      // Check if the pixel type is scalar
+      if (imageIO->GetPixelType() != itk::IOPixelEnum::SCALAR)
+      {
         if (verbose)
         {
           std::cout << "Image pixel type is not scalar." << std::endl << "See -e option for available input types."
-                << std::endl;
+                  << std::endl;
         }
         return EXIT_FAILURE;
+      }
     }
-
     typename ImageType::Pointer image;
     ReadImage<ImageType>(image, inputFN.c_str());
     inputImages.push_back(image);


### PR DESCRIPTION
This checks that scalar input to `antsApplyTransforms` is actually an N-dimensional scalar image, and if it's not, exit with error advising users to use the correct input flag with `-e`.

It's my opinion that it's wise to inform users of fatal errors even if they don't use `--verbose`, but if that's going to break anything I can hide the error message for non-verbose execution.