### PR TITLE
ENH/BUG: CompositeTransformUtil --disassemble prepended to the output…

### DIFF
--- a/Examples/CompositeTransformUtil.cxx
+++ b/Examples/CompositeTransformUtil.cxx
@@ -70,7 +70,7 @@ Disassemble(itk::TransformBaseTemplate<double> * transform,
     TransformPointer  curXfrm = composite->GetNthTransform(i);
     auto *            dispXfrm = dynamic_cast<DisplacementFieldTransformType *>(curXfrm.GetPointer());
     std::stringstream fname;
-    fname << std::setfill('0') << std::setw(2) << i << "_" << prefix << "_" << curXfrm->GetNameOfClass();
+    fname << prefix << "_" << std::setfill('0') << std::setw(2) << i << "_" << curXfrm->GetNameOfClass();
     if (dispXfrm != nullptr)
     {
       fname << ".nii.gz"; // if it's a displacement field transform


### PR DESCRIPTION
… prefix

This makes it impossible to output transforms anywhere but the current working directory

Now fixed to write prefix_{number}_{transformtype} rather than {number}_prefix_{transformtype}