### PR TITLE
ENH: update and reformat README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Advanced Normalization Tools (ANTs) is a C++ library available through the comma
 
 The ANTs library is considered a state-of-the-art medical image registration and segmentation toolkit which depends on the Insight ToolKit, a widely used medical image processing library to which ANTs developers contribute. ANTs-related tools have also won several international, unbiased competitions such as MICCAI, BRATS, and STACOM.
 
-It is also possible to use ANTs in R ([ANTsR](https://github.com/antsx/antsr)) and Python ([ANTsPy](https://github.com/antsx/antsr)), with additional functionality for deep learning in R ([ANTsRNet](https://github.com/antsx/antsrnet)) and Python ([ANTsPyNet](https://github.com/antsx/antspynet)). These libraries make it possible to integrate ANTs with the broader R and Python ecosystem.
+It is also possible to use ANTs in R ([ANTsR](https://github.com/antsx/antsr)) and Python ([ANTsPy](https://github.com/antsx/antsr)), with additional functionality for deep learning in R ([ANTsRNet](https://github.com/antsx/antsrnet)) and Python ([ANTsPyNet](https://github.com/antsx/antspynet)). These libraries help integrate ANTs with the broader R / Python ecosystems.
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Advanced Normalization Tools (ANTs) is a C++ and command-line library that compu
 
 The ANTs library is considered a state-of-the-art medical image registration and segmentation toolkit which depends on the Insight ToolKit, a widely used medical image processing library to which ANTs developers contribute. ANTs-related tools have also won several international, unbiased challenges and competitions such as MICCAI, BRATS, and STACOM.
 
-You can also use ANTs in R ([ANTsR](https://github.com/antsx/antsr)) and Python ([ANTsPy](https://github.com/antsx/antsr)), with additional functionality for deep learning in R ([ANTsRNet](https://github.com/antsx/antsrnet)) and Python ([ANTsPyNet](https://github.com/antsx/antspynet)). These libraries also include additional functionality for interacting with the broader R and Python ecosystem.
+You can also use ANTs in R ([ANTsR](https://github.com/antsx/antsr)) and Python ([ANTsPy](https://github.com/antsx/antsr)), with additional functionality for deep learning in R ([ANTsRNet](https://github.com/antsx/antsrnet)) and Python ([ANTsPyNet](https://github.com/antsx/antspynet)). These libraries make it possible to integrate ANTs with the broader R and Python ecosystem.
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ More details and a full downloadable installation script can be found in the [Li
 There are many different resources for learning about how to use ANTs functions and the methodology behind them. The [Wiki](https://github.com/ANTsX/ANTs/wiki) is a good place to start, but a selected list of commonly visited tutorials is also provided here.
 
 - ANTs Documentation [[Link](https://github.com/stnava/ANTsDoc/blob/master/ants2.pdf)]
+- ANTs Tutorial Repo [[Link](https://github.com/stnava/ANTsTutorial)
 - Using antsRegistration [[Link](https://github.com/ANTsX/ANTs/wiki/ANTS-and-antsRegistration)]
 - Using antsCorticalThickness [[Link](https://github.com/ANTsX/ANTs/wiki/antsCorticalThickness-and-antsLongitudinalCorticalThickness-output)]
 - Using N4BiasFieldCorrection [[Link](https://github.com/ANTsX/ANTs/wiki/N4BiasFieldCorrection)]

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ ANTs is a flexible library that can be used for a variety of applications and ar
 
 ### Registration
 
-- Basic example [[Link](https://github.com/stnava/ANTs/blob/master/Scripts/newAntsExample.sh)]
-- Basic example with mask [[Link](https://github.com/ntustison/antsRegistrationWithMaskExample)]
+- Basic registration [[Link](https://github.com/stnava/ANTs/blob/master/Scripts/newAntsExample.sh)]
+- Basic registration with mask [[Link](https://github.com/ntustison/antsRegistrationWithMaskExample)]
 - Large deformation [[Link](http://stnava.github.io/C/)]
 - Asymmetry [[Link](http://stnava.github.io/asymmetry/)]
 - Automobile registration [[Link](http://stnava.github.io/cars/)]
@@ -76,7 +76,7 @@ ANTs is a flexible library that can be used for a variety of applications and ar
   
 ### Cortical thickness
 
-- Basic example [[Link](https://github.com/ntustison/antsCorticalThicknessExample)]
+- Basic cortical thickness [[Link](https://github.com/ntustison/antsCorticalThicknessExample)]
 - Chimpanzee example [[Link](https://github.com/stnava/WHopkinsNHP/)]
 
 ### Segmentation
@@ -85,7 +85,7 @@ ANTs is a flexible library that can be used for a variety of applications and ar
 
 ### Neuroimages
 
-- Basic Brain Mapping [[Link](http://stnava.github.io/BasicBrainMapping/)]
+- Basic brain mapping [[Link](http://stnava.github.io/BasicBrainMapping/)]
 - Brain extraction [[Link](https://github.com/ntustison/antsBrainExtractionExample)]
 - Multi-atlas joint label/intensity fusion [[Link](https://github.com/ntustison/MalfLabelingExample), [Link](https://github.com/qureai/Multi-Atlas-Segmentation)] (credit: @chsasank)
 - fMRI or Motion Correction [[Link](http://stnava.github.io/fMRIANTs/)]

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ ANTs is a flexible library that can be used for a variety of applications and ar
 - N4 bias correction + Atropos [[Link](https://github.com/ntustison/antsAtroposN4Example)]
 - Brain tumor segmentation [[Link](https://github.com/ntustison/BRATS2013/tree/master/SimpleExample)]
 
-### Neuroimages
+### Brain
 
 - Basic brain mapping [[Link](http://stnava.github.io/BasicBrainMapping/)]
 - Brain extraction [[Link](https://github.com/ntustison/antsBrainExtractionExample)]

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ ANTs is a flexible library that can be used for a variety of applications and ar
   
 ### Template construction
 
+- Brain template [[Link](http://ntustison.github.io/TemplateBuildingExample/)]
+- Single subject template [[Link](https://github.com/ntustison/SingleSubjectTemplateExample)]
+  
 ### Cortical thickness
 
 ### Joint label fusion
@@ -85,26 +88,15 @@ ANTs is a flexible library that can be used for a variety of applications and ar
 ### Neuroimages
 
 - Basic Brain Mapping [[Link](http://stnava.github.io/BasicBrainMapping/)]
+- Brain extraction [[Link](https://github.com/ntustison/antsBrainExtractionExample)]
 
+See also our pre-built ANTs templates with spatial priors available for [download](http://figshare.com/articles/ANTs_ANTsR_Brain_Templates/915436) including an [MNI version](https://figshare.com/articles/ANTs_files_for_mni_icbm152_nlin_sym_09a/8061914).
+  
 ### Lung
 
 ### Cardiac
 
 
-### General
-
-* **antsRegistration** [bash example](https://github.com/stnava/ANTs/blob/master/Scripts/newAntsExample.sh)
-* **antsRegistration with mask** [(bash, ANTsR and ANTsPy examples)](https://github.com/ntustison/antsRegistrationWithMaskExample)
-* **Large deformation** [(bash, ANTsR and ANTsPy examples)](http://stnava.github.io/C/)
-* **Automobile** [(bash and ANTsR examples)](http://stnava.github.io/cars/)
-* **Asymmetry** [example](http://stnava.github.io/asymmetry/)
-* **Point-set** [mapping](http://stnava.github.io/chicken/) which includes the PSE metric and affine and deformable registration with (labeled) pointsets or iterative closest point
-* **Feature matching** [example](http://stnava.github.io/featureMatching/) ... not up to date ...
-* **Global optimization** [example](http://stnava.github.io/butterfly/)
-* **Patch-based super resolution** [example](https://github.com/ntustison/NonLocalSuperResolutionExample)
-* **Image denoising** [(bash, ANTsR and ANTsPy examples)](https://github.com/ntustison/DenoiseImageExample)
-* **Visualization** [example](https://github.com/ntustison/antsVisualizationExamples)
-* **Morphing** [example](http://stnava.github.io/Morpheus/)
 
 ### Neuro
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,27 @@ More details and a full downloadable installation script can be found in the [Li
 
 ANTs is a flexible library that can be used for a variety of applications and areas. Below is a collection of example scripts that - with a little effort - can be adapted to fit your specific needs.
 
+### Registration
+
+- Basic example [[Link](https://github.com/stnava/ANTs/blob/master/Scripts/newAntsExample.sh)]
+- Basic with mask [Link](https://github.com/ntustison/antsRegistrationWithMaskExample)]
+- Large deformation [[Link](http://stnava.github.io/C/)]
+
+### Template construction
+
+### Cortical thickness
+
+### Joint label fusion
+
+### Segmentation
+
+### fMRI
+
+### Lung
+
+### Cardiac
+
+
 ### General
 
 * **antsRegistration** [bash example](https://github.com/stnava/ANTs/blob/master/Scripts/newAntsExample.sh)

--- a/README.md
+++ b/README.md
@@ -64,15 +64,17 @@ More details and a full downloadable installation script can be found in the [Li
 
 ## Resources
 
-There are many different resources for learning about how to use ANTs functions and the methodology behind them. 
+There are many different resources for learning about how to use ANTs functions and the methodology behind them. The [Wiki](https://github.com/ANTsX/ANTs/wiki) is a good place to start. A selected list of tutorials is also provided here.
+
+- ANTs Documentation [PDF](https://github.com/stnava/ANTsDoc/blob/master/ants2.pdf)
 
 <br />
 
 ## Contributing
 
-If you have a question, feature request, or bug report the best way to get help is by posting an issue on the GitHub page. Please remember to give as much detail as possible to reproduce your environment - including code, OS, ANTs version, and example images where possible. It is difficult to provide any help without being to reproduce your issue.
+If you have a question, feature request, or bug report the best way to get help is by posting an issue on the GitHub page. Please remember that it is difficult to provide any help without being to reproduce your issue.
 
-We welcome any new contributions and ideas to improve ANTs. If you want to contribute code, the best way to get started is by reading through the [Wiki](https://github.com/ANTsX/ANTs/wiki) to get an understanding of the project. ANTs relies heavily on ITK, so learning more about that project is also a good place to start.
+We welcome any new contributions and ideas to improve ANTs. If you want to contribute code, the best way to get started is by reading through the [Wiki](https://github.com/ANTsX/ANTs/wiki) to get an understanding of the project or posting an issue.
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ More details and a full downloadable installation script can be found in the [Li
 
 ## Examples
 
-ANTs is a flexible library that can be used for a variety of applications and areas. Below is a collection of example scripts that - with a little effort - can be adapted to fit your specific needs. Some of these examples also include code for performing the same operations with ANTsR or ANTsPy.
+ANTs is a flexible library that can be used for a variety of applications and areas. Below is a collection of example scripts that - with a little effort - can be adapted to fit your specific needs. Some examples also include code for ANTsR or ANTsPy.
 
 ### Registration
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can check that this worked by running a command to find the path to any ANTs
 which antsRegistration
 ```
 
-If that works, you should be able to use the full functionality of ANTs from the command line.
+If that works, you should be able to use the full functionality of ANTs from the command line or bash.
 
 ### Building from source
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ More details and a full downloadable installation script can be found in the [Li
 There are many different resources for learning about how to use ANTs functions and the methodology behind them. The [Wiki](https://github.com/ANTsX/ANTs/wiki) is a good place to start, but a selected list of commonly visited tutorials is also provided here.
 
 - ANTs Documentation [[Link](https://github.com/stnava/ANTsDoc/blob/master/ants2.pdf)]
-- ANTs Tutorial Repo [[Link](https://github.com/stnava/ANTsTutorial)
+- ANTs Tutorial Repo [[Link](https://github.com/stnava/ANTsTutorial)]
 - Using antsRegistration [[Link](https://github.com/ANTsX/ANTs/wiki/ANTS-and-antsRegistration)]
 - Using antsCorticalThickness [[Link](https://github.com/ANTsX/ANTs/wiki/antsCorticalThickness-and-antsLongitudinalCorticalThickness-output)]
 - Using N4BiasFieldCorrection [[Link](https://github.com/ANTsX/ANTs/wiki/N4BiasFieldCorrection)]

--- a/README.md
+++ b/README.md
@@ -61,90 +61,48 @@ ANTs is a flexible library that can be used for a variety of applications and ar
 ### General
 
 * **antsRegistration** [bash example](https://github.com/stnava/ANTs/blob/master/Scripts/newAntsExample.sh)
-
 * **antsRegistration with mask** [(bash, ANTsR and ANTsPy examples)](https://github.com/ntustison/antsRegistrationWithMaskExample)
-
-* **ANTs and ITK** [paper](http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4009425/)
-
 * **Large deformation** [(bash, ANTsR and ANTsPy examples)](http://stnava.github.io/C/)
-
 * **Automobile** [(bash and ANTsR examples)](http://stnava.github.io/cars/)
-
 * **Asymmetry** [example](http://stnava.github.io/asymmetry/)
-
 * **Point-set** [mapping](http://stnava.github.io/chicken/) which includes the PSE metric and affine and deformable registration with (labeled) pointsets or iterative closest point
-
 * **Feature matching** [example](http://stnava.github.io/featureMatching/) ... not up to date ...
-
 * **Global optimization** [example](http://stnava.github.io/butterfly/)
-
 * **Patch-based super resolution** [example](https://github.com/ntustison/NonLocalSuperResolutionExample)
-
 * **Image denoising** [(bash, ANTsR and ANTsPy examples)](https://github.com/ntustison/DenoiseImageExample)
-
 * **Visualization** [example](https://github.com/ntustison/antsVisualizationExamples)
-
 * **Morphing** [example](http://stnava.github.io/Morpheus/)
-
-* **Bibliography** [bibtex of ANTs-related papers](https://github.com/stnava/ANTsBibliography)
-
-* **ANTs** [google scholar page](http://scholar.google.com/citations?user=ox-mhOkAAAAJ&hl=en)
 
 ### Neuro
 
 * **Basic Brain Mapping** [(bash and ANTsR examples)](http://stnava.github.io/BasicBrainMapping/)
-
 * **Template construction** [(bash, ANTsR and ANTsPy examples)](http://ntustison.github.io/TemplateBuildingExample/)
-
 * **Single subject template construction** [example](https://github.com/ntustison/SingleSubjectTemplateExample)
-
 * **Pre-built ANTs templates with spatial priors** [download](http://figshare.com/articles/ANTs_ANTsR_Brain_Templates/915436) including an [MNI version](https://figshare.com/articles/ANTs_files_for_mni_icbm152_nlin_sym_09a/8061914).
-
 * **Brain extraction** [(bash and ANTsR examples)](https://github.com/ntustison/antsBrainExtractionExample)
-
 * **N4 bias correction <-> segmentation** [(bash, ANTsR and ANTsPy examples)](https://github.com/ntustison/antsAtroposN4Example)
-
 * **Cortical thickness** [example](https://github.com/ntustison/antsCorticalThicknessExample)
-
 * **"Cooking" tissue priors for templates**
   [example](https://github.com/ntustison/antsCookTemplatePriorsExample)
   (after you build your template)
-
 * **Multi-atlas joint label/intensity fusion examples** [(bash and ANTsR examples 1)](https://github.com/ntustison/MalfLabelingExample) [example 2](https://github.com/qureai/Multi-Atlas-Segmentation) (thanks to @chsasank)
-
-* **The ANTs Cortical Thickness Pipeline** [example](https://github.com/ntustison/KapowskiChronicles/blob/master/paper2.pdf?raw=true)
-
 * **Chimpanzee cortical thickness** [example](https://github.com/stnava/WHopkinsNHP/)
-
 * **Brain tumor segmentation** [example](https://github.com/ntustison/BRATS2013/tree/master/SimpleExample)
-
-* **Eigenanatomy** for [multivariate neuroimage analysis](http://www.ncbi</a>.nlm.nih.gov/pubmed/23269595) via
-    [PCA](http://www.ncbi.nlm.nih.gov/pubmed/23286132) &
-    [CCA](http://www.ncbi.nlm.nih.gov/pubmed/20083207)
-
 * **fMRI or Motion Correction** [example](http://stnava.github.io/fMRIANTs/)
-
 * **fMRI reproducibility** [example](http://stnava.github.io/RfMRI/)
-
 * **fMRI prediction** [example](http://stnava.github.io/Haxby2001/) ... WIP ...
-
 * **Partial EPI slab to T1 image registration** [example](https://github.com/ntustison/PartialSlabEpiT1ImageRegistration)
 
 ### Lung
 
 * **CT lung registration** [(bash and ANTsR examples)](https://github.com/ntustison/antsCtLungRegistrationExample)
-
 * **Lung mask registration** [example](https://github.com/ntustison/ProtonCtLungMaskRegistration)
-
 * **Lung and lobe estimation** [example](https://github.com/ntustison/LungAndLobeEstimationExample)
-
 * **Lung ventilation-based segmentation** [example](https://github.com/ntustison/LungVentilationSegmentationExample)
 
 ### Cardiac
 
 * **Cardiac** [example](http://stnava.github.io/LabelMyHeart)
-
-
 
 <br />
 
@@ -153,15 +111,10 @@ ANTs is a flexible library that can be used for a variety of applications and ar
 There are many different resources for learning about how to use ANTs functions and the methodology behind them. The [Wiki](https://github.com/ANTsX/ANTs/wiki) is a good place to start, but a selected list of commonly visited tutorials is also provided here.
 
 * ANTs Documentation [[Link](https://github.com/stnava/ANTsDoc/blob/master/ants2.pdf)]
-  
 * ANTs Tutorial Repo [[Link](https://github.com/stnava/ANTsTutorial)]
-
 * Using antsRegistration [[Link](https://github.com/ANTsX/ANTs/wiki/ANTS-and-antsRegistration)]
-
 * Using antsCorticalThickness [[Link](https://github.com/ANTsX/ANTs/wiki/antsCorticalThickness-and-antsLongitudinalCorticalThickness-output)]
-
 * Using N4BiasFieldCorrection [[Link](https://github.com/ANTsX/ANTs/wiki/N4BiasFieldCorrection)]
-
 * Multi-modality Presentation [[Link](https://github.com/stnava/ANTS_MultiModality/blob/master/ants_multimodality.pdf)]
   
 <br />

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ More details and a full downloadable installation script can be found in the [Li
 
 <br />
 
-## Overview
-
-<br />
-
 ## Examples
+
+ANTs is a flexible library that can be used for a variety of applications and areas. Below is a collection of example scripts that can be easily adapted to fit your needs.
+
+
 
 <br />
 
@@ -66,11 +66,12 @@ More details and a full downloadable installation script can be found in the [Li
 
 There are many different resources for learning about how to use ANTs functions and the methodology behind them. The [Wiki](https://github.com/ANTsX/ANTs/wiki) is a good place to start, but a selected list of commonly visited tutorials is also provided here.
 
-- ANTs Documentation [[Link](https://github.com/stnava/ANTsDoc/blob/master/ants2.pdf)]
-- ANTs Tutorial Repo [[Link](https://github.com/stnava/ANTsTutorial)]
+- ANTs Documentation [[PDF](https://github.com/stnava/ANTsDoc/blob/master/ants2.pdf)]
+- ANTs Tutorial Repo [[Repo](https://github.com/stnava/ANTsTutorial)]
 - Using antsRegistration [[Link](https://github.com/ANTsX/ANTs/wiki/ANTS-and-antsRegistration)]
 - Using antsCorticalThickness [[Link](https://github.com/ANTsX/ANTs/wiki/antsCorticalThickness-and-antsLongitudinalCorticalThickness-output)]
 - Using N4BiasFieldCorrection [[Link](https://github.com/ANTsX/ANTs/wiki/N4BiasFieldCorrection)]
+- Multi-modality Presentation [[Slides](https://github.com/stnava/ANTS_MultiModality/blob/master/ants_multimodality.pdf)]
   
 <br />
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can check that this worked by running a command to find the path to any ANTs
 which antsRegistration
 ```
 
-If that works, you should be able to use the full functionality of ANTs.
+If that works, you should be able to use the full functionality of ANTs from the command line.
 
 ### Building from source
 

--- a/README.md
+++ b/README.md
@@ -104,39 +104,41 @@ A large collection of journal articles have been published using ANTs software a
 
 <i>Evaluation of 14 nonlinear deformation algorithms applied to human brain MRI registration.</i> Neuroimage (2009). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/19195496)]
 
-<i>Evaluation of registration methods on thoracic CT: the EMPIRE10 challenge.</i> IEEE Trans Med Imaging (2011) [[Link](http://www.ncbi.nlm.nih.gov/pubmed/21632295)]
+<i>Evaluation of registration methods on thoracic CT: the EMPIRE10 challenge.</i> IEEE Trans Med Imaging (2011). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/21632295)]
 
-<i>A reproducible evaluation of ANTs similarity metric performance in brain image registration.</i> Neuroimage (2011). [[Link]](https://pubmed.ncbi.nlm.nih.gov/20851191/)
+<i>A reproducible evaluation of ANTs similarity metric performance in brain image registration.</i> Neuroimage (2011). [[Link](https://pubmed.ncbi.nlm.nih.gov/20851191/)]
 
-<i>Multivariate analysis of structural and diffusion imaging in traumatic brain injury.</i> Acad Radiol (2008). [[Link]](http://www.ncbi.nlm.nih.gov/pubmed/18995188)
+<i>Multivariate analysis of structural and diffusion imaging in traumatic brain injury.</i> Acad Radiol (2008). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/18995188)]
 
 ### Templates
 
-<i>The optimal template effect in hippocampus studies of diseased populations.</i> Neuroimage (2010). [[Link]](https://pubmed.ncbi.nlm.nih.gov/19818860/)
+<i>The optimal template effect in hippocampus studies of diseased populations.</i> Neuroimage (2010). [[Link](https://pubmed.ncbi.nlm.nih.gov/19818860/)]
 
 ### Image Segmentation
 
-<i>An open source multivariate framework for n-tissue segmentation with evaluation on public data</i> Neuroinformatics (2011). [[Link]](http://www.ncbi.nlm.nih.gov/pubmed/21373993)
+<i>An open source multivariate framework for n-tissue segmentation with evaluation on public data</i> Neuroinformatics (2011). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/21373993)]
 
-<i>Multi-atlas segmentation with joint label fusion and corrective learning—an open source implementation</i> Front Neuroinform (2013). [[Link]](https://www.frontiersin.org/articles/10.3389/fninf.2013.00027/full)
+<i>Multi-atlas segmentation with joint label fusion and corrective learning—an open source implementation</i> Front Neuroinform (2013). [[Link](https://www.frontiersin.org/articles/10.3389/fninf.2013.00027/full)]
 
 ### Bias Correction
 
-<i>N4ITK: improved N3 bias correction</i> IEEE Trans Med Imaging (2010). [[Link]](http://www.ncbi.nlm.nih.gov/pubmed/20378467)
+<i>N4ITK: improved N3 bias correction</i> IEEE Trans Med Imaging (2010). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/20378467)]
 
 ### Cortical Thickness
 
-<i>Registration based cortical thickness measurement</i> Neuroimage (2009). [[Link]](http://www.ncbi.nlm.nih.gov/pubmed/19150502)
+<i>Registration based cortical thickness measurement</i> Neuroimage (2009). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/19150502)]
 
-<i>Regional and hemispheric variation in cortical thickness in chimpanzees</i> J Neurosci (2013). [[Link]](http://www.ncbi.nlm.nih.gov/pubmed/23516289)
+<i>Regional and hemispheric variation in cortical thickness in chimpanzees</i> J Neurosci (2013). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/23516289)]
 
 ### Eigenanatomy 
 
-<i>Eigenanatomy improves detection power for longitudinal cortical change</i> Med Image Comput Comput Assist Interv (2012) [[Link]](http://www.ncbi.nlm.nih.gov/pubmed/23286132)
+<i>Eigenanatomy improves detection power for longitudinal cortical change</i> Med Image Comput Comput Assist Interv (2012). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/23286132)]
 
-<i>White matter imaging helps dissociate tau from TDP-43 in frontotemporal lobar degeneration</i> J Neurol Neurosurg Psychiatry (2013). [[Link]](https://pubmed.ncbi.nlm.nih.gov/23475817/)
+<i>White matter imaging helps dissociate tau from TDP-43 in frontotemporal lobar degeneration</i> J Neurol Neurosurg Psychiatry (2013). [[Link](https://pubmed.ncbi.nlm.nih.gov/23475817/)]
 
-<i>Dementia induces correlated reductions in white matter integrity and cortical thickness: a multivariate neuroimaging study with sparse canonical correlation analysis</i> Neuroimage (2010). [[Link]](https://pubmed.ncbi.nlm.nih.gov/20083207/)
+### Software
+
+<i>The ANTsX ecosystem for quantitative biological and medical imaging</i> Scientific Reports (2021). [[Link](https://www.nature.com/articles/s41598-021-87564-6)]
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -108,8 +108,6 @@ A large collection of journal articles have been published using ANTs software a
 
 <i>A reproducible evaluation of ANTs similarity metric performance in brain image registration.</i> Neuroimage (2011). [[Link](https://pubmed.ncbi.nlm.nih.gov/20851191/)]
 
-<i>Multivariate analysis of structural and diffusion imaging in traumatic brain injury.</i> Acad Radiol (2008). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/18995188)]
-
 ### Templates
 
 <i>The optimal template effect in hippocampus studies of diseased populations.</i> Neuroimage (2010). [[Link](https://pubmed.ncbi.nlm.nih.gov/19818860/)]

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Development of ANTs is led by the following people:
 - [Nicholas J. Tustison](http://ntustison.github.io/CV/) - UVA (Compeller, Algorithm Design, Implementation Guru)
 - Hans J. Johnson - UIowa (Large-Scale Application, Testing, Software design). 
 
-The core development team consists of Gang Song (Originator), Philip A. Cook, Jeffrey T. Duda (DTI), Ben M. Kandel (Perfusion, multivariate analysis).
+The core development team also consists of Gang Song (Originator), Philip A. Cook, Jeffrey T. Duda (DTI), Ben M. Kandel (Perfusion, multivariate analysis).
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -115,10 +115,11 @@ See also our pre-built ANTs templates with spatial priors available for download
 
 ## Learning resources
 
-There are many different resources for learning about how to use ANTs functions and the methodology behind them. The [Wiki](https://github.com/ANTsX/ANTs/wiki) is a good place to start, but a selected list of commonly visited tutorials is also provided here.
+There are many different resources for learning about how to use ANTs functions and the methodology behind them. A selected list of useful resources is provided here.
 
+* ANTs Wiki [[Link](https://github.com/ANTsX/ANTs/wiki)]
 * ANTs Documentation [[Link](https://github.com/stnava/ANTsDoc/blob/master/ants2.pdf)]
-* ANTs Tutorial Repo [[Link](https://github.com/stnava/ANTsTutorial)]
+* ANTs Tutorials [[Link](https://github.com/stnava/ANTsTutorial)]
 * Using antsRegistration [[Link](https://github.com/ANTsX/ANTs/wiki/ANTS-and-antsRegistration)]
 * Using antsCorticalThickness [[Link](https://github.com/ANTsX/ANTs/wiki/antsCorticalThickness-and-antsLongitudinalCorticalThickness-output)]
 * Using N4BiasFieldCorrection [[Link](https://github.com/ANTsX/ANTs/wiki/N4BiasFieldCorrection)]

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ See also our pre-built ANTs templates with spatial priors available for [downloa
 
 ### Cardiac
 
-- Basic example [example](http://stnava.github.io/LabelMyHeart)
+- Basic example [[Link](http://stnava.github.io/LabelMyHeart)]
   
 ### Other
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ More details and a full downloadable installation script can be found in the [Li
 
 <br />
 
-## Examples
+## Code examples
 
 ANTs is a flexible library that can be used for a variety of applications and areas. Below is a collection of example scripts that - with a little effort - can be adapted to fit your specific needs. Some examples also include code for ANTsR or ANTsPy.
 
@@ -113,7 +113,7 @@ See also our pre-built ANTs templates with spatial priors available for download
 
 <br />
 
-## Resources
+## Learning resources
 
 There are many different resources for learning about how to use ANTs functions and the methodology behind them. The [Wiki](https://github.com/ANTsX/ANTs/wiki) is a good place to start, but a selected list of commonly visited tutorials is also provided here.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Advanced Normalization Tools (ANTs) is a C++ and command-line library that computes high-dimensional mappings to capture the statistics of brain structure and function. It allows one to organize, visualize and statistically explore large biomedical image sets. Additionally, it integrates imaging modalities and related information in space and time, as well as works across species or organ systems with minimal customization. 
 
-The ANTs library is considered a state-of-the-art medical image registration and segmentation toolkit which depends on the Insight ToolKit, a widely used medical image processing library to which ANTs developers contribute. ANTs and related tools have also won several international, unbiased challenges and competitions such as MICCAI, BRATS, and STACOM.
+The ANTs library is considered a state-of-the-art medical image registration and segmentation toolkit which depends on the Insight ToolKit, a widely used medical image processing library to which ANTs developers contribute. ANTs-related tools have also won several international, unbiased challenges and competitions such as MICCAI, BRATS, and STACOM.
 
 You can also use ANTs in R ([ANTsR](https://github.com/antsx/antsr)) and Python ([ANTsPy](https://github.com/antsx/antsr)), with additional functionality for deep learning in R ([ANTsRNet](https://github.com/antsx/antsrnet)) and Python ([ANTsPyNet](https://github.com/antsx/antspynet)). These libraries also include additional functionality for interacting with the broader R and Python ecosystem.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Advanced Normalization Tools (ANTs) is a C++ library available through the comma
 
 The ANTs library is considered a state-of-the-art medical image registration and segmentation toolkit which depends on the Insight ToolKit, a widely used medical image processing library to which ANTs developers contribute. ANTs-related tools have also won several international, unbiased competitions such as MICCAI, BRATS, and STACOM.
 
-You can also use ANTs in R ([ANTsR](https://github.com/antsx/antsr)) and Python ([ANTsPy](https://github.com/antsx/antsr)), with additional functionality for deep learning in R ([ANTsRNet](https://github.com/antsx/antsrnet)) and Python ([ANTsPyNet](https://github.com/antsx/antspynet)). These libraries make it possible to integrate ANTs with the broader R and Python ecosystem.
+It is also possible to use ANTs in R ([ANTsR](https://github.com/antsx/antsr)) and Python ([ANTsPy](https://github.com/antsx/antsr)), with additional functionality for deep learning in R ([ANTsRNet](https://github.com/antsx/antsrnet)) and Python ([ANTsPyNet](https://github.com/antsx/antspynet)). These libraries make it possible to integrate ANTs with the broader R and Python ecosystem.
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Advanced Normalization Tools (ANTs) is a C++ library available through the comma
 
 The ANTs library is considered a state-of-the-art medical image registration and segmentation toolkit which depends on the Insight ToolKit, a widely used medical image processing library to which ANTs developers contribute. ANTs-related tools have also won several international, unbiased competitions such as MICCAI, BRATS, and STACOM.
 
-It is also possible to use ANTs in R ([ANTsR](https://github.com/antsx/antsr)) and Python ([ANTsPy](https://github.com/antsx/antsr)), with additional functionality for deep learning in R ([ANTsRNet](https://github.com/antsx/antsrnet)) and Python ([ANTsPyNet](https://github.com/antsx/antspynet)). These libraries help integrate ANTs with the broader R / Python ecosystem.
+It is possible to use ANTs in R ([ANTsR](https://github.com/antsx/antsr)) and Python ([ANTsPy](https://github.com/antsx/antsr)), with additional functionality for deep learning in R ([ANTsRNet](https://github.com/antsx/antsrnet)) and Python ([ANTsPyNet](https://github.com/antsx/antspynet)). These libraries help integrate ANTs with the broader R / Python ecosystem.
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ There are many different resources for learning about how to use ANTs functions 
 
 ## Contributing
 
-If you have a question, feature request, or bug report the best way to get help is by posting an issue on the GitHub page. Please remember that it is difficult to provide any help without being to reproduce your issue.
+If you have a question, feature request, or bug report the best way to get help is by posting an issue on the GitHub page. Please remember that it is difficult to provide any help if you do not provide enough information to reproduce your issue or environment.
 
 We welcome any new contributions and ideas to improve ANTs. If you want to contribute code, the best way to get started is by reading through the [Wiki](https://github.com/ANTsX/ANTs/wiki) to get an understanding of the project or posting an issue.
 

--- a/README.md
+++ b/README.md
@@ -56,14 +56,18 @@ More details and a full downloadable installation script can be found in the [Li
 
 ## Examples
 
-ANTs is a flexible library that can be used for a variety of applications and areas. Below is a collection of example scripts that - with a little effort - can be adapted to fit your specific needs.
+ANTs is a flexible library that can be used for a variety of applications and areas. Below is a collection of example scripts that - with a little effort - can be adapted to fit your specific needs. Some of these examples also include code for performing the same operations with ANTsR or ANTsPy.
 
 ### Registration
 
 - Basic example [[Link](https://github.com/stnava/ANTs/blob/master/Scripts/newAntsExample.sh)]
-- Basic with mask [Link](https://github.com/ntustison/antsRegistrationWithMaskExample)]
+- Basic example with mask [[Link](https://github.com/ntustison/antsRegistrationWithMaskExample)]
 - Large deformation [[Link](http://stnava.github.io/C/)]
-
+- Asymmetry [[Link](http://stnava.github.io/asymmetry/)]
+- Automobile registration [[Link](http://stnava.github.io/cars/)]
+- Point-set mapping [[Link](http://stnava.github.io/chicken/)]
+- Global optimization [[Link](http://stnava.github.io/butterfly/)]
+  
 ### Template construction
 
 ### Cortical thickness
@@ -72,7 +76,15 @@ ANTs is a flexible library that can be used for a variety of applications and ar
 
 ### Segmentation
 
-### fMRI
+### General
+
+- Patch-based super-resolution [[Link](https://github.com/ntustison/NonLocalSuperResolutionExample)]
+- Image denoising [[Link](https://github.com/ntustison/DenoiseImageExample)]
+- Morphing [[Link](http://stnava.github.io/Morpheus/)]
+  
+### Neuroimages
+
+- Basic Brain Mapping [[Link](http://stnava.github.io/BasicBrainMapping/)]
 
 ### Lung
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ There are many different resources for learning about how to use ANTs functions 
 
 If you have a question, feature request, or bug report the best way to get help is by posting an issue on the GitHub page. Please remember that it is difficult to provide any help if you do not provide enough information to reproduce your issue or environment.
 
-We welcome any new contributions and ideas to improve ANTs. If you want to contribute code, the best way to get started is by reading through the [Wiki](https://github.com/ANTsX/ANTs/wiki) to get an understanding of the project or posting an issue.
+We welcome any new contributions and ideas to improve ANTs. If you want to contribute code, the best way to get started is by reading through the [Wiki](https://github.com/ANTsX/ANTs/wiki) to get an understanding of the project or by posting an issue.
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -95,9 +95,7 @@ The core development team consists of Gang Song (Originator), Philip A. Cook, Je
 
 ## References
 
-A large collection of journal articles have been published using ANTs software. The best way to find up-to-date articles is by searching on [Google
-Scholar](http://scholar.google.com/scholar?q=Advanced+Normalization+Tools+%22ANTs%22+-ant&hl=en&as_sdt=1%2C39&as_ylo=2008&as_yhi=) or
-[Pubmed](http://www.ncbi.nlm.nih.gov/pubmed?term=%22Avants%20B%22%20OR%20%22Tustison%20N%22). Below, we also provide a curated list of the most relevant articles to be used as a guide or for citing ANTs methods.
+A large collection of journal articles have been published using ANTs software and can be found by searching Google Scholar or PubMed. Below, we also provide a curated list of the most relevant articles to be used as a guide or for citing ANTs methods.
 
 ### Image Registration
 

--- a/README.md
+++ b/README.md
@@ -91,17 +91,11 @@ A large collection of journal articles have been published using ANTs software. 
 ### Image Registration
 
 Brian B. Avants, et al. Symmetric diffeomorphic image registration with cross-correlation: evaluating automated labeling of elderly and neurodegenerative brain. Med Image Anal (2008). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/17659998)]
-
 Arno Klein, et al. Evaluation of 14 nonlinear deformation algorithms applied to human brain MRI registration. Neuroimage (2009). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/19195496)]
-
 Murphy, et al. Evaluation of registration methods on thoracic CT: the EMPIRE10 challenge. IEEE Trans Med Imaging (2011) [[Link](http://www.ncbi.nlm.nih.gov/pubmed/21632295)]
-
 Brian B. Avants, et al. The optimal template effect in hippocampus studies of diseased populations. Neuroimage (2010). [[Link]](https://pubmed.ncbi.nlm.nih.gov/19818860/)
-
 Brian B. Avants, et al. A reproducible evaluation of ANTs similarity metric performance in brain image registration. Neuroimage (2011). [[Link]](https://pubmed.ncbi.nlm.nih.gov/20851191/)
-
 Brian B. Avants, et al. Multivariate analysis of structural and diffusion imaging in traumatic brain injury. Acad Radiol (2008). [[Link]](http://www.ncbi.nlm.nih.gov/pubmed/18995188)
-
 Nicholas J. Tustison, et al. Logical circularity in voxel-based analysis: normalization strategy may induce statistical bias. Hum Brain Mapp (2014). [[Link]](https://pubmed.ncbi.nlm.nih.gov/23151955/)
 
 ### Image Segmentation

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ ANTs is a flexible library that can be used for a variety of applications and ar
 
 - Basic Brain Mapping [[Link](http://stnava.github.io/BasicBrainMapping/)]
 - Brain extraction [[Link](https://github.com/ntustison/antsBrainExtractionExample)]
-- Multi-atlas joint label/intensity fusion examples [[Link](https://github.com/ntustison/MalfLabelingExample), [Link](https://github.com/qureai/Multi-Atlas-Segmentation)] (credit: @chsasank)
+- Multi-atlas joint label/intensity fusion [[Link](https://github.com/ntustison/MalfLabelingExample), [Link](https://github.com/qureai/Multi-Atlas-Segmentation)] (credit: @chsasank)
 - fMRI or Motion Correction [[Link](http://stnava.github.io/fMRIANTs/)]
 - fMRI reproducibility [[Link](http://stnava.github.io/RfMRI/)]
 - Partial EPI slab to T1 image registration [[Link](https://github.com/ntustison/PartialSlabEpiT1ImageRegistration)]

--- a/README.md
+++ b/README.md
@@ -64,12 +64,13 @@ More details and a full downloadable installation script can be found in the [Li
 
 ## Resources
 
-There are many different resources for learning about how to use ANTs functions and the methodology behind them. The [Wiki](https://github.com/ANTsX/ANTs/wiki) is a good place to start. A selected list of tutorials is also provided here.
+There are many different resources for learning about how to use ANTs functions and the methodology behind them. The [Wiki](https://github.com/ANTsX/ANTs/wiki) is a good place to start, but a selected list of commonly visited tutorials is also provided here.
 
 - ANTs Documentation [[Link](https://github.com/stnava/ANTsDoc/blob/master/ants2.pdf)]
-- Overview of antsRegistration [[Link](https://github.com/ANTsX/ANTs/wiki/ANTS-and-antsRegistration)]
-- Overview of antsCorticalThickness [[Link](https://github.com/ANTsX/ANTs/wiki/antsCorticalThickness-and-antsLongitudinalCorticalThickness-output)]
-
+- Using antsRegistration [[Link](https://github.com/ANTsX/ANTs/wiki/ANTS-and-antsRegistration)]
+- Using antsCorticalThickness [[Link](https://github.com/ANTsX/ANTs/wiki/antsCorticalThickness-and-antsLongitudinalCorticalThickness-output)]
+- Using N4BiasFieldCorrection [[Link](https://github.com/ANTsX/ANTs/wiki/N4BiasFieldCorrection)]
+  
 <br />
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -60,14 +60,90 @@ ANTs is a flexible library that can be used for a variety of applications and ar
 
 ### General
 
+* **antsRegistration** [bash example](https://github.com/stnava/ANTs/blob/master/Scripts/newAntsExample.sh)
 
-### Brain
+* **antsRegistration with mask** [(bash, ANTsR and ANTsPy examples)](https://github.com/ntustison/antsRegistrationWithMaskExample)
 
+* **ANTs and ITK** [paper](http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4009425/)
+
+* **Large deformation** [(bash, ANTsR and ANTsPy examples)](http://stnava.github.io/C/)
+
+* **Automobile** [(bash and ANTsR examples)](http://stnava.github.io/cars/)
+
+* **Asymmetry** [example](http://stnava.github.io/asymmetry/)
+
+* **Point-set** [mapping](http://stnava.github.io/chicken/) which includes the PSE metric and affine and deformable registration with (labeled) pointsets or iterative closest point
+
+* **Feature matching** [example](http://stnava.github.io/featureMatching/) ... not up to date ...
+
+* **Global optimization** [example](http://stnava.github.io/butterfly/)
+
+* **Patch-based super resolution** [example](https://github.com/ntustison/NonLocalSuperResolutionExample)
+
+* **Image denoising** [(bash, ANTsR and ANTsPy examples)](https://github.com/ntustison/DenoiseImageExample)
+
+* **Visualization** [example](https://github.com/ntustison/antsVisualizationExamples)
+
+* **Morphing** [example](http://stnava.github.io/Morpheus/)
+
+* **Bibliography** [bibtex of ANTs-related papers](https://github.com/stnava/ANTsBibliography)
+
+* **ANTs** [google scholar page](http://scholar.google.com/citations?user=ox-mhOkAAAAJ&hl=en)
+
+### Neuro
+
+* **Basic Brain Mapping** [(bash and ANTsR examples)](http://stnava.github.io/BasicBrainMapping/)
+
+* **Template construction** [(bash, ANTsR and ANTsPy examples)](http://ntustison.github.io/TemplateBuildingExample/)
+
+* **Single subject template construction** [example](https://github.com/ntustison/SingleSubjectTemplateExample)
+
+* **Pre-built ANTs templates with spatial priors** [download](http://figshare.com/articles/ANTs_ANTsR_Brain_Templates/915436) including an [MNI version](https://figshare.com/articles/ANTs_files_for_mni_icbm152_nlin_sym_09a/8061914).
+
+* **Brain extraction** [(bash and ANTsR examples)](https://github.com/ntustison/antsBrainExtractionExample)
+
+* **N4 bias correction <-> segmentation** [(bash, ANTsR and ANTsPy examples)](https://github.com/ntustison/antsAtroposN4Example)
+
+* **Cortical thickness** [example](https://github.com/ntustison/antsCorticalThicknessExample)
+
+* **"Cooking" tissue priors for templates**
+  [example](https://github.com/ntustison/antsCookTemplatePriorsExample)
+  (after you build your template)
+
+* **Multi-atlas joint label/intensity fusion examples** [(bash and ANTsR examples 1)](https://github.com/ntustison/MalfLabelingExample) [example 2](https://github.com/qureai/Multi-Atlas-Segmentation) (thanks to @chsasank)
+
+* **The ANTs Cortical Thickness Pipeline** [example](https://github.com/ntustison/KapowskiChronicles/blob/master/paper2.pdf?raw=true)
+
+* **Chimpanzee cortical thickness** [example](https://github.com/stnava/WHopkinsNHP/)
+
+* **Brain tumor segmentation** [example](https://github.com/ntustison/BRATS2013/tree/master/SimpleExample)
+
+* **Eigenanatomy** for [multivariate neuroimage analysis](http://www.ncbi</a>.nlm.nih.gov/pubmed/23269595) via
+    [PCA](http://www.ncbi.nlm.nih.gov/pubmed/23286132) &
+    [CCA](http://www.ncbi.nlm.nih.gov/pubmed/20083207)
+
+* **fMRI or Motion Correction** [example](http://stnava.github.io/fMRIANTs/)
+
+* **fMRI reproducibility** [example](http://stnava.github.io/RfMRI/)
+
+* **fMRI prediction** [example](http://stnava.github.io/Haxby2001/) ... WIP ...
+
+* **Partial EPI slab to T1 image registration** [example](https://github.com/ntustison/PartialSlabEpiT1ImageRegistration)
 
 ### Lung
 
+* **CT lung registration** [(bash and ANTsR examples)](https://github.com/ntustison/antsCtLungRegistrationExample)
+
+* **Lung mask registration** [example](https://github.com/ntustison/ProtonCtLungMaskRegistration)
+
+* **Lung and lobe estimation** [example](https://github.com/ntustison/LungAndLobeEstimationExample)
+
+* **Lung ventilation-based segmentation** [example](https://github.com/ntustison/LungVentilationSegmentationExample)
 
 ### Cardiac
+
+* **Cardiac** [example](http://stnava.github.io/LabelMyHeart)
+
 
 
 <br />

--- a/README.md
+++ b/README.md
@@ -72,24 +72,27 @@ ANTs is a flexible library that can be used for a variety of applications and ar
 
 - Brain template [[Link](http://ntustison.github.io/TemplateBuildingExample/)]
 - Single subject template [[Link](https://github.com/ntustison/SingleSubjectTemplateExample)]
+- "Cooking" tissue priors for templates [[Link](https://github.com/ntustison/antsCookTemplatePriorsExample)]
   
 ### Cortical thickness
 
-### Joint label fusion
+- Basic example [[Link](https://github.com/ntustison/antsCorticalThicknessExample)]
 
 ### Segmentation
+- N4 bias correction + Atropos [[Link](https://github.com/ntustison/antsAtroposN4Example)]
 
 ### General
 
 - Patch-based super-resolution [[Link](https://github.com/ntustison/NonLocalSuperResolutionExample)]
 - Image denoising [[Link](https://github.com/ntustison/DenoiseImageExample)]
 - Morphing [[Link](http://stnava.github.io/Morpheus/)]
-  
+
 ### Neuroimages
 
 - Basic Brain Mapping [[Link](http://stnava.github.io/BasicBrainMapping/)]
 - Brain extraction [[Link](https://github.com/ntustison/antsBrainExtractionExample)]
-
+- Multi-atlas joint label/intensity fusion examples by @chsasank [[Link-1](https://github.com/ntustison/MalfLabelingExample), [Link-2](https://github.com/qureai/Multi-Atlas-Segmentation)]
+ 
 See also our pre-built ANTs templates with spatial priors available for [download](http://figshare.com/articles/ANTs_ANTsR_Brain_Templates/915436) including an [MNI version](https://figshare.com/articles/ANTs_files_for_mni_icbm152_nlin_sym_09a/8061914).
   
 ### Lung
@@ -100,16 +103,6 @@ See also our pre-built ANTs templates with spatial priors available for [downloa
 
 ### Neuro
 
-* **Basic Brain Mapping** [(bash and ANTsR examples)](http://stnava.github.io/BasicBrainMapping/)
-* **Template construction** [(bash, ANTsR and ANTsPy examples)](http://ntustison.github.io/TemplateBuildingExample/)
-* **Single subject template construction** [example](https://github.com/ntustison/SingleSubjectTemplateExample)
-* **Pre-built ANTs templates with spatial priors** [download](http://figshare.com/articles/ANTs_ANTsR_Brain_Templates/915436) including an [MNI version](https://figshare.com/articles/ANTs_files_for_mni_icbm152_nlin_sym_09a/8061914).
-* **Brain extraction** [(bash and ANTsR examples)](https://github.com/ntustison/antsBrainExtractionExample)
-* **N4 bias correction <-> segmentation** [(bash, ANTsR and ANTsPy examples)](https://github.com/ntustison/antsAtroposN4Example)
-* **Cortical thickness** [example](https://github.com/ntustison/antsCorticalThicknessExample)
-* **"Cooking" tissue priors for templates**
-  [example](https://github.com/ntustison/antsCookTemplatePriorsExample)
-  (after you build your template)
 * **Multi-atlas joint label/intensity fusion examples** [(bash and ANTsR examples 1)](https://github.com/ntustison/MalfLabelingExample) [example 2](https://github.com/qureai/Multi-Atlas-Segmentation) (thanks to @chsasank)
 * **Chimpanzee cortical thickness** [example](https://github.com/stnava/WHopkinsNHP/)
 * **Brain tumor segmentation** [example](https://github.com/ntustison/BRATS2013/tree/master/SimpleExample)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Advanced Normalization Tools (ANTs) is a C++ library available through the comma
 
 The ANTs library is considered a state-of-the-art medical image registration and segmentation toolkit which depends on the Insight ToolKit, a widely used medical image processing library to which ANTs developers contribute. ANTs-related tools have also won several international, unbiased competitions such as MICCAI, BRATS, and STACOM.
 
-It is also possible to use ANTs in R ([ANTsR](https://github.com/antsx/antsr)) and Python ([ANTsPy](https://github.com/antsx/antsr)), with additional functionality for deep learning in R ([ANTsRNet](https://github.com/antsx/antsrnet)) and Python ([ANTsPyNet](https://github.com/antsx/antspynet)). These libraries help integrate ANTs with the broader R / Python ecosystems.
+It is also possible to use ANTs in R ([ANTsR](https://github.com/antsx/antsr)) and Python ([ANTsPy](https://github.com/antsx/antsr)), with additional functionality for deep learning in R ([ANTsRNet](https://github.com/antsx/antsrnet)) and Python ([ANTsPyNet](https://github.com/antsx/antspynet)). These libraries help integrate ANTs with the broader R / Python ecosystem.
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ ANTs is a flexible library that can be used for a variety of applications and ar
 - fMRI reproducibility [[Link](http://stnava.github.io/RfMRI/)]
 - Partial EPI slab to T1 image registration [[Link](https://github.com/ntustison/PartialSlabEpiT1ImageRegistration)]
   
-See also our pre-built ANTs templates with spatial priors available for [download](http://figshare.com/articles/ANTs_ANTsR_Brain_Templates/915436) including an [MNI version](https://figshare.com/articles/ANTs_files_for_mni_icbm152_nlin_sym_09a/8061914).
+See also our pre-built ANTs templates with spatial priors available for download [[General](http://figshare.com/articles/ANTs_ANTsR_Brain_Templates/915436), [MNI](https://figshare.com/articles/ANTs_files_for_mni_icbm152_nlin_sym_09a/8061914)].
   
 ### Lung
 

--- a/README.md
+++ b/README.md
@@ -141,13 +141,7 @@ We welcome any new contributions and ideas to improve ANTs. If you want to contr
 
 ## Team
 
-Development of ANTs is led by the following people:
-
-- [Brian B. Avants](http://stnava.github.io/Resume/) - UPENN (Creator, Algorithm Design, Implementation)
-- [Nicholas J. Tustison](http://ntustison.github.io/CV/) - UVA (Compeller, Algorithm Design, Implementation Guru)
-- Hans J. Johnson - UIowa (Large-Scale Application, Testing, Software design). 
-
-The core development team also consists of Gang Song (Originator), Philip A. Cook, Jeffrey T. Duda (DTI), Ben M. Kandel (Perfusion, multivariate analysis).
+Development of ANTs is led by [Brian B. Avants](http://stnava.github.io/Resume/) (Creator, Algorithm Design, Implementation), [Nicholas J. Tustison](http://ntustison.github.io/CV/)(Compeller, Algorithm Design, Implementation Guru), Hans J. Johnson (Large-Scale Application, Testing, Software design), Gang Song (Originator), Philip A. Cook, Jeffrey T. Duda (DTI), Ben M. Kandel (Perfusion, multivariate analysis), and Nick Cullen (Python, R). 
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ More details and a full downloadable installation script can be found in the [Li
 
 ## Overview
 
+<br />
+
 ## Examples
+
+<br />
 
 ## Resources
 
@@ -90,315 +94,46 @@ A large collection of journal articles have been published using ANTs software. 
 
 ### Image Registration
 
-- Symmetric diffeomorphic image registration with cross-correlation: evaluating automated labeling of elderly and neurodegenerative brain. Brian B. Avants, et al. Med Image Anal (2008). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/17659998)]
+<i>Symmetric diffeomorphic image registration with cross-correlation: evaluating automated labeling of elderly and neurodegenerative brain.</i>  Med Image Anal (2008). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/17659998)]
 
-- Evaluation of 14 nonlinear deformation algorithms applied to human brain MRI registration. Arno Klein, et al.  Neuroimage (2009). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/19195496)]
+<i>Evaluation of 14 nonlinear deformation algorithms applied to human brain MRI registration.</i> Neuroimage (2009). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/19195496)]
 
-- Evaluation of registration methods on thoracic CT: the EMPIRE10 challenge. Murphy, et al. IEEE Trans Med Imaging (2011) [[Link](http://www.ncbi.nlm.nih.gov/pubmed/21632295)]
+<i>Evaluation of registration methods on thoracic CT: the EMPIRE10 challenge.</i> IEEE Trans Med Imaging (2011) [[Link](http://www.ncbi.nlm.nih.gov/pubmed/21632295)]
 
-- The optimal template effect in hippocampus studies of diseased populations. Brian B. Avants, et al. Neuroimage (2010). [[Link]](https://pubmed.ncbi.nlm.nih.gov/19818860/)
+<i>A reproducible evaluation of ANTs similarity metric performance in brain image registration.</i> Neuroimage (2011). [[Link]](https://pubmed.ncbi.nlm.nih.gov/20851191/)
 
-- A reproducible evaluation of ANTs similarity metric performance in brain image registration. Brian B. Avants, et al. Neuroimage (2011). [[Link]](https://pubmed.ncbi.nlm.nih.gov/20851191/)
+<i>Multivariate analysis of structural and diffusion imaging in traumatic brain injury.</i> Acad Radiol (2008). [[Link]](http://www.ncbi.nlm.nih.gov/pubmed/18995188)
 
-- Multivariate analysis of structural and diffusion imaging in traumatic brain injury. Brian B. Avants, et al. Acad Radiol (2008). [[Link]](http://www.ncbi.nlm.nih.gov/pubmed/18995188)
+### Templates
 
-- Logical circularity in voxel-based analysis: normalization strategy may induce statistical bias. Nicholas J. Tustison, et al. Hum Brain Mapp (2014). [[Link]](https://pubmed.ncbi.nlm.nih.gov/23151955/)
+<i>The optimal template effect in hippocampus studies of diseased populations.</i> Neuroimage (2010). [[Link]](https://pubmed.ncbi.nlm.nih.gov/19818860/)
 
 ### Image Segmentation
 
-Atropos Multivar-EM Segmentation
-[(link)](http://www.ncbi.nlm.nih.gov/pubmed/21373993), Multi-atlas
-methods [(link)](https://scholar.google.com/scholar?q=joint+label+fusion+yushkevich&btnG=&hl=en&as_sdt=0%2C31) and [JLF](http://journal.frontiersin.org/article/10.3389/fninf.2013.00027/full), Bias
-Correction [(link)](http://www.ncbi.nlm.nih.gov/pubmed/20378467), DiReCT
-cortical thickness
-[(link)](http://www.ncbi.nlm.nih.gov/pubmed/19150502), DiReCT in
-[chimpanzees](http://www.ncbi.nlm.nih.gov/pubmed/23516289)
+<i>An open source multivariate framework for n-tissue segmentation with evaluation on public data</i> Neuroinformatics (2011). [[Link]](http://www.ncbi.nlm.nih.gov/pubmed/21373993)
+
+<i>Multi-atlas segmentation with joint label fusion and corrective learning—an open source implementation</i> Front Neuroinform (2013). [[Link]](https://www.frontiersin.org/articles/10.3389/fninf.2013.00027/full)
+
+### Bias Correction
+
+<i>N4ITK: improved N3 bias correction</i> IEEE Trans Med Imaging (2010). [[Link]](http://www.ncbi.nlm.nih.gov/pubmed/20378467)
 
 ### Cortical Thickness
 
-### Multivariate Analysis Eigenanatomy 
+<i>Registration based cortical thickness measurement</i> Neuroimage (2009). [[Link]](http://www.ncbi.nlm.nih.gov/pubmed/19150502)
 
-[(1)](http://www.ncbi.nlm.nih.gov/pubmed/23286132) [(2)](http://www.ncbi.nlm.nih.gov/pubmed/23475817)
+<i>Regional and hemispheric variation in cortical thickness in chimpanzees</i> J Neurosci (2013). [[Link]](http://www.ncbi.nlm.nih.gov/pubmed/23516289)
 
-### Prior-Based Eigenanatomy 
-[(in
-prep)](http://www.ncbi.nlm.nih.gov/pubmed/?), Sparse CCA
-[(1)](http://www.ncbi.nlm.nih.gov/pubmed/20083207),
-[(2)](http://www.ncbi.nlm.nih.gov/pubmed/20879247), Sparse Regression
-[(link)](http://link.springer.com/chapter/10.1007%2F978-3-642-38868-2_8)
+### Eigenanatomy 
 
+<i>Eigenanatomy improves detection power for longitudinal cortical change</i> Med Image Comput Comput Assist Interv (2012) [[Link]](http://www.ncbi.nlm.nih.gov/pubmed/23286132)
+
+<i>White matter imaging helps dissociate tau from TDP-43 in frontotemporal lobar degeneration</i> J Neurol Neurosurg Psychiatry (2013). [[Link]](https://pubmed.ncbi.nlm.nih.gov/23475817/)
+
+<i>Dementia induces correlated reductions in white matter integrity and cortical thickness: a multivariate neuroimaging study with sparse canonical correlation analysis</i> Neuroimage (2010). [[Link]](https://pubmed.ncbi.nlm.nih.gov/20083207/)
+
+<br />
 
 ## Funding
 
 Current support comes from R01-EB031722. Previous support includes R01-EB006266-01 and K01-ES025432-01.
-
-
-
-
-The [ANTs handout](https://github.com/stnava/ANTsTutorial/raw/master/handout/antsHandout.pdf), part of forthcoming [ANTs tutorial](https://github.com/stnava/ANTsTutorial) material [here](https://github.com/stnava/ANTsTutorial) and [here](https://rpubs.com/antsr/).
-
-[ANTsTalk - subject to change at any moment](http://stnava.github.io/ANTsTalk/)
-
-[ANTsRegistrationTalk - subject to change at any moment](http://stnava.github.io/ANTsRegistrationTalk/)
-
-
-
-
-ImageMath Useful!
------------------
-
-morphology, GetLargestComponent, CCA, FillHoles ... much more!
-
-Application Domains
--------------------
-
-### Frontotemporal degeneration [PENN FTD center](http://ftd.med.upenn.edu)
-
-### Multimodality Neuroimaging
-
--   [Structural MRI](http://jeffduda.github.io/NeuroBattery/)
--   Functional MRI
--   Network Analysis
-
-### Lung Imaging
-
--   Structure
--   Perfusion MRI
--   Branching
-
-### Multiple sclerosis (lesion filling) [example](https://github.com/armaneshaghi/LesionFilling_example)
-
-Background & Theory
-----------------------------------------------------------
-
--   The
-    [SyN](http://www.ncbi.nlm.nih.gov/pubmed/?term=%22SyN%22+AND+%22Avants+B%22)
-    and [N4 bias
-    correction](http://www.ncbi.nlm.nih.gov/pubmed/?term=%22N4%22+AND+%22Tustison+N4ITK%22)
-    papers and other relevant references in
-    [Pubmed](http://www.ncbi.nlm.nih.gov/pubmed/?term=%22Tustison+N%22+AND+%22Avants+B%22)
-
--   Visualization: e.g. [a gource of ANTs
-    development](http://vimeo.com/66781467)
-
--   [DiReCT](http://www.ncbi.nlm.nih.gov/pubmed/?term=%22DIRECT%22+AND+%22Avants%22+AND+DAS)
-    cortical thickness
-    [papers](http://www.ncbi.nlm.nih.gov/pubmed/?term=%22Cortical+Thickness%22+AND+%22Avants%22)
-
--   A
-    [folder](https://sourceforge.net/projects/advants/files/Documentation/)
-    of relevant docs:
-    [segmentation](http://sourceforge.net/projects/advants/files/Documentation/atropos.pdf/download),
-    [registration](http://sourceforge.net/projects/advants/files/Documentation/antstheory.pdf/download),
-    [usage(old)](http://sourceforge.net/projects/advants/files/Documentation/ants.pdf/download),
-    [for clinical
-    apps](http://sourceforge.net/projects/advants/files/Documentation/ANTSMethodologySummary.docx/download)
-
--   ANTs redesigned for generality, automation, multi-core computation
-    with ITKv4
-
--   Dev'd ITKv4 with Kitware, GE, Natl. Lib of Medicine & Academia
-
-
-ANTs has won several unbiased & international competitions
-----------------------------------------------------------
-
--   ANTs finished in 1st rank in [Klein 2009 intl. brain mapping
-    competition](http://www.ncbi.nlm.nih.gov/pubmed/19195496)
-
--   ANTs finished 1st overall in [EMPIRE10 intl. lung mapping
-    competition](http://www.ncbi.nlm.nih.gov/pubmed/21632295)
-
--   ANTs is the standard registration for
-    [MICCAI-2013](http://www.miccai2013.org/) segmentation competitions
-
--   Conducting ANTs-based R tutorial @ MICCAI-2013
-
--   ITK-focused Frontiers in Neuroinformatics research topic
-    [here](http://www.frontiersin.org/neuroinformatics/researchtopics/neuroinformatics_with_the_insi/1580)
-
--   Won the [BRATS 2013 challenge](http://martinos.org/qtim/miccai2013/) with [ANTsR](http://stnava.github.io/ANTsR/)
-
--   Won the best paper award at the [STACOM 2014 challenge](http://www.cardiacatlas.org/web/stacom2014/home)
-
-Learning about ANTs (examples, etc.)
-----------------------------------------------------------
-
-### General
-
-* **antsRegistration** [bash example](https://github.com/stnava/ANTs/blob/master/Scripts/newAntsExample.sh)
-
-* **antsRegistration with mask** [(bash, ANTsR and ANTsPy examples)](https://github.com/ntustison/antsRegistrationWithMaskExample)
-
-* **ANTs and ITK** [paper](http://www.ncbi.nlm.nih.gov/pmc/articles/PMC4009425/)
-
-* **Large deformation** [(bash, ANTsR and ANTsPy examples)](http://stnava.github.io/C/)
-
-* **Automobile** [(bash and ANTsR examples)](http://stnava.github.io/cars/)
-
-* **Asymmetry** [example](http://stnava.github.io/asymmetry/)
-
-* **Point-set** [mapping](http://stnava.github.io/chicken/) which includes the PSE metric and affine and deformable registration with (labeled) pointsets or iterative closest point
-
-* **Feature matching** [example](http://stnava.github.io/featureMatching/) ... not up to date ...
-
-* **Global optimization** [example](http://stnava.github.io/butterfly/)
-
-* **Patch-based super resolution** [example](https://github.com/ntustison/NonLocalSuperResolutionExample)
-
-* **Image denoising** [(bash, ANTsR and ANTsPy examples)](https://github.com/ntustison/DenoiseImageExample)
-
-* **Visualization** [example](https://github.com/ntustison/antsVisualizationExamples)
-
-* **Morphing** [example](http://stnava.github.io/Morpheus/)
-
-* **Bibliography** [bibtex of ANTs-related papers](https://github.com/stnava/ANTsBibliography)
-
-* **ANTs** [google scholar page](http://scholar.google.com/citations?user=ox-mhOkAAAAJ&hl=en)
-
-### Neuro
-
-* **Basic Brain Mapping** [(bash and ANTsR examples)](http://stnava.github.io/BasicBrainMapping/)
-
-* **Template construction** [(bash, ANTsR and ANTsPy examples)](http://ntustison.github.io/TemplateBuildingExample/)
-
-* **Single subject template construction** [example](https://github.com/ntustison/SingleSubjectTemplateExample)
-
-* **Pre-built ANTs templates with spatial priors** [download](http://figshare.com/articles/ANTs_ANTsR_Brain_Templates/915436) including an [MNI version](https://figshare.com/articles/ANTs_files_for_mni_icbm152_nlin_sym_09a/8061914).
-
-* **Brain extraction** [(bash and ANTsR examples)](https://github.com/ntustison/antsBrainExtractionExample)
-
-* **N4 bias correction <-> segmentation** [(bash, ANTsR and ANTsPy examples)](https://github.com/ntustison/antsAtroposN4Example)
-
-* **Cortical thickness** [example](https://github.com/ntustison/antsCorticalThicknessExample)
-
-* **"Cooking" tissue priors for templates**
-  [example](https://github.com/ntustison/antsCookTemplatePriorsExample)
-  (after you build your template)
-
-* **Multi-atlas joint label/intensity fusion examples** [(bash and ANTsR examples 1)](https://github.com/ntustison/MalfLabelingExample) [example 2](https://github.com/qureai/Multi-Atlas-Segmentation) (thanks to @chsasank)
-
-* **The ANTs Cortical Thickness Pipeline** [example](https://github.com/ntustison/KapowskiChronicles/blob/master/paper2.pdf?raw=true)
-
-* **Chimpanzee cortical thickness** [example](https://github.com/stnava/WHopkinsNHP/)
-
-* **Brain tumor segmentation** [example](https://github.com/ntustison/BRATS2013/tree/master/SimpleExample)
-
-* **Eigenanatomy** for [multivariate neuroimage analysis](http://www.ncbi</a>.nlm.nih.gov/pubmed/23269595) via
-    [PCA](http://www.ncbi.nlm.nih.gov/pubmed/23286132) &
-    [CCA](http://www.ncbi.nlm.nih.gov/pubmed/20083207)
-
-* **fMRI or Motion Correction** [example](http://stnava.github.io/fMRIANTs/)
-
-* **fMRI reproducibility** [example](http://stnava.github.io/RfMRI/)
-
-* **fMRI prediction** [example](http://stnava.github.io/Haxby2001/) ... WIP ...
-
-* **Partial EPI slab to T1 image registration** [example](https://github.com/ntustison/PartialSlabEpiT1ImageRegistration)
-
-### Lung
-
-* **CT lung registration** [(bash and ANTsR examples)](https://github.com/ntustison/antsCtLungRegistrationExample)
-
-* **Lung mask registration** [example](https://github.com/ntustison/ProtonCtLungMaskRegistration)
-
-* **Lung and lobe estimation** [example](https://github.com/ntustison/LungAndLobeEstimationExample)
-
-* **Lung ventilation-based segmentation** [example](https://github.com/ntustison/LungVentilationSegmentationExample)
-
-### Cardiac
-
-* **Cardiac** [example](http://stnava.github.io/LabelMyHeart)
-
-### Misc.
-
-Presentations: e.g. [a Prezi about
-ANTs](http://prezi.com/mwrmcm-h9-w4/ants/?kw=view-mwrmcm-h9-w4&rc=ref-40024395)
-(WIP)
-
-Reproducible science as a teaching tool: e.g. [compilable ANTs
-tutorial](https://github.com/stnava/ANTS_MultiModality) (WIP)
-
-Other examples [slideshow](http://brianavants.wordpress.com)
-
-Landmark-based mapping for e.g. hippocampus [discussed
-here](https://sourceforge.net/p/advants/discussion/840261/thread/1cb7b165/?limit=50)
-
-Brief ANTs segmentation [video](http://vimeo.com/67814201)
-
-**Benchmarks** for expected memory and computation time: [results](https://github.com/gdevenyi/antsRegistration-benchmarking).  These
-results are, of course, system and data dependent.
-
-References
-----------------------------------------------------------
-
-[Google
-Scholar](http://scholar.google.com/scholar?q=Advanced+Normalization+Tools+%22ANTs%22+-ant&hl=en&as_sdt=1%2C39&as_ylo=2008&as_yhi=)
-
-[Pubmed](http://www.ncbi.nlm.nih.gov/pubmed?term=%22Avants%20B%22%20OR%20%22Tustison%20N%22)
-
-Boilerplate ANTs
-------------------
-
-Here is some boilerplate regarding ants image processing:
-
-We will analyze multiple modality neuroimaging data with Advanced
-Normalization Tools (ANTs) version >= 2.1 [1]
-(http://stnava.github.io/ANTs/).  ANTs has proven performance in
-lifespan analyses of brain morphology [1] and function [2] in both
-adult [1] and pediatric brain data [2,5,6] including infants [7].
-ANTs employs both probabilistic tissue segmentation (via Atropos [3])
-and machine learning methods based on expert labeled data (via joint
-label fusion [4]) in order to maximize reliability and consistency of
-multiple modality image segmentation.  These methods allow detailed
-extraction of critical image-based biomarkers such as volumes
-(e.g. hippocampus and amygdala), cortical thickness and area and
-connectivity metrics derived from structural white matter [13] or
-functional connectivity [12]. Critically, all ANTs components are
-capable of leveraging multivariate image features as well as expert
-knowledge in order to learn the best segmentation strategy available
-for each individual image [3,4].  This flexibility in segmentation and
-the underlying high-performance normalization methods have been
-validated by winning several internationally recognized medical image
-processing challenges conducted within the premier conferences within
-the field and published in several accompanying articles
-[8][9][10][11].
-
-References
-
-[1] http://www.ncbi.nlm.nih.gov/pubmed/24879923
-
-[2] http://www.ncbi.nlm.nih.gov/pubmed/24817849
-
-[3] http://www.ncbi.nlm.nih.gov/pubmed/21373993
-
-[4] http://www.ncbi.nlm.nih.gov/pubmed/21237273
-
-[5] http://www.ncbi.nlm.nih.gov/pubmed/22517961
-
-[6] http://www.ncbi.nlm.nih.gov/pubmed/24033570
-
-[7] http://www.ncbi.nlm.nih.gov/pubmed/24139564
-
-[8]  http://www.ncbi.nlm.nih.gov/pubmed/21632295
-
-[9] http://www.ncbi.nlm.nih.gov/pubmed/19195496
-
-[10] http://www.ncbi.nlm.nih.gov/pmc/articles/PMC3837555/
-
-[11] http://nmr.mgh.harvard.edu/~koen/MenzeTMI2014.pdf
-
-[12] http://www.ncbi.nlm.nih.gov/pubmed/23813017
-
-[13] http://www.ncbi.nlm.nih.gov/pubmed/24830834
-
-
-Current support:  
-* R01-EB031722
-
-Previous support: 
-* R01-EB006266-01
-* K01-ES025432-01
-
-
-![ants chimp](http://i.imgur.com/4tPvy05.png)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PubMed](https://img.shields.io/badge/ANTsX_paper-Open_Access-8DABFF?logo=pubmed)](https://pubmed.ncbi.nlm.nih.gov/33907199/)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](code_of_conduct.md)
 
-Advanced Normalization Tools (ANTs) is a C++ library available through the command line that computes high-dimensional mappings to capture the statistics of brain structure and function. It allows one to organize, visualize and statistically explore large biomedical image sets. Additionally, it integrates imaging modalities in space and time and works across species or organ systems with minimal customization. 
+Advanced Normalization Tools (ANTs) is a C++ library available through the command line that computes high-dimensional mappings to capture the statistics of brain structure and function. It allows one to organize, visualize and statistically explore large biomedical image sets. Additionally, it integrates imaging modalities in space + time and works across species or organ systems with minimal customization. 
 
 The ANTs library is considered a state-of-the-art medical image registration and segmentation toolkit which depends on the Insight ToolKit, a widely used medical image processing library to which ANTs developers contribute. ANTs-related tools have also won several international, unbiased challenges and competitions such as MICCAI, BRATS, and STACOM.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Advanced Normalization Tools (ANTs) is a C++ library available through the command line that computes high-dimensional mappings to capture the statistics of brain structure and function. It allows one to organize, visualize and statistically explore large biomedical image sets. Additionally, it integrates imaging modalities in space + time and works across species or organ systems with minimal customization. 
 
-The ANTs library is considered a state-of-the-art medical image registration and segmentation toolkit which depends on the Insight ToolKit, a widely used medical image processing library to which ANTs developers contribute. ANTs-related tools have also won several international, unbiased challenges and competitions such as MICCAI, BRATS, and STACOM.
+The ANTs library is considered a state-of-the-art medical image registration and segmentation toolkit which depends on the Insight ToolKit, a widely used medical image processing library to which ANTs developers contribute. ANTs-related tools have also won several international, unbiased competitions such as MICCAI, BRATS, and STACOM.
 
 You can also use ANTs in R ([ANTsR](https://github.com/antsx/antsr)) and Python ([ANTsPy](https://github.com/antsx/antsr)), with additional functionality for deep learning in R ([ANTsRNet](https://github.com/antsx/antsrnet)) and Python ([ANTsPyNet](https://github.com/antsx/antspynet)). These libraries make it possible to integrate ANTs with the broader R and Python ecosystem.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PubMed](https://img.shields.io/badge/ANTsX_paper-Open_Access-8DABFF?logo=pubmed)](https://pubmed.ncbi.nlm.nih.gov/33907199/)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](code_of_conduct.md)
 
-Advanced Normalization Tools (ANTs) is a C++ library available through the command line that computes high-dimensional mappings to capture the statistics of brain structure and function. It allows one to organize, visualize and statistically explore large biomedical image sets. Additionally, it integrates imaging modalities and related information in space and time, as well as works across species or organ systems with minimal customization. 
+Advanced Normalization Tools (ANTs) is a C++ library available through the command line that computes high-dimensional mappings to capture the statistics of brain structure and function. It allows one to organize, visualize and statistically explore large biomedical image sets. Additionally, it integrates imaging modalities in space and time and works across species or organ systems with minimal customization. 
 
 The ANTs library is considered a state-of-the-art medical image registration and segmentation toolkit which depends on the Insight ToolKit, a widely used medical image processing library to which ANTs developers contribute. ANTs-related tools have also won several international, unbiased challenges and competitions such as MICCAI, BRATS, and STACOM.
 

--- a/README.md
+++ b/README.md
@@ -83,12 +83,6 @@ ANTs is a flexible library that can be used for a variety of applications and ar
 - N4 bias correction + Atropos [[Link](https://github.com/ntustison/antsAtroposN4Example)]
 - Brain tumor segmentation [[Link](https://github.com/ntustison/BRATS2013/tree/master/SimpleExample)]
 
-### General
-
-- Patch-based super-resolution [[Link](https://github.com/ntustison/NonLocalSuperResolutionExample)]
-- Image denoising [[Link](https://github.com/ntustison/DenoiseImageExample)]
-- Morphing [[Link](http://stnava.github.io/Morpheus/)]
-
 ### Neuroimages
 
 - Basic Brain Mapping [[Link](http://stnava.github.io/BasicBrainMapping/)]
@@ -102,30 +96,20 @@ See also our pre-built ANTs templates with spatial priors available for [downloa
   
 ### Lung
 
-### Cardiac
-
-
-
-### Neuro
-
-* **Multi-atlas joint label/intensity fusion examples** [(bash and ANTsR examples 1)](https://github.com/ntustison/MalfLabelingExample) [example 2](https://github.com/qureai/Multi-Atlas-Segmentation) (thanks to @chsasank)
-* **Chimpanzee cortical thickness** [example](https://github.com/stnava/WHopkinsNHP/)
-* **Brain tumor segmentation** [example](https://github.com/ntustison/BRATS2013/tree/master/SimpleExample)
-* **fMRI or Motion Correction** [example](http://stnava.github.io/fMRIANTs/)
-* **fMRI reproducibility** [example](http://stnava.github.io/RfMRI/)
-* **fMRI prediction** [example](http://stnava.github.io/Haxby2001/) ... WIP ...
-* **Partial EPI slab to T1 image registration** [example](https://github.com/ntustison/PartialSlabEpiT1ImageRegistration)
-
-### Lung
-
-* **CT lung registration** [(bash and ANTsR examples)](https://github.com/ntustison/antsCtLungRegistrationExample)
-* **Lung mask registration** [example](https://github.com/ntustison/ProtonCtLungMaskRegistration)
-* **Lung and lobe estimation** [example](https://github.com/ntustison/LungAndLobeEstimationExample)
-* **Lung ventilation-based segmentation** [example](https://github.com/ntustison/LungVentilationSegmentationExample)
+- CT lung registration [[Link](https://github.com/ntustison/antsCtLungRegistrationExample)]
+- Lung mask registration [[Link](https://github.com/ntustison/ProtonCtLungMaskRegistration)]
+- Lung and lobe estimation [[Link](https://github.com/ntustison/LungAndLobeEstimationExample)]
+- Lung ventilation-based segmentation [[Link](https://github.com/ntustison/LungVentilationSegmentationExample)]
 
 ### Cardiac
 
-* **Cardiac** [example](http://stnava.github.io/LabelMyHeart)
+- Basic example [example](http://stnava.github.io/LabelMyHeart)
+  
+### Other
+
+- Patch-based super-resolution [[Link](https://github.com/ntustison/NonLocalSuperResolutionExample)]
+- Image denoising [[Link](https://github.com/ntustison/DenoiseImageExample)]
+- Morphing [[Link](http://stnava.github.io/Morpheus/)]
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ More details and a full downloadable installation script can be found in the [Li
 
 There are many different resources for learning about how to use ANTs functions and the methodology behind them. The [Wiki](https://github.com/ANTsX/ANTs/wiki) is a good place to start. A selected list of tutorials is also provided here.
 
-- ANTs Documentation [[PDF]](https://github.com/stnava/ANTsDoc/blob/master/ants2.pdf)
+- ANTs Documentation [[PDF](https://github.com/stnava/ANTsDoc/blob/master/ants2.pdf)]
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -90,19 +90,19 @@ A large collection of journal articles have been published using ANTs software. 
 
 ### Image Registration
 
-- Brian B. Avants, et al. Symmetric diffeomorphic image registration with cross-correlation: evaluating automated labeling of elderly and neurodegenerative brain. Med Image Anal (2008). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/17659998)]
+- Symmetric diffeomorphic image registration with cross-correlation: evaluating automated labeling of elderly and neurodegenerative brain. Brian B. Avants, et al. Med Image Anal (2008). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/17659998)]
 
-- Arno Klein, et al. Evaluation of 14 nonlinear deformation algorithms applied to human brain MRI registration. Neuroimage (2009). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/19195496)]
+- Evaluation of 14 nonlinear deformation algorithms applied to human brain MRI registration. Arno Klein, et al.  Neuroimage (2009). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/19195496)]
 
-- Murphy, et al. Evaluation of registration methods on thoracic CT: the EMPIRE10 challenge. IEEE Trans Med Imaging (2011) [[Link](http://www.ncbi.nlm.nih.gov/pubmed/21632295)]
+- Evaluation of registration methods on thoracic CT: the EMPIRE10 challenge. Murphy, et al. IEEE Trans Med Imaging (2011) [[Link](http://www.ncbi.nlm.nih.gov/pubmed/21632295)]
 
-- Brian B. Avants, et al. The optimal template effect in hippocampus studies of diseased populations. Neuroimage (2010). [[Link]](https://pubmed.ncbi.nlm.nih.gov/19818860/)
+- The optimal template effect in hippocampus studies of diseased populations. Brian B. Avants, et al. Neuroimage (2010). [[Link]](https://pubmed.ncbi.nlm.nih.gov/19818860/)
 
-- Brian B. Avants, et al. A reproducible evaluation of ANTs similarity metric performance in brain image registration. Neuroimage (2011). [[Link]](https://pubmed.ncbi.nlm.nih.gov/20851191/)
+- A reproducible evaluation of ANTs similarity metric performance in brain image registration. Brian B. Avants, et al. Neuroimage (2011). [[Link]](https://pubmed.ncbi.nlm.nih.gov/20851191/)
 
-- Brian B. Avants, et al. Multivariate analysis of structural and diffusion imaging in traumatic brain injury. Acad Radiol (2008). [[Link]](http://www.ncbi.nlm.nih.gov/pubmed/18995188)
+- Multivariate analysis of structural and diffusion imaging in traumatic brain injury. Brian B. Avants, et al. Acad Radiol (2008). [[Link]](http://www.ncbi.nlm.nih.gov/pubmed/18995188)
 
-- Nicholas J. Tustison, et al. Logical circularity in voxel-based analysis: normalization strategy may induce statistical bias. Hum Brain Mapp (2014). [[Link]](https://pubmed.ncbi.nlm.nih.gov/23151955/)
+- Logical circularity in voxel-based analysis: normalization strategy may induce statistical bias. Nicholas J. Tustison, et al. Hum Brain Mapp (2014). [[Link]](https://pubmed.ncbi.nlm.nih.gov/23151955/)
 
 ### Image Segmentation
 

--- a/README.md
+++ b/README.md
@@ -90,13 +90,19 @@ A large collection of journal articles have been published using ANTs software. 
 
 ### Image Registration
 
-Brian B. Avants, et al. Symmetric diffeomorphic image registration with cross-correlation: evaluating automated labeling of elderly and neurodegenerative brain. Med Image Anal (2008). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/17659998)]
-Arno Klein, et al. Evaluation of 14 nonlinear deformation algorithms applied to human brain MRI registration. Neuroimage (2009). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/19195496)]
-Murphy, et al. Evaluation of registration methods on thoracic CT: the EMPIRE10 challenge. IEEE Trans Med Imaging (2011) [[Link](http://www.ncbi.nlm.nih.gov/pubmed/21632295)]
-Brian B. Avants, et al. The optimal template effect in hippocampus studies of diseased populations. Neuroimage (2010). [[Link]](https://pubmed.ncbi.nlm.nih.gov/19818860/)
-Brian B. Avants, et al. A reproducible evaluation of ANTs similarity metric performance in brain image registration. Neuroimage (2011). [[Link]](https://pubmed.ncbi.nlm.nih.gov/20851191/)
-Brian B. Avants, et al. Multivariate analysis of structural and diffusion imaging in traumatic brain injury. Acad Radiol (2008). [[Link]](http://www.ncbi.nlm.nih.gov/pubmed/18995188)
-Nicholas J. Tustison, et al. Logical circularity in voxel-based analysis: normalization strategy may induce statistical bias. Hum Brain Mapp (2014). [[Link]](https://pubmed.ncbi.nlm.nih.gov/23151955/)
+- Brian B. Avants, et al. Symmetric diffeomorphic image registration with cross-correlation: evaluating automated labeling of elderly and neurodegenerative brain. Med Image Anal (2008). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/17659998)]
+
+- Arno Klein, et al. Evaluation of 14 nonlinear deformation algorithms applied to human brain MRI registration. Neuroimage (2009). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/19195496)]
+
+- Murphy, et al. Evaluation of registration methods on thoracic CT: the EMPIRE10 challenge. IEEE Trans Med Imaging (2011) [[Link](http://www.ncbi.nlm.nih.gov/pubmed/21632295)]
+
+- Brian B. Avants, et al. The optimal template effect in hippocampus studies of diseased populations. Neuroimage (2010). [[Link]](https://pubmed.ncbi.nlm.nih.gov/19818860/)
+
+- Brian B. Avants, et al. A reproducible evaluation of ANTs similarity metric performance in brain image registration. Neuroimage (2011). [[Link]](https://pubmed.ncbi.nlm.nih.gov/20851191/)
+
+- Brian B. Avants, et al. Multivariate analysis of structural and diffusion imaging in traumatic brain injury. Acad Radiol (2008). [[Link]](http://www.ncbi.nlm.nih.gov/pubmed/18995188)
+
+- Nicholas J. Tustison, et al. Logical circularity in voxel-based analysis: normalization strategy may induce statistical bias. Hum Brain Mapp (2014). [[Link]](https://pubmed.ncbi.nlm.nih.gov/23151955/)
 
 ### Image Segmentation
 

--- a/README.md
+++ b/README.md
@@ -96,16 +96,13 @@ Arno Klein, et al. Evaluation of 14 nonlinear deformation algorithms applied to 
 
 Murphy, et al. Evaluation of registration methods on thoracic CT: the EMPIRE10 challenge. IEEE Trans Med Imaging (2011) [[Link](http://www.ncbi.nlm.nih.gov/pubmed/21632295)]
 
+Brian B. Avants, et al. The optimal template effect in hippocampus studies of diseased populations. Neuroimage (2010). [[Link]](https://pubmed.ncbi.nlm.nih.gov/19818860/)
 
-Independent Evaluation:
-Template
-Construction
-[(2004)](http://www.ncbi.nlm.nih.gov/pubmed/15501083)[(2010)](http://www.ncbi.nlm.nih.gov/pubmed/19818860),
-[Similarity Metrics](http://www.ncbi.nlm.nih.gov/pubmed/20851191),
-[Multivariate
-registration](http://www.ncbi.nlm.nih.gov/pubmed/18995188), [Multiple
-modality analysis and statistical
-bias](http://www.ncbi.nlm.nih.gov/pubmed/23151955)
+Brian B. Avants, et al. A reproducible evaluation of ANTs similarity metric performance in brain image registration. Neuroimage (2011). [[Link]](https://pubmed.ncbi.nlm.nih.gov/20851191/)
+
+Brian B. Avants, et al. Multivariate analysis of structural and diffusion imaging in traumatic brain injury. Acad Radiol (2008). [[Link]](http://www.ncbi.nlm.nih.gov/pubmed/18995188)
+
+Nicholas J. Tustison, et al. Logical circularity in voxel-based analysis: normalization strategy may induce statistical bias. Hum Brain Mapp (2014). [[Link]](https://pubmed.ncbi.nlm.nih.gov/23151955/)
 
 ### Image Segmentation
 
@@ -116,6 +113,8 @@ Correction [(link)](http://www.ncbi.nlm.nih.gov/pubmed/20378467), DiReCT
 cortical thickness
 [(link)](http://www.ncbi.nlm.nih.gov/pubmed/19150502), DiReCT in
 [chimpanzees](http://www.ncbi.nlm.nih.gov/pubmed/23516289)
+
+### Cortical Thickness
 
 ### Multivariate Analysis Eigenanatomy 
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ More details and a full downloadable installation script can be found in the [Li
 
 ANTs is a flexible library that can be used for a variety of applications and areas. Below is a collection of example scripts that can be easily adapted to fit your needs.
 
+### General
+
+
+### Brain
+
+
+### Lung
+
+
+### Cardiac
 
 
 <br />
@@ -126,6 +136,8 @@ A large collection of journal articles have been published using ANTs software a
 ### Cortical Thickness
 
 <i>Registration based cortical thickness measurement</i>. Neuroimage (2009). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/19150502)]
+
+<i>Large-scale evaluation of ANTs and FreeSurfer cortical thickness measurements</i>. Neuroimage (2014). [[Link](https://pubmed.ncbi.nlm.nih.gov/24879923/)]
 
 <i>Regional and hemispheric variation in cortical thickness in chimpanzees</i>. J Neurosci (2013). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/23516289)]
 

--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ ANTs is a flexible library that can be used for a variety of applications and ar
 
 There are many different resources for learning about how to use ANTs functions and the methodology behind them. The [Wiki](https://github.com/ANTsX/ANTs/wiki) is a good place to start, but a selected list of commonly visited tutorials is also provided here.
 
-- ANTs Documentation [[PDF](https://github.com/stnava/ANTsDoc/blob/master/ants2.pdf)]
-- ANTs Tutorial Repo [[Repo](https://github.com/stnava/ANTsTutorial)]
+- ANTs Documentation [[Link](https://github.com/stnava/ANTsDoc/blob/master/ants2.pdf)]
+- ANTs Tutorial Repo [[Link](https://github.com/stnava/ANTsTutorial)]
 - Using antsRegistration [[Link](https://github.com/ANTsX/ANTs/wiki/ANTS-and-antsRegistration)]
 - Using antsCorticalThickness [[Link](https://github.com/ANTsX/ANTs/wiki/antsCorticalThickness-and-antsLongitudinalCorticalThickness-output)]
 - Using N4BiasFieldCorrection [[Link](https://github.com/ANTsX/ANTs/wiki/N4BiasFieldCorrection)]
-- Multi-modality Presentation [[Slides](https://github.com/stnava/ANTS_MultiModality/blob/master/ants_multimodality.pdf)]
+- Multi-modality Presentation [[Link](https://github.com/stnava/ANTS_MultiModality/blob/master/ants_multimodality.pdf)]
   
 <br />
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ There are many different resources for learning about how to use ANTs functions 
 Some commonly visited tutorials for specific ANTs functions are also presented below.
 
 * Using antsRegistration [[Link](https://github.com/ANTsX/ANTs/wiki/ANTS-and-antsRegistration)]
+* Forward and inverse warps using antsApplyTransforms [[Link](https://github.com/ANTsX/ANTs/wiki/Forward-and-inverse-warps-for-warping-images,-pointsets-and-Jacobians)]
 * Using antsCorticalThickness [[Link](https://github.com/ANTsX/ANTs/wiki/antsCorticalThickness-and-antsLongitudinalCorticalThickness-output)]
 * Using N4BiasFieldCorrection [[Link](https://github.com/ANTsX/ANTs/wiki/N4BiasFieldCorrection)]
 * Multi-modality Presentation [[Link](https://github.com/stnava/ANTS_MultiModality/blob/master/ants_multimodality.pdf)]

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ More details and a full downloadable installation script can be found in the [Li
 
 ## Examples
 
-ANTs is a flexible library that can be used for a variety of applications and areas. Below is a collection of example scripts that can be easily adapted to fit your needs.
+ANTs is a flexible library that can be used for a variety of applications and areas. Below is a collection of example scripts that - with a little effort - can be adapted to fit your specific needs.
 
 ### General
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ There are many different resources for learning about how to use ANTs functions 
 * ANTs Wiki [[Link](https://github.com/ANTsX/ANTs/wiki)]
 * ANTs Documentation [[Link](https://github.com/stnava/ANTsDoc/blob/master/ants2.pdf)]
 * ANTs Tutorials [[Link](https://github.com/stnava/ANTsTutorial)]
+
+Some commonly visited tutorials for specific ANTs functions is also presented below.
+
 * Using antsRegistration [[Link](https://github.com/ANTsX/ANTs/wiki/ANTS-and-antsRegistration)]
 * Using antsCorticalThickness [[Link](https://github.com/ANTsX/ANTs/wiki/antsCorticalThickness-and-antsLongitudinalCorticalThickness-output)]
 * Using N4BiasFieldCorrection [[Link](https://github.com/ANTsX/ANTs/wiki/N4BiasFieldCorrection)]

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The core development team also consists of Gang Song (Originator), Philip A. Coo
 
 ## References
 
-A large collection of journal articles have been published using ANTs software and can be found by searching Google Scholar or PubMed. Below, we also provide a curated list of the most relevant articles to be used as a guide or for citing ANTs methods.
+A large collection of journal articles have been published using ANTs software and can be found by searching Google Scholar or PubMed. Below, we provide a curated list of the most relevant articles to be used as a guide for better understanding or citing ANTs.
 
 ### Image Registration
 

--- a/README.md
+++ b/README.md
@@ -152,12 +152,17 @@ ANTs is a flexible library that can be used for a variety of applications and ar
 
 There are many different resources for learning about how to use ANTs functions and the methodology behind them. The [Wiki](https://github.com/ANTsX/ANTs/wiki) is a good place to start, but a selected list of commonly visited tutorials is also provided here.
 
-- ANTs Documentation [[Link](https://github.com/stnava/ANTsDoc/blob/master/ants2.pdf)]
-- ANTs Tutorial Repo [[Link](https://github.com/stnava/ANTsTutorial)]
-- Using antsRegistration [[Link](https://github.com/ANTsX/ANTs/wiki/ANTS-and-antsRegistration)]
-- Using antsCorticalThickness [[Link](https://github.com/ANTsX/ANTs/wiki/antsCorticalThickness-and-antsLongitudinalCorticalThickness-output)]
-- Using N4BiasFieldCorrection [[Link](https://github.com/ANTsX/ANTs/wiki/N4BiasFieldCorrection)]
-- Multi-modality Presentation [[Link](https://github.com/stnava/ANTS_MultiModality/blob/master/ants_multimodality.pdf)]
+* ANTs Documentation [[Link](https://github.com/stnava/ANTsDoc/blob/master/ants2.pdf)]
+  
+* ANTs Tutorial Repo [[Link](https://github.com/stnava/ANTsTutorial)]
+
+* Using antsRegistration [[Link](https://github.com/ANTsX/ANTs/wiki/ANTS-and-antsRegistration)]
+
+* Using antsCorticalThickness [[Link](https://github.com/ANTsX/ANTs/wiki/antsCorticalThickness-and-antsLongitudinalCorticalThickness-output)]
+
+* Using N4BiasFieldCorrection [[Link](https://github.com/ANTsX/ANTs/wiki/N4BiasFieldCorrection)]
+
+* Multi-modality Presentation [[Link](https://github.com/stnava/ANTS_MultiModality/blob/master/ants_multimodality.pdf)]
   
 <br />
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PubMed](https://img.shields.io/badge/ANTsX_paper-Open_Access-8DABFF?logo=pubmed)](https://pubmed.ncbi.nlm.nih.gov/33907199/)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](code_of_conduct.md)
 
-Advanced Normalization Tools (ANTs) is a C++ library available through the command line that computes high-dimensional mappings to capture the statistics of brain structure and function. It allows one to organize, visualize and statistically explore large biomedical image sets. Additionally, it integrates imaging modalities in space + time and works across species or organ systems with minimal customization. 
+**Advanced Normalization Tools (ANTs)** is a C++ library available through the command line that computes high-dimensional mappings to capture the statistics of brain structure and function. It allows one to organize, visualize and statistically explore large biomedical image sets. Additionally, it integrates imaging modalities in space + time and works across species or organ systems with minimal customization. 
 
 The ANTs library is considered a state-of-the-art medical image registration and segmentation toolkit which depends on the Insight ToolKit, a widely used medical image processing library to which ANTs developers contribute. ANTs-related tools have also won several international, unbiased competitions such as MICCAI, BRATS, and STACOM.
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ There are many different resources for learning about how to use ANTs functions 
 Some commonly visited tutorials for specific ANTs functions are also presented below.
 
 * Using antsRegistration [[Link](https://github.com/ANTsX/ANTs/wiki/ANTS-and-antsRegistration)]
-* Forward and inverse warps using antsApplyTransforms [[Link](https://github.com/ANTsX/ANTs/wiki/Forward-and-inverse-warps-for-warping-images,-pointsets-and-Jacobians)]
+* Applying warps with antsApplyTransforms [[Link](https://github.com/ANTsX/ANTs/wiki/Forward-and-inverse-warps-for-warping-images,-pointsets-and-Jacobians)]
 * Using antsCorticalThickness [[Link](https://github.com/ANTsX/ANTs/wiki/antsCorticalThickness-and-antsLongitudinalCorticalThickness-output)]
 * Using N4BiasFieldCorrection [[Link](https://github.com/ANTsX/ANTs/wiki/N4BiasFieldCorrection)]
 * Multi-modality Presentation [[Link](https://github.com/stnava/ANTS_MultiModality/blob/master/ants_multimodality.pdf)]

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ which antsRegistration
 
 If that works, you should be able to use the full functionality of ANTs.
 
-### Build from source
+### Building from source
 
-When necessary, you can also build ANTs from source. A minimal example on Linux or Mac looks like this:
+When necessary, you can also build ANTs from the latest source code. A minimal example on Linux or Mac looks like this:
 
 ```bash
 workingDir=${PWD}

--- a/README.md
+++ b/README.md
@@ -77,9 +77,11 @@ ANTs is a flexible library that can be used for a variety of applications and ar
 ### Cortical thickness
 
 - Basic example [[Link](https://github.com/ntustison/antsCorticalThicknessExample)]
+- Chimpanzee example [[Link](https://github.com/stnava/WHopkinsNHP/)]
 
 ### Segmentation
 - N4 bias correction + Atropos [[Link](https://github.com/ntustison/antsAtroposN4Example)]
+- Brain tumor segmentation [[Link](https://github.com/ntustison/BRATS2013/tree/master/SimpleExample)]
 
 ### General
 
@@ -91,8 +93,11 @@ ANTs is a flexible library that can be used for a variety of applications and ar
 
 - Basic Brain Mapping [[Link](http://stnava.github.io/BasicBrainMapping/)]
 - Brain extraction [[Link](https://github.com/ntustison/antsBrainExtractionExample)]
-- Multi-atlas joint label/intensity fusion examples by @chsasank [[Link-1](https://github.com/ntustison/MalfLabelingExample), [Link-2](https://github.com/qureai/Multi-Atlas-Segmentation)]
- 
+- Multi-atlas joint label/intensity fusion examples by @chsasank [[Link](https://github.com/ntustison/MalfLabelingExample), [Link](https://github.com/qureai/Multi-Atlas-Segmentation)]
+- fMRI or Motion Correction [[Link](http://stnava.github.io/fMRIANTs/)]
+- fMRI reproducibility [[Link](http://stnava.github.io/RfMRI/)]
+- Partial EPI slab to T1 image registration [[Link](https://github.com/ntustison/PartialSlabEpiT1ImageRegistration)]
+  
 See also our pre-built ANTs templates with spatial priors available for [download](http://figshare.com/articles/ANTs_ANTsR_Brain_Templates/915436) including an [MNI version](https://figshare.com/articles/ANTs_files_for_mni_icbm152_nlin_sym_09a/8061914).
   
 ### Lung

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ We welcome any new contributions and ideas to improve ANTs. If you want to contr
 
 ## Team
 
-Development of ANTs is led by [Brian B. Avants](http://stnava.github.io/Resume/) (Creator, Algorithm Design, Implementation), [Nicholas J. Tustison](http://ntustison.github.io/CV/)(Compeller, Algorithm Design, Implementation Guru), Hans J. Johnson (Large-Scale Application, Testing, Software design), Gang Song (Originator), Philip A. Cook, Jeffrey T. Duda (DTI), Ben M. Kandel (Perfusion, multivariate analysis), and Nick Cullen (Python, R). 
+Development of ANTs is led by [Brian B. Avants](http://stnava.github.io/Resume/) (Creator, Algorithm Design, Implementation), [Nicholas J. Tustison](http://ntustison.github.io/CV/) (Compeller, Algorithm Design, Implementation Guru), Hans J. Johnson (Large-Scale Application, Testing, Software design), Gang Song (Originator), Philip A. Cook, Jeffrey T. Duda (DTI), Ben M. Kandel (Perfusion, multivariate analysis), and Nick Cullen (Python, R). 
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -100,43 +100,43 @@ A large collection of journal articles have been published using ANTs software a
 
 ### Image Registration
 
-<i>Symmetric diffeomorphic image registration with cross-correlation: evaluating automated labeling of elderly and neurodegenerative brain.</i>  Med Image Anal (2008). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/17659998)]
+<i>Symmetric diffeomorphic image registration with cross-correlation: evaluating automated labeling of elderly and neurodegenerative brain</i>.  Med Image Anal (2008). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/17659998)]
 
-<i>Evaluation of 14 nonlinear deformation algorithms applied to human brain MRI registration.</i> Neuroimage (2009). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/19195496)]
+<i>Evaluation of 14 nonlinear deformation algorithms applied to human brain MRI registration</i>. Neuroimage (2009). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/19195496)]
 
-<i>Evaluation of registration methods on thoracic CT: the EMPIRE10 challenge.</i> IEEE Trans Med Imaging (2011). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/21632295)]
+<i>Evaluation of registration methods on thoracic CT: the EMPIRE10 challenge</i>. IEEE Trans Med Imaging (2011). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/21632295)]
 
-<i>A reproducible evaluation of ANTs similarity metric performance in brain image registration.</i> Neuroimage (2011). [[Link](https://pubmed.ncbi.nlm.nih.gov/20851191/)]
+<i>A reproducible evaluation of ANTs similarity metric performance in brain image registration</i>. Neuroimage (2011). [[Link](https://pubmed.ncbi.nlm.nih.gov/20851191/)]
 
 ### Templates
 
-<i>The optimal template effect in hippocampus studies of diseased populations.</i> Neuroimage (2010). [[Link](https://pubmed.ncbi.nlm.nih.gov/19818860/)]
+<i>The optimal template effect in hippocampus studies of diseased populations</i>. Neuroimage (2010). [[Link](https://pubmed.ncbi.nlm.nih.gov/19818860/)]
 
 ### Image Segmentation
 
-<i>An open source multivariate framework for n-tissue segmentation with evaluation on public data</i> Neuroinformatics (2011). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/21373993)]
+<i>An open source multivariate framework for n-tissue segmentation with evaluation on public data</i>. Neuroinformatics (2011). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/21373993)]
 
-<i>Multi-atlas segmentation with joint label fusion and corrective learning—an open source implementation</i> Front Neuroinform (2013). [[Link](https://www.frontiersin.org/articles/10.3389/fninf.2013.00027/full)]
+<i>Multi-atlas segmentation with joint label fusion and corrective learning—an open source implementation</i>. Front Neuroinform (2013). [[Link](https://www.frontiersin.org/articles/10.3389/fninf.2013.00027/full)]
 
 ### Bias Correction
 
-<i>N4ITK: improved N3 bias correction</i> IEEE Trans Med Imaging (2010). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/20378467)]
+<i>N4ITK: improved N3 bias correction</i>. IEEE Trans Med Imaging (2010). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/20378467)]
 
 ### Cortical Thickness
 
-<i>Registration based cortical thickness measurement</i> Neuroimage (2009). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/19150502)]
+<i>Registration based cortical thickness measurement</i>. Neuroimage (2009). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/19150502)]
 
-<i>Regional and hemispheric variation in cortical thickness in chimpanzees</i> J Neurosci (2013). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/23516289)]
+<i>Regional and hemispheric variation in cortical thickness in chimpanzees</i>. J Neurosci (2013). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/23516289)]
 
 ### Eigenanatomy 
 
-<i>Eigenanatomy improves detection power for longitudinal cortical change</i> Med Image Comput Comput Assist Interv (2012). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/23286132)]
+<i>Eigenanatomy improves detection power for longitudinal cortical change</i>. Med Image Comput Comput Assist Interv (2012). [[Link](http://www.ncbi.nlm.nih.gov/pubmed/23286132)]
 
-<i>White matter imaging helps dissociate tau from TDP-43 in frontotemporal lobar degeneration</i> J Neurol Neurosurg Psychiatry (2013). [[Link](https://pubmed.ncbi.nlm.nih.gov/23475817/)]
+<i>White matter imaging helps dissociate tau from TDP-43 in frontotemporal lobar degeneration</i>. J Neurol Neurosurg Psychiatry (2013). [[Link](https://pubmed.ncbi.nlm.nih.gov/23475817/)]
 
 ### Software
 
-<i>The ANTsX ecosystem for quantitative biological and medical imaging</i> Scientific Reports (2021). [[Link](https://www.nature.com/articles/s41598-021-87564-6)]
+<i>The ANTsX ecosystem for quantitative biological and medical imaging</i>. Scientific Reports (2021). [[Link](https://www.nature.com/articles/s41598-021-87564-6)]
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PubMed](https://img.shields.io/badge/ANTsX_paper-Open_Access-8DABFF?logo=pubmed)](https://pubmed.ncbi.nlm.nih.gov/33907199/)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](code_of_conduct.md)
 
-Advanced Normalization Tools (ANTs) is a C++ and command-line library that computes high-dimensional mappings to capture the statistics of brain structure and function. It allows one to organize, visualize and statistically explore large biomedical image sets. Additionally, it integrates imaging modalities and related information in space and time, as well as works across species or organ systems with minimal customization. 
+Advanced Normalization Tools (ANTs) is a C++ library available through the command line that computes high-dimensional mappings to capture the statistics of brain structure and function. It allows one to organize, visualize and statistically explore large biomedical image sets. Additionally, it integrates imaging modalities and related information in space and time, as well as works across species or organ systems with minimal customization. 
 
 The ANTs library is considered a state-of-the-art medical image registration and segmentation toolkit which depends on the Insight ToolKit, a widely used medical image processing library to which ANTs developers contribute. ANTs-related tools have also won several international, unbiased challenges and competitions such as MICCAI, BRATS, and STACOM.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ The core development team consists of Gang Song (Originator), Philip A. Cook, Je
 
 ## References
 
-A large collection of journal articles have been published using ANTs software. The following is a curated list of relevant articles that can be used as a guide for selecting the right methods when using ANTs.
+A large collection of journal articles have been published using ANTs software. The best way to find up-to-date articles is by searching on [Google
+Scholar](http://scholar.google.com/scholar?q=Advanced+Normalization+Tools+%22ANTs%22+-ant&hl=en&as_sdt=1%2C39&as_ylo=2008&as_yhi=) or
+[Pubmed](http://www.ncbi.nlm.nih.gov/pubmed?term=%22Avants%20B%22%20OR%20%22Tustison%20N%22). Below, we also provide a curated list of the most relevant articles to be used as a guide or for citing ANTs methods.
 
 ### Image Registration
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Advanced Normalization Tools (ANTs) is a C++ and command-line library that computes high-dimensional mappings to capture the statistics of brain structure and function. It allows one to organize, visualize and statistically explore large biomedical image sets. Additionally, it integrates imaging modalities and related information in space and time, as well as works across species or organ systems with minimal customization. 
 
-The ANTs library is considered a state-of-the-art medical image registration and segmentation toolkit which depends on the Insight ToolKit [(ITK)](http://www.itk.org), a widely used medical image processing library to which ANTs developers contribute. ANTs and related tools have won several international and unbiased competitions.
+The ANTs library is considered a state-of-the-art medical image registration and segmentation toolkit which depends on the Insight ToolKit, a widely used medical image processing library to which ANTs developers contribute. ANTs and related tools have also won several international, unbiased challenges and competitions such as MICCAI, BRATS, and STACOM.
 
 You can also use ANTs in R ([ANTsR](https://github.com/antsx/antsr)) and Python ([ANTsPy](https://github.com/antsx/antsr)), with additional functionality for deep learning in R ([ANTsRNet](https://github.com/antsx/antsrnet)) and Python ([ANTsPyNet](https://github.com/antsx/antspynet)). These libraries also include additional functionality for interacting with the broader R and Python ecosystem.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ More details and a full downloadable installation script can be found in the [Li
 
 There are many different resources for learning about how to use ANTs functions and the methodology behind them. The [Wiki](https://github.com/ANTsX/ANTs/wiki) is a good place to start. A selected list of tutorials is also provided here.
 
-- ANTs Documentation [PDF](https://github.com/stnava/ANTsDoc/blob/master/ants2.pdf)
+- ANTs Documentation [[PDF]](https://github.com/stnava/ANTsDoc/blob/master/ants2.pdf)
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If that works, you should be able to use the full functionality of ANTs.
 
 ### Building from source
 
-When necessary, you can also build ANTs from the latest source code. A minimal example on Linux or Mac looks like this:
+When necessary, you can also build ANTs from the latest source code. A minimal example on Linux / Mac looks like this:
 
 ```bash
 workingDir=${PWD}

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ ANTs is a flexible library that can be used for a variety of applications and ar
 
 - Basic Brain Mapping [[Link](http://stnava.github.io/BasicBrainMapping/)]
 - Brain extraction [[Link](https://github.com/ntustison/antsBrainExtractionExample)]
-- Multi-atlas joint label/intensity fusion examples by @chsasank [[Link](https://github.com/ntustison/MalfLabelingExample), [Link](https://github.com/qureai/Multi-Atlas-Segmentation)]
+- Multi-atlas joint label/intensity fusion examples [[Link](https://github.com/ntustison/MalfLabelingExample), [Link](https://github.com/qureai/Multi-Atlas-Segmentation)] (credit: @chsasank)
 - fMRI or Motion Correction [[Link](http://stnava.github.io/fMRIANTs/)]
 - fMRI reproducibility [[Link](http://stnava.github.io/RfMRI/)]
 - Partial EPI slab to T1 image registration [[Link](https://github.com/ntustison/PartialSlabEpiT1ImageRegistration)]

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ More details and a full downloadable installation script can be found in the [Li
 
 There are many different resources for learning about how to use ANTs functions and the methodology behind them. The [Wiki](https://github.com/ANTsX/ANTs/wiki) is a good place to start. A selected list of tutorials is also provided here.
 
-- ANTs Documentation [[PDF](https://github.com/stnava/ANTsDoc/blob/master/ants2.pdf)]
+- ANTs Documentation [[Link](https://github.com/stnava/ANTsDoc/blob/master/ants2.pdf)]
+- Overview of antsRegistration [[Link](https://github.com/ANTsX/ANTs/wiki/ANTS-and-antsRegistration)]
+- Overview of antsCorticalThickness [[Link](https://github.com/ANTsX/ANTs/wiki/antsCorticalThickness-and-antsLongitudinalCorticalThickness-output)]
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ There are many different resources for learning about how to use ANTs functions 
 * ANTs Documentation [[Link](https://github.com/stnava/ANTsDoc/blob/master/ants2.pdf)]
 * ANTs Tutorials [[Link](https://github.com/stnava/ANTsTutorial)]
 
-Some commonly visited tutorials for specific ANTs functions is also presented below.
+Some commonly visited tutorials for specific ANTs functions are also presented below.
 
 * Using antsRegistration [[Link](https://github.com/ANTsX/ANTs/wiki/ANTS-and-antsRegistration)]
 * Using antsCorticalThickness [[Link](https://github.com/ANTsX/ANTs/wiki/antsCorticalThickness-and-antsLongitudinalCorticalThickness-output)]


### PR DESCRIPTION
This proposed PR updates and reformats the README. It is best to view it visually on my fork at https://github.com/ncullen93/ANTs instead of the raw file. 

Improvements:
- You don't have to leave the readme to learn how to install ANTs in a basic scenario.
- All learning resources are grouped together so when I’m in “learning mode” I can quickly evaluate which one I need.
- Same with scripts / example code that are now grouped a bit more semantically. 
- For references, article titles are displayed so I can quickly evaluate which are relevant rather than having to follow a ton of links that take me away from the readme.
- In general, it's much clearer now when you're nevigating to a script, to a tutorial, or to a journal article. It was a complete lottery what I’m going to get from the links on the current Readme.
- In general, links that take users away from the repo should be minimized… they’ll get distracted and never come back.
- Links to outdated (e.g., source forge) or unfinished resources are all removed
