### PR TITLE
ENH: Suppress "Bad Rotation Matrix" warnings

### DIFF
--- a/ImageRegistration/itkANTSCenteredAffine2DTransform.hxx
+++ b/ImageRegistration/itkANTSCenteredAffine2DTransform.hxx
@@ -133,9 +133,12 @@ ANTSCenteredAffine2DTransform<TScalarType>::ComputeMatrixParameters(void)
 
   this->ComputeMatrix();
 
-  if (static_cast<double>(this->GetMatrix()[1][0]) - static_cast<double>(std::sin(m_Angle)) > 0.000001)
+  if (this->GetDebug())
   {
-    itkWarningMacro("Bad Rotation Matrix " << this->GetMatrix());
+    if (static_cast<double>(this->GetMatrix()[1][0]) - static_cast<double>(std::sin(m_Angle)) > 0.000001)
+    {
+      itkWarningMacro("Bad Rotation Matrix " << this->GetMatrix());
+    }
   }
 }
 


### PR DESCRIPTION
This warning show up a lot for me (e.g. from [here](https://github.com/dzenanz/ANTsWasm/commit/e85adc1959b80fc5252a5579cab1866e7cc4e615)). Should I be concerned?

Example of occurrence:

```log
Progress  | 0 | 0.01 | 0.0345 | 0.059 | 0.0835 | 0.108 | 0.1325 | 0.157 | 0.1815 | 0.206
 | 0.2305 | 0.255WARNING: In C:\Dev\ANTsWasm\VS22py\_deps\ants_inner-src\ImageRegistration\itkANTSCenteredAffine2DTransform.hxx, line 138
ANTSCenteredAffine2DTransform (000002581E7CA7F0): Bad Rotation Matrix 1.02555 -0.00607706 0.00711725 1.02636

WARNING: In C:\Dev\ANTsWasm\VS22py\_deps\ants_inner-src\ImageRegistration\itkANTSCenteredAffine2DTransform.hxx, line 138 ANTSCenteredAffine2DTransform (000002581E930950): Bad Rotation Matrix 1.0038 0.000658097 0.0181835 1.0196

WARNING: In C:\Dev\ANTsWasm\VS22py\_deps\ants_inner-src\ImageRegistration\itkANTSCenteredAffine2DTransform.hxx, line 138 ANTSCenteredAffine2DTransform (000002581E8193D0): Bad Rotation Matrix 1.01296 -0.000485504 0.00252202 0.99968

WARNING: In C:\Dev\ANTsWasm\VS22py\_deps\ants_inner-src\ImageRegistration\itkANTSCenteredAffine2DTransform.hxx, line 138 ANTSCenteredAffine2DTransform (000002581F07ABF0): Bad Rotation Matrix 1.00139 -0.0353489 0.014181 0.954691

WARNING: In C:\Dev\ANTsWasm\VS22py\_deps\ants_inner-src\ImageRegistration\itkANTSCenteredAffine2DTransform.hxx, line 138 ANTSCenteredAffine2DTransform (000002581E8F5140): Bad Rotation Matrix 0.94323 0.00672548 -0.0293821 1.00311

 | 0.2795 | 0.304 | 0.3285 | 0.353 | 0.3775 | 0.402 | 0.4265 | 0.451
 | 0.4755 | 0.5WARNING: In C:\Dev\ANTsWasm\VS22py\_deps\ants_inner-src\ImageRegistration\itkANTSCenteredAffine2DTransform.hxx, line 138
ANTSCenteredAffine2DTransform (000002581EC262E0): Bad Rotation Matrix 1.01756 -0.00261415 0.0241831 1.00784

WARNING: In C:\Dev\ANTsWasm\VS22py\_deps\ants_inner-src\ImageRegistration\itkANTSCenteredAffine2DTransform.hxx, line 138 ANTSCenteredAffine2DTransform (000002581EC265A0): Bad Rotation Matrix 1.05521 -0.0124403 0.0215943 0.991163

WARNING: In C:\Dev\ANTsWasm\VS22py\_deps\ants_inner-src\ImageRegistration\itkANTSCenteredAffine2DTransform.hxx, line 138 ANTSCenteredAffine2DTransform (000002581F29B710): Bad Rotation Matrix 0.943761 -0.00148547 -0.0278611 1.00295

 | 0.5245 | 0.549 | 0.5735 | 0.598 | 0.6225 | 0.647 | 0.6715 | 0.696
 | 0.7205 | 0.745WARNING: In C:\Dev\ANTsWasm\VS22py\_deps\ants_inner-src\ImageRegistration\itkANTSCenteredAffine2DTransform.hxx, line 138
ANTSCenteredAffine2DTransform (000002581EF693A0): Bad Rotation Matrix 1.02405 -0.00516537 0.0336307 1.01107

WARNING: In C:\Dev\ANTsWasm\VS22py\_deps\ants_inner-src\ImageRegistration\itkANTSCenteredAffine2DTransform.hxx, line 138 ANTSCenteredAffine2DTransform (000002581EF69BE0): Bad Rotation Matrix 1.04952 -0.0166267 0.00826341 0.983876

WARNING: In C:\Dev\ANTsWasm\VS22py\_deps\ants_inner-src\ImageRegistration\itkANTSCenteredAffine2DTransform.hxx, line 138 ANTSCenteredAffine2DTransform (000002581EF69D40): Bad Rotation Matrix 0.946308 -0.0141908 -0.0155272 1.0036

 | 0.7695 | 0.794 | 0.8185 | 0.843 | 0.8675 | 0.892 | 0.9165 | 0.941
 | 0.9655 | 0.99WARNING: In C:\Dev\ANTsWasm\VS22py\_deps\ants_inner-src\ImageRegistration\itkANTSCenteredAffine2DTransform.hxx, line 138
ANTSCenteredAffine2DTransform (000002581EDCFCE0): Bad Rotation Matrix 1.02332 -0.0042626 0.0304406 1.01458

WARNING: In C:\Dev\ANTsWasm\VS22py\_deps\ants_inner-src\ImageRegistration\itkANTSCenteredAffine2DTransform.hxx, line 138 ANTSCenteredAffine2DTransform (000002581EDD07E0): Bad Rotation Matrix 1.04445 -0.00741455 0.0214106 0.99242

WARNING: In C:\Dev\ANTsWasm\VS22py\_deps\ants_inner-src\ImageRegistration\itkANTSCenteredAffine2DTransform.hxx, line 138 ANTSCenteredAffine2DTransform (000002581EDD0680): Bad Rotation Matrix 0.955261 -0.0237769 -0.00559731 0.994758

 | 1
Filter took 147.606 seconds.
```

Should we try to retain these warnings in command-line tools?
