### PR TITLE
CI: Drop v from release versions

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -32,6 +32,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: antsx/ants
+          tags: |
+            type=ref,event=tag,enable=true,strip-prefix=v
+            type=ref,event=branch
       -
         name: Login to DockerHub
         if: github.event_name != 'pull_request'

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -35,6 +35,7 @@ jobs:
           tags: |
             type=ref,event=tag,enable=true,strip-prefix=v
             type=ref,event=branch
+            type=ref,event=pr,prefix=pr-
       -
         name: Login to DockerHub
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
These were originally part of version labels but now we use X.Y.Z not vX.Y.Z. Makes sense to do the same for Dockerhub