### PR TITLE
DOC: Fix wrong link for ANTsPy in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 The ANTs library is considered a state-of-the-art medical image registration and segmentation toolkit which depends on the Insight ToolKit, a widely used medical image processing library to which ANTs developers contribute. ANTs-related tools have also won several international, unbiased competitions such as MICCAI, BRATS, and STACOM.
 
-It is possible to use ANTs in R ([ANTsR](https://github.com/antsx/antsr)) and Python ([ANTsPy](https://github.com/antsx/antsr)), with additional functionality for deep learning in R ([ANTsRNet](https://github.com/antsx/antsrnet)) and Python ([ANTsPyNet](https://github.com/antsx/antspynet)). These libraries help integrate ANTs with the broader R / Python ecosystem.
+It is possible to use ANTs in R ([ANTsR](https://github.com/antsx/antsr)) and Python ([ANTsPy](https://github.com/antsx/antspy)), with additional functionality for deep learning in R ([ANTsRNet](https://github.com/antsx/antsrnet)) and Python ([ANTsPyNet](https://github.com/antsx/antspynet)). These libraries help integrate ANTs with the broader R / Python ecosystem.
 
 <br />
 


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your
pull request.

We welcome contributions to ANTs. Pull requests will be reviewed by the
developers and if accepted, become part of ANTs, distributed under the license
terms in COPYING.txt.

Please title your PR according to what it does:
ENH: new or improved functionality
PERF: performance enhancements to existing functionality
BUG: fixing a run time bug
COMP: relating to compilation
DOC: documentation changes
WIP: work in progress, needs further commits to be ready
-->

# Description

This PR proposes to fix the link to `ANTsPy` in the main README which currently points to `ANTsR`.

<!--
Extended description of your PR.

If the PR can close an existing issue, you can say "Fixes #1234" or "Resolves
#1234". Otherwise you can say something like "Related to #1234".
-->


