### PR TITLE
ENH: write template output such that things sort together

### DIFF
--- a/Scripts/antsMultivariateTemplateConstruction2.sh
+++ b/Scripts/antsMultivariateTemplateConstruction2.sh
@@ -904,7 +904,7 @@ elif [[ ${NINFILES} -eq 1 ]];
         IMAGECOUNT=0
         while read line
             do
-            files=(`echo $line | tr ',' ' '`)
+            files=(`echo $line | tr "," "\n"`)
             if [[ ${#files[@]} -ne $NUMBEROFMODALITIES ]];
                 then
                 echo "The number of files in the csv file does not match the specified number of modalities."
@@ -1366,13 +1366,13 @@ fi # endif RIGID
 #
 ##########################################################################
 
-ITERATLEVEL=( $(echo $MAXITERATIONS | tr 'x' ' ') )
+ITERATLEVEL=( $(echo $MAXITERATIONS | tr 'x' '\n') )
 NUMLEVELS=${#ITERATLEVEL[@]}
 
-SHRINKLEVEL=( $(echo $SHRINKFACTORS | tr 'x' ' ') )
+SHRINKLEVEL=( $(echo $SHRINKFACTORS | tr 'x' '\n') )
 NUMSHRINK=${#SHRINKLEVEL[@]}
 
-SMOOTHLEVEL=( $(echo $SMOOTHINGFACTORS | tr 'x' ' ') )
+SMOOTHLEVEL=( $(echo $SMOOTHINGFACTORS | tr 'x' '\n') )
 NUMSMOOTH=${#SMOOTHLEVEL[@]}
 
 if [[ $NUMLEVELS -ne $NUMSHRINK ]]

--- a/Scripts/antsMultivariateTemplateConstruction2.sh
+++ b/Scripts/antsMultivariateTemplateConstruction2.sh
@@ -1,4 +1,7 @@
-#!/bin/bash -e
+#!/bin/bash
+
+set -euo pipefail
+IFS=$'\n\t'
 
 shopt -s extglob
 
@@ -1063,7 +1066,7 @@ for (( i = 0; i < $NUMBEROFMODALITIES; i++ ))
   do
     setCurrentImageSet $i
 
-    if [[ -n "${REGTEMPLATES[$i]}" ]];
+    if [[ ${#REGTEMPLATES[@]} -gt 0 && -n "${REGTEMPLATES[$i]}" ]];
       then
         if [[ ! -r "${REGTEMPLATES[$i]}" ]];
           then

--- a/Scripts/antsMultivariateTemplateConstruction2.sh
+++ b/Scripts/antsMultivariateTemplateConstruction2.sh
@@ -404,7 +404,10 @@ function shapeupdatetotemplate() {
     WARPLIST=( `ls ${outputname}input*-[0-9]Warp.nii.gz 2> /dev/null` ) || true
     NWARPS=${#WARPLIST[@]}
     echo "number of warps = $NWARPS"
-    echo "${WARPLIST[@]}"
+    if [[ $NWARPS -ne 0 ]];
+      then
+        echo "${WARPLIST[@]}"
+      fi
 
     if [[ $whichtemplate -eq 0 ]];
       then
@@ -1683,49 +1686,32 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
           fi
       fi
 
-    WARPFILES=(`ls ${OUTPUTNAME}*Warp.nii.gz | grep -v "InverseWarp"`)
-    AFFINEFILES=(`ls ${OUTPUTNAME}*GenericAffine.mat`)
+    NUM_AFFINEFILES=0
+    NUM_AFFINEFILES=$(ls ${OUTPUTNAME}*GenericAffine.mat | wc -l) || true
 
-    if [[ ${#WARPFILES[@]} -eq 0 ]];
+    if [[ $NOWARP -eq 1 ]];
       then
-        if [[ ${#AFFINEFILES[@]} -eq 0 ]];
+        if [[ ${NUM_AFFINEFILES} -eq 0 ]];
           then
-            echo "The registrations did not terminate properly.  There are no warp files"
-            echo "or affine files."
+            echo "The registrations did not terminate properly.  There are no warp files or affine files."
             exit 1
+          fi
+      if [[ ${NUM_AFFINEFILES} -ne $IMAGESPERMODALITY ]];
+        then
+          echo "The registrations did not terminate properly.  The number of affine transform files"
+          echo "does not match the number of input images."
+          exit 1
         fi
-
-        if [[ $NOWARP -eq 0 ]];
+      else
+        NUM_WARPFILES=0
+        NUM_WARPFILES=$(ls ${OUTPUTNAME}*Warp.nii.gz | grep -v InverseWarp | wc -l) || true
+        if [[ ${NUM_WARPFILES} -ne $IMAGESPERMODALITY ]];
           then
-            echo "The registrations did not terminate properly.  "
-            echo "A nonlinear transform was requested, but there are no warp files."
-            exit 1
-        fi
-
-        if [[ ${#AFFINEFILES[@]} -ne $IMAGESPERMODALITY ]];
-          then
-            echo "The registrations did not terminate properly.  The number of affine transform files"
+            echo "The registrations did not terminate properly.  The number of warp files"
             echo "does not match the number of input images."
             exit 1
-        fi
-    fi
-
-    if [[ ${#WARPFILES[@]} -gt 0 ]];
-      then
-        if [[ ${#WARPFILES[@]} -ne ${#AFFINEFILES[@]} ]];
-          then
-            echo "The registrations did not terminate properly.  The number of warp files"
-            echo "does not match the number of affine files."
-            exit 1
-        fi
-
-        if [[ ${#WARPFILES[@]} -ne $IMAGESPERMODALITY ]];
-          then
-            echo "The registrations did not terminate properly.  The number of warp files"
-           echo "does not match the number of input images."
-            exit 1
-        fi
-    fi
+          fi
+      fi
 
     for (( j = 0; j < $NUMBEROFMODALITIES; j++ ))
       do


### PR DESCRIPTION
A few fixes

* Replaced all the "let" statements and other traps that prevent running with `bash -e`, and turned that on.

* Fixed error checking in pairwise registration stage

* Attempted to make output more readable by prefixing input indices, rather than adding them at the end. Trying to make things easier to list and review, especially with multiple modalities