### PR TITLE
ENH: Make eccentricity more similar to elongation

### DIFF
--- a/Examples/LabelGeometryMeasures.cxx
+++ b/Examples/LabelGeometryMeasures.cxx
@@ -199,7 +199,13 @@ LabelGeometryMeasures(int argc, char * argv[])
     // Get principal moments and use them to calculate eccentricity and axes lengths
     auto principalMoments = labelObject->GetPrincipalMoments();
 
-    double lambda1 = principalMoments[0];
+    // define in 3D such that it describes the ellipse with axes propotional to the
+    // two largest principal moments. This is useful eg for cortex, where the thickness
+    // is much smaller than the other two dimensions.
+    //
+    // Roundness gives a more general measure of deviation from a sphere, including all three dimensions.
+    //
+    double lambda1 = principalMoments[ImageDimension - 2];
     double lambdaN = principalMoments[ImageDimension - 1];
     double eccentricity = 0.0;
 


### PR DESCRIPTION
Related to #1733 

Given a 3D object with principal moments V_0 <= V_1 <= V_2, itkShapeLabelMapFilter computes elongation as sqrt(V_2 / V_1).

It doesn't compute eccentricity, so I had added that to LabelGeometryMeasures as sqrt(1 - V_2^2 / V_0^2).

But I think it might be better to use sqrt(1 - V_2^2 / V_1^2), so that it works on the same moments as the elongation. For cortex and other thin structures, the relative shape of the longer sides are often more interesting anyway.

The new filter also has roundness, which is a measure of similarity to a sphere and considers all three axes.