### PR TITLE
ENH: Make COM translation consistent with antsRegistration

### DIFF
--- a/Examples/antsAI.cxx
+++ b/Examples/antsAI.cxx
@@ -1098,10 +1098,12 @@ antsAI(itk::ants::CommandLineParser * parser)
       }
       else if (initialTransformInitializedWithImages == true)
       {
-        using TranslationTransformType = itk::TranslationTransform<RealType, ImageDimension>;
-        typename TranslationTransformType::Pointer bestTranslationTransform = TranslationTransformType::New();
-        bestTranslationTransform->SetOffset(initialTransform->GetOffset());
-        transformWriter->SetInput(bestTranslationTransform);
+        // write the translation transform as a rigid transform, to be consistent with antsRegistration
+        typename RigidTransformType::Pointer bestRigidTransform = RigidTransformType::New();
+        bestRigidTransform->SetCenter(initialTransform->GetCenter());
+        bestRigidTransform->SetMatrix(initialTransform->GetMatrix());
+        bestRigidTransform->SetOffset(initialTransform->GetOffset());
+        transformWriter->SetInput(bestRigidTransform);
       }
 
       transformWriter->SetFileName(outputName.c_str());


### PR DESCRIPTION
Use a rigid transform type with identity matrix. This is what antsRegistration does with `-r [ fixed, moving, 1 ]`.

Avoids having to deal explicitly with translation-only transforms in antsTransformInfo

This bypasses #1819 though I think it would be good to merge error checks in #1820 anyway.