### PR TITLE
COMP: Cancel previous ci builds

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -13,6 +13,11 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) }}
+
 jobs:
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
If multiple pushes are made to the same branch or PR, cancel prior CI runs

Avoids wasting time and also prevents dockerhub getting out of sync