### PR TITLE
ENH: Update default gradient step, turn off histogram matching

### DIFF
--- a/Scripts/antsCorticalThickness.sh
+++ b/Scripts/antsCorticalThickness.sh
@@ -381,7 +381,7 @@ ATROPOS_SEGMENTATION_PRIOR_WEIGHT=0.25
 
 ANTS=antsRegistration
 ANTS_MAX_ITERATIONS="100x100x70x20"
-ANTS_TRANSFORMATION="SyN[ 0.1,3,0 ]"
+ANTS_TRANSFORMATION="SyN[ 0.2,3,0 ]"
 ANTS_LINEAR_METRIC_PARAMS="1,32,Regular,0.25"
 ANTS_LINEAR_CONVERGENCE="[ 1000x500x250x100,1e-8,10 ]"
 ANTS_METRIC="CC"
@@ -520,7 +520,7 @@ fi
 
 if [[ $USE_BSPLINE_SMOOTHING -ne 0 ]];
   then
-    ANTS_TRANSFORMATION="BSplineSyN[ 0.1,26,0,3 ]"
+    ANTS_TRANSFORMATION="BSplineSyN[ 0.2,26,0,3 ]"
     DIRECT_SMOOTHING_PARAMETER="5.75"
   fi
 
@@ -898,7 +898,7 @@ if [[ ! -s ${OUTPUT_PREFIX}ACTStage2Complete.txt ]]  && \
                     basecall="${basecall} -p f"
                   fi
             else
-              basecall="${ANTS} -d ${DIMENSION} -u 1 -w [ 0.0,0.999 ] -o ${SEGMENTATION_WARP_OUTPUT_PREFIX} --float ${USE_FLOAT_PRECISION} --verbose 1"
+              basecall="${ANTS} -d ${DIMENSION} -u 0 -w [ 0.0,0.999 ] -o ${SEGMENTATION_WARP_OUTPUT_PREFIX} --float ${USE_FLOAT_PRECISION} --verbose 1"
               IMAGES="${EXTRACTED_SEGMENTATION_BRAIN},${EXTRACTED_BRAIN_TEMPLATE}"
               if [[ -f ${EXTRACTION_GENERIC_AFFINE} ]];
                 then
@@ -1136,7 +1136,7 @@ if [[ -f ${REGISTRATION_TEMPLATE} ]] && [[ ! -f $REGISTRATION_LOG_JACOBIAN ]];
           fi
       else
         IMAGES="${REGISTRATION_TEMPLATE},${EXTRACTED_SEGMENTATION_BRAIN_N4_IMAGE}"
-        basecall="${ANTS} -d ${DIMENSION} -v 1 -u 1 -w [ 0.0,0.999 ] -o ${REGISTRATION_TEMPLATE_OUTPUT_PREFIX} -r [ ${IMAGES},1 ] --float ${USE_FLOAT_PRECISION}"
+        basecall="${ANTS} -d ${DIMENSION} -v 1 -u 0 -w [ 0.0,0.999 ] -o ${REGISTRATION_TEMPLATE_OUTPUT_PREFIX} -r [ ${IMAGES},1 ] --float ${USE_FLOAT_PRECISION}"
         stage1="-m MI[ ${IMAGES},${ANTS_LINEAR_METRIC_PARAMS} ] -c ${ANTS_LINEAR_CONVERGENCE} -t Rigid[ 0.1 ] -f 8x4x2x1 -s 3x2x1x0"
         stage2="-m MI[ ${IMAGES},${ANTS_LINEAR_METRIC_PARAMS} ] -c ${ANTS_LINEAR_CONVERGENCE} -t Affine[ 0.1 ] -f 8x4x2x1 -s 3x2x1x0"
         stage3="-m CC[ ${IMAGES},1,4 ] -c [ ${ANTS_MAX_ITERATIONS},1e-9,15 ] -t ${ANTS_TRANSFORMATION} -f 6x4x2x1 -s 3x2x1x0"

--- a/Scripts/antsMultivariateTemplateConstruction.sh
+++ b/Scripts/antsMultivariateTemplateConstruction.sh
@@ -991,7 +991,7 @@ if [[ "$RIGID" -eq 1 ]];
         BASENAME=` echo ${IMGbase} | cut -d '.' -f 1 `
         RIGID="${outdir}/rigid${i}_0_${IMGbase}"
 
-        exe="$ANTS $DIM $IMAGEMETRICSET -o $RIGID -i 0 --use-Histogram-Matching $LINEARTRANSFORMPARAMS $RIGIDTYPE"
+        exe="$ANTS $DIM $IMAGEMETRICSET -o $RIGID -i 0 $LINEARTRANSFORMPARAMS $RIGIDTYPE"
 
         echo "$exe" >> $qscript
 
@@ -1383,10 +1383,10 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
 
         LINEARTRANSFORMPARAMS="--number-of-affine-iterations 10000x10000x1000 --MI-option 32x16000"
 
-        exe="$exe $ANTS ${DIM} $IMAGEMETRICSET -i ${MAXITERATIONS} -t ${TRANSFORMATION} -r $REGULARIZATION -o ${outdir}/${OUTWARPFN} --use-Histogram-Matching  $LINEARTRANSFORMPARAMS\n"
+        exe="$exe $ANTS ${DIM} $IMAGEMETRICSET -i ${MAXITERATIONS} -t ${TRANSFORMATION} -r $REGULARIZATION -o ${outdir}/${OUTWARPFN} $LINEARTRANSFORMPARAMS\n"
         exe="$exe $warpexe"
 
-        pexe="$pexe $ANTS ${DIM} $IMAGEMETRICSET -i ${MAXITERATIONS} -t ${TRANSFORMATION} -r $REGULARIZATION -o ${outdir}/${OUTWARPFN} --use-Histogram-Matching  $LINEARTRANSFORMPARAMS >> ${outdir}/job_${count}_metriclog.txt\n"
+        pexe="$pexe $ANTS ${DIM} $IMAGEMETRICSET -i ${MAXITERATIONS} -t ${TRANSFORMATION} -r $REGULARIZATION -o ${outdir}/${OUTWARPFN} $LINEARTRANSFORMPARAMS >> ${outdir}/job_${count}_metriclog.txt\n"
         pexe="$pexe $warppexe"
 
         qscript="${outdir}/job_${count}_${i}.sh"

--- a/Scripts/antsMultivariateTemplateConstruction2.sh
+++ b/Scripts/antsMultivariateTemplateConstruction2.sh
@@ -805,7 +805,7 @@ if [[ $TRANSFORMATIONTYPE == "BSplineSyN"* ]];
         TRANSFORMATION=${TRANSFORMATIONTYPE}
         TRANSFORMATIONTYPE="BSplineSyN"
       else
-        TRANSFORMATION="BSplineSyN[ 0.1,26,0,3 ]"
+        TRANSFORMATION="BSplineSyN[ 0.2,26,0,3 ]"
     fi
 elif [[ $TRANSFORMATIONTYPE == "SyN"* ]];
   then
@@ -814,7 +814,7 @@ elif [[ $TRANSFORMATIONTYPE == "SyN"* ]];
         TRANSFORMATION=${TRANSFORMATIONTYPE}
         TRANSFORMATIONTYPE="SyN"
       else
-        TRANSFORMATION="SyN[ 0.1,3,0 ]"
+        TRANSFORMATION="SyN[ 0.2,3,0 ]"
     fi
 elif [[ $TRANSFORMATIONTYPE == "TimeVaryingVelocityField"* ]];
   then
@@ -1144,7 +1144,7 @@ if [[ "$RIGID" -eq 1 ]];
     for (( i = 0; i < ${#IMAGESETARRAY[@]}; i+=$NUMBEROFMODALITIES ))
       do
 
-        basecall="${ANTS} -d ${DIM} --float $USEFLOAT --verbose 1 -u 1 -w [ 0.01,0.99 ] -z 1 -r [ ${TEMPLATES[0]},${IMAGESETARRAY[$i]},1 ]"
+        basecall="${ANTS} -d ${DIM} --float $USEFLOAT --verbose 1 -u 0 -w [ 0.01,0.99 ] -z 1 -r [ ${TEMPLATES[0]},${IMAGESETARRAY[$i]},1 ]"
 
         IMAGEMETRICSET=""
         for (( j = 0; j < $NUMBEROFMODALITIES; j++ ))
@@ -1439,7 +1439,7 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
 
     for (( j = 0; j < ${#IMAGESETARRAY[@]}; j+=$NUMBEROFMODALITIES ))
       do
-        basecall="${ANTS} -d ${DIM} --float $USEFLOAT --verbose 1 -u 1 -w [ 0.01,0.99 ] -z 1"
+        basecall="${ANTS} -d ${DIM} --float $USEFLOAT --verbose 1  -u 0 -w [ 0.01,0.99 ] -z 1"
 
         IMAGEMETRICLINEARSET=''
         IMAGEMETRICSET=''


### PR DESCRIPTION
Have left antsBrainExtraction.sh alone because I'm not sure if histogram matching is more important where Laplacians are involved

Trying to harmonize with #768 and #770 in ANTsPy.

There are a lot of specialized / old scripts that I didn't change, we should consider moving to a permanent archive.

Histogram matching also defaults to on in antsMotionCorr, but again that is kind of a specialized case