### PR TITLE
BUG:  Manifold parzen windows.

### DIFF
--- a/ImageSegmentation/antsAtroposSegmentationImageFilter.hxx
+++ b/ImageSegmentation/antsAtroposSegmentationImageFilter.hxx
@@ -615,7 +615,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>::Gener
     {
       this->m_MixtureModelComponents[n]->SetListSampleWeights(&weights[n]);
       this->m_MixtureModelComponents[n]->SetInputListSample(samples[n]);
-      this->m_MixtureModelComponents[n]->ClearInputListSample();
+      // this->m_MixtureModelComponents[n]->ClearInputListSample();
 
       if (this->m_UseMixtureModelProportions)
       {
@@ -635,7 +635,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>::Gener
       {
         this->m_MixtureModelComponents[n]->SetListSampleWeights(d, &weights[labelSet[d] - 1]);
         this->m_MixtureModelComponents[n]->SetIndexedInputListSample(d, samples[labelSet[d] - 1]);
-        this->m_MixtureModelComponents[n]->ClearInputListSample(d);
+        // this->m_MixtureModelComponents[n]->ClearInputListSample(d);
       }
 
       this->m_MixtureModelProportions[n] = 0.0;
@@ -1279,7 +1279,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>::Updat
     {
       this->m_MixtureModelComponents[n]->SetListSampleWeights(&weights);
       this->m_MixtureModelComponents[n]->SetInputListSample(sample);
-      this->m_MixtureModelComponents[n]->ClearInputListSample();
+      // this->m_MixtureModelComponents[n]->ClearInputListSample();
     }
     else
     {
@@ -1290,7 +1290,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>::Updat
         {
           this->m_MixtureModelComponents[n]->SetListSampleWeights(d, &weights);
           this->m_MixtureModelComponents[n]->SetIndexedInputListSample(d, sample);
-          this->m_MixtureModelComponents[n]->ClearInputListSample(d);
+          // this->m_MixtureModelComponents[n]->ClearInputListSample(d);
         }
       }
       this->m_MixtureModelProportions[n] = 0.0;

--- a/ImageSegmentation/antsManifoldParzenWindowsListSampleFunction.hxx
+++ b/ImageSegmentation/antsManifoldParzenWindowsListSampleFunction.hxx
@@ -191,7 +191,7 @@ ManifoldParzenWindowsListSampleFunction<TListSample, TOutput, TCoordRep>::Evalua
     }
     else
     {
-      typename TreeGeneratorType::KdTreeType ::InstanceIdentifierVectorType neighbors;
+      typename TreeGeneratorType::KdTreeType::InstanceIdentifierVectorType neighbors;
       this->m_KdTreeGenerator->GetOutput()->Search(measurement, numberOfNeighbors, neighbors);
       for (unsigned int j = 0; j < numberOfNeighbors; j++)
       {


### PR DESCRIPTION
Addresses https://github.com/ANTsX/ANTs/issues/1664.

The different likelihood functions (e.g., Gaussian, ManifoldParzenWindows) are generated from a list of samples.  For example, in the classic three tissue scenario, the voxels labeled as 'CSF' for the current iteration are fed into the first likelihood function which are used to estimate the likelihood function parameters (e.g., Gaussian mean).  When I first wrote this, once these parameters were estimated, the samples were no longer needed so I wrote a function to clear the input sample list immediately after likelihood parameter estimation.  However, this is no longer the case with the ManifoldParzenWindows, which relies on the Kdtree class which apparently needs to know the size of the input sample list during evaluation.    This pull request removes the deletion of the input list sample after parameter estimation.  