### PR TITLE
STYLE: Add itkVirtualGetNameOfClassMacro + itkOverrideGetNameOfClassMacro

### DIFF
--- a/Examples/antsCommandIterationUpdate.h
+++ b/Examples/antsCommandIterationUpdate.h
@@ -125,7 +125,7 @@ public:
   /**
    * Run-time type information (and related methods).
    */
-  itkTypeMacro(antsCommandIterationUpdate, itk::Command);
+  itkOverrideGetNameOfClassMacro(antsCommandIterationUpdate);
 
 
   /**

--- a/Examples/itkantsRegistrationHelper.h
+++ b/Examples/itkantsRegistrationHelper.h
@@ -461,7 +461,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(RegistrationHelper, Object);
+  itkOverrideGetNameOfClassMacro(RegistrationHelper);
 
   /** Dimension of the image.  This constant is used by functions that are
    * templated over image type (as opposed to being templated over pixel type

--- a/ImageRegistration/itkANTSAffine3DTransform.h
+++ b/ImageRegistration/itkANTSAffine3DTransform.h
@@ -30,8 +30,8 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods).   */
-  // itkTypeMacro( ANTSAffine3DTransform, Rigid3DTransform );
-  itkTypeMacro(ANTSAffine3DTransform, MatrixOffsetTransformBase);
+  // itkOverrideGetNameOfClassMacro( ANTSAffine3DTransform);
+  itkOverrideGetNameOfClassMacro(ANTSAffine3DTransform);
 
   /** Dimension of parameters   */
   static constexpr unsigned int InputSpaceDimension = 3;

--- a/ImageRegistration/itkANTSCenteredAffine2DTransform.h
+++ b/ImageRegistration/itkANTSCenteredAffine2DTransform.h
@@ -22,8 +22,8 @@ public:
   typedef SmartPointer<const Self>                     ConstPointer;
 
   /** Run-time type information (and related methods). */
-  // itkTypeMacro( Rigid2DTransform, MatrixOffsetTransformBase );
-  itkTypeMacro(ANTSCenteredAffine2DTransform, MatrixOffsetTransformBase);
+  // itkOverrideGetNameOfClassMacro( Rigid2DTransform);
+  itkOverrideGetNameOfClassMacro(ANTSCenteredAffine2DTransform);
 
   /** New macro for creation of through a Smart Pointer */
   itkNewMacro(Self);

--- a/ImageRegistration/itkANTSImageRegistrationOptimizer.h
+++ b/ImageRegistration/itkANTSImageRegistrationOptimizer.h
@@ -66,7 +66,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ANTSImageRegistrationOptimizer, Object);
+  itkOverrideGetNameOfClassMacro(ANTSImageRegistrationOptimizer);
   static constexpr unsigned int Dimension = TDimension;
   static constexpr unsigned int ImageDimension = TDimension;
 

--- a/ImageRegistration/itkANTSImageTransformation.h
+++ b/ImageRegistration/itkANTSImageTransformation.h
@@ -46,7 +46,7 @@ public:
 
   typedef double TComp;
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ANTSImageTransformation, Object);
+  itkOverrideGetNameOfClassMacro(ANTSImageTransformation);
   static constexpr unsigned int Dimension = TDimension;
   static constexpr unsigned int ImageDimension = TDimension;
 

--- a/ImageRegistration/itkANTSLabeledPointSet.h
+++ b/ImageRegistration/itkANTSLabeledPointSet.h
@@ -37,7 +37,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ANTSLabeledPointSet, Object);
+  itkOverrideGetNameOfClassMacro(ANTSLabeledPointSet);
   static constexpr unsigned int Dimension = TDimension;
 
   typedef float                                                RealType;

--- a/ImageRegistration/itkANTSSimilarityMetric.h
+++ b/ImageRegistration/itkANTSSimilarityMetric.h
@@ -38,7 +38,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ANTSSimilarityMetric, Object);
+  itkOverrideGetNameOfClassMacro(ANTSSimilarityMetric);
   static constexpr unsigned int Dimension = TDimension;
 
   typedef TReal                                                RealType;

--- a/ImageRegistration/itkAvantsMutualInformationRegistrationFunction.h
+++ b/ImageRegistration/itkAvantsMutualInformationRegistrationFunction.h
@@ -132,7 +132,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(AvantsMutualInformationRegistrationFunction, AvantsPDEDeformableRegistrationFunction);
+  itkOverrideGetNameOfClassMacro(AvantsMutualInformationRegistrationFunction);
 
   /** MovingImage image type. */
   typedef typename Superclass::MovingImageType    MovingImageType;

--- a/ImageRegistration/itkAvantsPDEDeformableRegistrationFunction.h
+++ b/ImageRegistration/itkAvantsPDEDeformableRegistrationFunction.h
@@ -45,7 +45,7 @@ public:
   typedef SmartPointer<const Self>                                                         ConstPointer;
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(AvantsPDEDeformableRegistrationFunction, PDEDeformableRegistrationFunction);
+  itkOverrideGetNameOfClassMacro(AvantsPDEDeformableRegistrationFunction);
 
   /** MovingImage image type. */
   typedef TMovingImage                           MovingImageType;

--- a/ImageRegistration/itkCrossCorrelationRegistrationFunction.h
+++ b/ImageRegistration/itkCrossCorrelationRegistrationFunction.h
@@ -65,7 +65,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(CrossCorrelationRegistrationFunction, AvantsPDEDeformableRegistrationFunction);
+  itkOverrideGetNameOfClassMacro(CrossCorrelationRegistrationFunction);
 
   /** MovingImage image type. */
   typedef typename Superclass::MovingImageType    MovingImageType;

--- a/ImageRegistration/itkExpectationBasedPointSetRegistrationFunction.h
+++ b/ImageRegistration/itkExpectationBasedPointSetRegistrationFunction.h
@@ -71,7 +71,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ExpectationBasedPointSetRegistrationFunction, PDEDeformableRegistrationFunction);
+  itkOverrideGetNameOfClassMacro(ExpectationBasedPointSetRegistrationFunction);
 
   /** MovingImage image type. */
   using MovingImageType = typename Superclass::MovingImageType;

--- a/ImageRegistration/itkJensenHavrdaCharvatTsallisLabeledPointSetMetric.h
+++ b/ImageRegistration/itkJensenHavrdaCharvatTsallisLabeledPointSetMetric.h
@@ -41,7 +41,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(JensenHavrdaCharvatTsallisLabeledPointSetMetric, PointSetToLabelPointSetMetric);
+  itkOverrideGetNameOfClassMacro(JensenHavrdaCharvatTsallisLabeledPointSetMetric);
 
   itkStaticConstMacro(PointDimension, unsigned int, TPointSet::PointDimension);
 

--- a/ImageRegistration/itkJensenHavrdaCharvatTsallisPointSetMetric.h
+++ b/ImageRegistration/itkJensenHavrdaCharvatTsallisPointSetMetric.h
@@ -40,7 +40,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(JensenHavrdaCharvatTsallisPointSetMetric, PointSetToPointSetMetric);
+  itkOverrideGetNameOfClassMacro(JensenHavrdaCharvatTsallisPointSetMetric);
 
   itkStaticConstMacro(PointDimension, unsigned int, TPointSet::PointDimension);
 

--- a/ImageRegistration/itkJensenTsallisBSplineRegistrationFunction.h
+++ b/ImageRegistration/itkJensenTsallisBSplineRegistrationFunction.h
@@ -45,7 +45,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(JensenTsallisBSplineRegistrationFunction, AvantsPDEDeformableRegistrationFunction);
+  itkOverrideGetNameOfClassMacro(JensenTsallisBSplineRegistrationFunction);
 
   /**
    * Inherit some enums from the superclass.

--- a/ImageRegistration/itkPICSLAdvancedNormalizationToolKit.h
+++ b/ImageRegistration/itkPICSLAdvancedNormalizationToolKit.h
@@ -41,7 +41,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(PICSLAdvancedNormalizationToolKit, Object);
+  itkOverrideGetNameOfClassMacro(PICSLAdvancedNormalizationToolKit);
   static constexpr unsigned int                              Dimension = TDimension;
   typedef double                                             TComp;
   typedef TReal                                              RealType;

--- a/ImageRegistration/itkProbabilisticRegistrationFunction.h
+++ b/ImageRegistration/itkProbabilisticRegistrationFunction.h
@@ -65,7 +65,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ProbabilisticRegistrationFunction, AvantsPDEDeformableRegistrationFunction);
+  itkOverrideGetNameOfClassMacro(ProbabilisticRegistrationFunction);
 
   /** MovingImage image type. */
   typedef typename Superclass::MovingImageType    MovingImageType;

--- a/ImageRegistration/itkSpatialMutualInformationRegistrationFunction.h
+++ b/ImageRegistration/itkSpatialMutualInformationRegistrationFunction.h
@@ -129,7 +129,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SpatialMutualInformationRegistrationFunction, AvantsPDEDeformableRegistrationFunction);
+  itkOverrideGetNameOfClassMacro(SpatialMutualInformationRegistrationFunction);
 
   /** MovingImage image type. */
   typedef typename Superclass::MovingImageType    MovingImageType;

--- a/ImageRegistration/itkSyNDemonsRegistrationFunction.h
+++ b/ImageRegistration/itkSyNDemonsRegistrationFunction.h
@@ -61,7 +61,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SyNDemonsRegistrationFunction, PDEDeformableRegistrationFunction);
+  itkOverrideGetNameOfClassMacro(SyNDemonsRegistrationFunction);
 
   /** MovingImage image type. */
   typedef typename Superclass::MovingImageType    MovingImageType;

--- a/ImageRegistration/itkVectorParameterizedNeighborhoodOperatorImageFilter.h
+++ b/ImageRegistration/itkVectorParameterizedNeighborhoodOperatorImageFilter.h
@@ -65,7 +65,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(VectorParameterizedNeighborhoodOperatorImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(VectorParameterizedNeighborhoodOperatorImageFilter);
 
   /** Extract some information from the image types.  Dimensionality
    * of the two images is assumed to be the same. */

--- a/ImageSegmentation/antsAtroposSegmentationImageFilter.h
+++ b/ImageSegmentation/antsAtroposSegmentationImageFilter.h
@@ -75,7 +75,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(AtroposSegmentationImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(AtroposSegmentationImageFilter);
 
   /** Dimension of the images. */
   itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);

--- a/ImageSegmentation/antsBoxPlotQuantileListSampleFilter.h
+++ b/ImageSegmentation/antsBoxPlotQuantileListSampleFilter.h
@@ -46,7 +46,7 @@ public:
   /**
    * Standard macros
    */
-  itkTypeMacro(BoxPlotQuantileListSampleFilter, ListSampleToScalarListSampleFilter);
+  itkOverrideGetNameOfClassMacro(BoxPlotQuantileListSampleFilter);
 
   /**
    * Method for creation through the object factory.

--- a/ImageSegmentation/antsGaussianListSampleFunction.h
+++ b/ImageSegmentation/antsGaussianListSampleFunction.h
@@ -42,7 +42,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(GaussianListSampleFunction, ListSampleFunction);
+  itkOverrideGetNameOfClassMacro(GaussianListSampleFunction);
 
   typedef typename Superclass::InputListSampleType        InputListSampleType;
   typedef typename Superclass::InputMeasurementVectorType InputMeasurementVectorType;

--- a/ImageSegmentation/antsGrubbsRosnerListSampleFilter.h
+++ b/ImageSegmentation/antsGrubbsRosnerListSampleFilter.h
@@ -46,7 +46,7 @@ public:
   /**
    * Standard macros
    */
-  itkTypeMacro(GrubbsRosnerListSampleFilter, ListSampleToScalarListSampleFilter);
+  itkOverrideGetNameOfClassMacro(GrubbsRosnerListSampleFilter);
 
   /**
    * Method for creation through the object factory.

--- a/ImageSegmentation/antsHistogramParzenWindowsListSampleFunction.h
+++ b/ImageSegmentation/antsHistogramParzenWindowsListSampleFunction.h
@@ -44,7 +44,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(HistogramParzenWindowsListSampleFunction, ListSampleFunction);
+  itkOverrideGetNameOfClassMacro(HistogramParzenWindowsListSampleFunction);
 
   typedef typename Superclass::InputListSampleType        InputListSampleType;
   typedef typename Superclass::InputMeasurementVectorType InputMeasurementVectorType;

--- a/ImageSegmentation/antsJointHistogramParzenShapeAndOrientationListSampleFunction.h
+++ b/ImageSegmentation/antsJointHistogramParzenShapeAndOrientationListSampleFunction.h
@@ -44,7 +44,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(JointHistogramParzenShapeAndOrientationListSampleFunction, ListSampleFunction);
+  itkOverrideGetNameOfClassMacro(JointHistogramParzenShapeAndOrientationListSampleFunction);
 
   typedef typename Superclass::InputListSampleType        InputListSampleType;
   typedef typename Superclass::InputMeasurementVectorType InputMeasurementVectorType;

--- a/ImageSegmentation/antsJointHistogramParzenWindowsListSampleFunction.h
+++ b/ImageSegmentation/antsJointHistogramParzenWindowsListSampleFunction.h
@@ -42,7 +42,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(JointHistogramParzenWindowsListSampleFunction, ListSampleFunction);
+  itkOverrideGetNameOfClassMacro(JointHistogramParzenWindowsListSampleFunction);
 
   typedef typename Superclass::InputListSampleType        InputListSampleType;
   typedef typename Superclass::InputMeasurementVectorType InputMeasurementVectorType;

--- a/ImageSegmentation/antsListSampleFunction.h
+++ b/ImageSegmentation/antsListSampleFunction.h
@@ -50,7 +50,7 @@ public:
   typedef SmartPointer<const Self>                ConstPointer;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ListSampleFunction, FunctionBase);
+  itkOverrideGetNameOfClassMacro(ListSampleFunction);
 
   /** InputListSampleType typedef support. */
   typedef TInputListSample InputListSampleType;

--- a/ImageSegmentation/antsListSampleToListSampleFilter.h
+++ b/ImageSegmentation/antsListSampleToListSampleFilter.h
@@ -46,7 +46,7 @@ public:
   typedef SmartPointer<const Self>     ConstPointer;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ListSampleToListSampleFilter, ProcessObject);
+  itkOverrideGetNameOfClassMacro(ListSampleToListSampleFilter);
 
   /** Some convenient typedefs. */
   typedef TInputListSample  InputListSampleType;

--- a/ImageSegmentation/antsLogEuclideanGaussianListSampleFunction.h
+++ b/ImageSegmentation/antsLogEuclideanGaussianListSampleFunction.h
@@ -42,7 +42,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(LogEuclideanGaussianListSampleFunction, ListSampleFunction);
+  itkOverrideGetNameOfClassMacro(LogEuclideanGaussianListSampleFunction);
 
   typedef typename Superclass::InputListSampleType        InputListSampleType;
   typedef typename Superclass::InputMeasurementVectorType InputMeasurementVectorType;

--- a/ImageSegmentation/antsManifoldParzenWindowsListSampleFunction.h
+++ b/ImageSegmentation/antsManifoldParzenWindowsListSampleFunction.h
@@ -45,7 +45,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ManifoldParzenWindowsListSampleFunction, ListSampleFunction);
+  itkOverrideGetNameOfClassMacro(ManifoldParzenWindowsListSampleFunction);
 
   typedef typename Superclass::InputListSampleType        InputListSampleType;
   typedef typename Superclass::InputMeasurementVectorType InputMeasurementVectorType;

--- a/ImageSegmentation/antsPartialVolumeGaussianListSampleFunction.h
+++ b/ImageSegmentation/antsPartialVolumeGaussianListSampleFunction.h
@@ -42,7 +42,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(PartialVolumeGaussianListSampleFunction, ListSampleFunction);
+  itkOverrideGetNameOfClassMacro(PartialVolumeGaussianListSampleFunction);
 
   typedef typename Superclass::InputListSampleType        InputListSampleType;
   typedef typename Superclass::InputMeasurementVectorType InputMeasurementVectorType;

--- a/ImageSegmentation/antsPassThroughListSampleFilter.h
+++ b/ImageSegmentation/antsPassThroughListSampleFilter.h
@@ -43,7 +43,7 @@ public:
   /**
    * Standard macros
    */
-  itkTypeMacro(PassThroughListSampleFilter, ListSampleToScalarListSampleFilter);
+  itkOverrideGetNameOfClassMacro(PassThroughListSampleFilter);
 
   /**
    * Method for creation through the object factory.

--- a/ImageSegmentation/itkWeightedVotingFusionImageFilter.h
+++ b/ImageSegmentation/itkWeightedVotingFusionImageFilter.h
@@ -61,7 +61,7 @@ public:
   typedef SmartPointer<const Self>                                 ConstPointer;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(WeightedVotingFusionImageFilter, NonLocalPatchBasedImageFilter);
+  itkOverrideGetNameOfClassMacro(WeightedVotingFusionImageFilter);
 
   itkNewMacro(Self);
 

--- a/Temporary/antsFastMarchingImageFilter.h
+++ b/Temporary/antsFastMarchingImageFilter.h
@@ -111,7 +111,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(FMarchingImageFilter, ImageSource);
+  itkOverrideGetNameOfClassMacro(FMarchingImageFilter);
 
   /** Typedef support of level set method types. */
   typedef LevelSetTypeDefault<TLevelSet>              LevelSetType;

--- a/Temporary/itkAddConstantToImageFilter.h
+++ b/Temporary/itkAddConstantToImageFilter.h
@@ -103,7 +103,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(AddConstantToImageFilter, UnaryFunctorImageFilter);
+  itkOverrideGetNameOfClassMacro(AddConstantToImageFilter);
 
   /** Set the constant that will be used to multiply all the image
    * pixels */

--- a/Temporary/itkDijkstrasAlgorithm.h
+++ b/Temporary/itkDijkstrasAlgorithm.h
@@ -77,7 +77,7 @@ public:
   typedef LightObject              Superclass;
   typedef SmartPointer<Self>       Pointer;
   typedef SmartPointer<const Self> ConstPointer;
-  itkTypeMacro(GraphSearchNode, LightObject);
+  itkOverrideGetNameOfClassMacro(GraphSearchNode);
   itkNewMacro(Self); /** Method for creation through the object factory.   */
 
   enum StateType
@@ -315,7 +315,7 @@ typedef DijkstrasAlgorithmQueue  Self;
 typedef LightObject              Superclass;
 typedef SmartPointer<Self>       Pointer;
 typedef SmartPointer<const Self> ConstPointer;
-itkTypeMacro(DijkstrasAlgorithmQueue, LightObject);
+itkOverrideGetNameOfClassMacro(DijkstrasAlgorithmQueue);
 itkNewMacro(Self); /** Method for creation through the object factory.   */
 
 typedef typename TGraphSearchNode::Pointer   TGraphSearchNodePointer;
@@ -440,7 +440,7 @@ public:
   typedef LightObject              Superclass;
   typedef SmartPointer<Self>       Pointer;
   typedef SmartPointer<const Self> ConstPointer;
-  itkTypeMacro(DijkstrasAlgorithm, LightObject);
+  itkOverrideGetNameOfClassMacro(DijkstrasAlgorithm);
   itkNewMacro(Self);
 
   // Computation Data

--- a/Temporary/itkFEMConformalMap.h
+++ b/Temporary/itkFEMConformalMap.h
@@ -83,7 +83,7 @@ public:
   typedef SmartPointer<const Self> ConstPointer;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(FEMConformalMap, ProcessObject);
+  itkOverrideGetNameOfClassMacro(FEMConformalMap);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Temporary/itkFEMDiscConformalMap.h
+++ b/Temporary/itkFEMDiscConformalMap.h
@@ -87,7 +87,7 @@ public:
   typedef SmartPointer<const Self> ConstPointer;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(FEMDiscConformalMap, ProcessObject);
+  itkOverrideGetNameOfClassMacro(FEMDiscConformalMap);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Temporary/itkManifoldIntegrationAlgorithm.h
+++ b/Temporary/itkManifoldIntegrationAlgorithm.h
@@ -51,7 +51,7 @@ public:
   typedef LightObject                  Superclass;
   typedef SmartPointer<Self>           Pointer;
   typedef SmartPointer<const Self>     ConstPointer;
-  itkTypeMacro(ManifoldIntegrationAlgorithm, LightObject);
+  itkOverrideGetNameOfClassMacro(ManifoldIntegrationAlgorithm);
   itkNewMacro(Self);
 
   // Computation Data

--- a/Temporary/itkMeanSquaresPointSetToPointSetIntensityMetricv4.h
+++ b/Temporary/itkMeanSquaresPointSetToPointSetIntensityMetricv4.h
@@ -59,7 +59,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MeanSquaresPointSetToPointSetIntensityMetricv4, PointSetToPointSetMetricv4);
+  itkOverrideGetNameOfClassMacro(MeanSquaresPointSetToPointSetIntensityMetricv4);
 
   /**  Type of the fixed point set. */
   typedef TFixedPointSet                              FixedPointSetType;

--- a/Temporary/itkMultiplyByConstantImageFilter.h
+++ b/Temporary/itkMultiplyByConstantImageFilter.h
@@ -49,7 +49,7 @@ public:
   /** method for creation through object factory */
   itkNewMacro(Self);
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MultiplyByConstantImageFilter, MultiplyImageFilter);
+  itkOverrideGetNameOfClassMacro(MultiplyByConstantImageFilter);
 
 protected:
   MultiplyByConstantImageFilter() = default;

--- a/Tensor/itkExpTensorImageFilter.h
+++ b/Tensor/itkExpTensorImageFilter.h
@@ -58,7 +58,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ExpTensorImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(ExpTensorImageFilter);
 
   /** Image typedef support. */
   typedef typename InputImageType::ConstPointer InputImagePointer;

--- a/Tensor/itkLogTensorImageFilter.h
+++ b/Tensor/itkLogTensorImageFilter.h
@@ -58,7 +58,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(LogTensorImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(LogTensorImageFilter);
 
   /** Image typedef support. */
   typedef typename InputImageType::ConstPointer InputImagePointer;

--- a/Tensor/itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.h
+++ b/Tensor/itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.h
@@ -113,7 +113,7 @@ public:
   itkGetMacro(UseImageDirection, bool);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(PreservationOfPrincipalDirectionTensorReorientationImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(PreservationOfPrincipalDirectionTensorReorientationImageFilter);
 
   /** Image typedef support. */
   typedef typename InputImageType::ConstPointer InputImagePointer;

--- a/Tensor/itkWarpTensorImageMultiTransformFilter.h
+++ b/Tensor/itkWarpTensorImageMultiTransformFilter.h
@@ -99,7 +99,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(WarpTensorImageMultiTransformFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(WarpTensorImageMultiTransformFilter);
 
   /** Typedef to describe the output image region type. */
   typedef typename TOutputImage::RegionType OutputImageRegionType;

--- a/Utilities/antsCommandLineOption.h
+++ b/Utilities/antsCommandLineOption.h
@@ -59,7 +59,7 @@ public:
 
   itkNewMacro(Self);
 
-  itkTypeMacro(OptionFunction, DataObject);
+  itkOverrideGetNameOfClassMacro(OptionFunction);
 
   typedef std::deque<std::string> ParameterStackType;
 
@@ -122,7 +122,7 @@ public:
 
   itkNewMacro(Self);
 
-  itkTypeMacro(CommandLineOption, DataObject);
+  itkOverrideGetNameOfClassMacro(CommandLineOption);
 
   typedef OptionFunction OptionFunctionType;
 

--- a/Utilities/antsCommandLineParser.h
+++ b/Utilities/antsCommandLineParser.h
@@ -62,7 +62,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(CommandLineParser, DataObject);
+  itkOverrideGetNameOfClassMacro(CommandLineParser);
 
   typedef CommandLineOption              OptionType;
   typedef std::list<OptionType::Pointer> OptionListType;

--- a/Utilities/antsMatrixUtilities.h
+++ b/Utilities/antsMatrixUtilities.h
@@ -35,7 +35,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(antsMatrixUtilities, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(antsMatrixUtilities);
 
   /** Dimension of the images. */
   itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);

--- a/Utilities/antsSCCANObject.h
+++ b/Utilities/antsSCCANObject.h
@@ -45,7 +45,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(antsSCCANObject, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(antsSCCANObject);
 
   /** Dimension of the images. */
   itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);

--- a/Utilities/itkAlternatingValueDifferenceImageFilter.h
+++ b/Utilities/itkAlternatingValueDifferenceImageFilter.h
@@ -54,7 +54,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(AlternatingValueDifferenceImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(AlternatingValueDifferenceImageFilter);
 
   /** Compiler can't inherit typedef? */
   typedef typename Superclass::InputImageType  InputImageType;

--- a/Utilities/itkAlternatingValueSimpleSubtractionImageFilter.h
+++ b/Utilities/itkAlternatingValueSimpleSubtractionImageFilter.h
@@ -50,7 +50,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(AlternatingValueSimpleSubtractionImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(AlternatingValueSimpleSubtractionImageFilter);
 
   /** Compiler can't inherit typedef? */
   typedef typename Superclass::InputImageType  InputImageType;

--- a/Utilities/itkAverageOverDimensionImageFilter.h
+++ b/Utilities/itkAverageOverDimensionImageFilter.h
@@ -100,7 +100,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(AverageOverDimensionImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(AverageOverDimensionImageFilter);
 
   /** Image type information. */
   typedef TInputImage  InputImageType;

--- a/Utilities/itkDecomposeTensorFunction.h
+++ b/Utilities/itkDecomposeTensorFunction.h
@@ -40,7 +40,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(DecomposeTensorFunction, ProcessObject);
+  itkOverrideGetNameOfClassMacro(DecomposeTensorFunction);
 
   /** Extract some information from the image types.  Dimensionality
    * of the two images is assumed to be the same. */

--- a/Utilities/itkDeformationFieldGradientTensorImageFilter.h
+++ b/Utilities/itkDeformationFieldGradientTensorImageFilter.h
@@ -41,7 +41,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(DeformationFieldGradientTensorImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(DeformationFieldGradientTensorImageFilter);
 
   /** Extract some information from the image types.  Dimensionality
    * of the two images is assumed to be the same. */

--- a/Utilities/itkDeterminantTensorImageFilter.h
+++ b/Utilities/itkDeterminantTensorImageFilter.h
@@ -38,7 +38,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(DeterminantTensorImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(DeterminantTensorImageFilter);
 
   /** Extract some information from the image types.  Dimensionality
    * of the two images is assumed to be the same. */

--- a/Utilities/itkDisplacementFieldFromMultiTransformFilter.h
+++ b/Utilities/itkDisplacementFieldFromMultiTransformFilter.h
@@ -21,7 +21,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(DisplacementFieldFromMultiTransformFilter, WarpImageMultiTransformFilter);
+  itkOverrideGetNameOfClassMacro(DisplacementFieldFromMultiTransformFilter);
 
   /** Typedef to describe the output image region type. */
   typedef typename TOutputImage::RegionType OutputImageRegionType;

--- a/Utilities/itkGeometricJacobianDeterminantImageFilter.h
+++ b/Utilities/itkGeometricJacobianDeterminantImageFilter.h
@@ -39,7 +39,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(GeometricJacobianDeterminantImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(GeometricJacobianDeterminantImageFilter);
 
   /** Extract some information from the image types.  Dimensionality
    * of the two images is assumed to be the same. */

--- a/Utilities/itkImageIntensityAndGradientToPointSetFilter.h
+++ b/Utilities/itkImageIntensityAndGradientToPointSetFilter.h
@@ -44,7 +44,7 @@ public:
   itkStaticConstMacro(Dimension, unsigned int, TInputImage::ImageDimension);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ImageIntensityAndGradientToPointSetFilter, MeshSource);
+  itkOverrideGetNameOfClassMacro(ImageIntensityAndGradientToPointSetFilter);
 
   /** Hold on to the type information specified by the template parameters. */
   typedef TInputImage                        InputImageType;

--- a/Utilities/itkLabeledPointSetFileReader.h
+++ b/Utilities/itkLabeledPointSetFileReader.h
@@ -47,7 +47,7 @@ public:
   itkStaticConstMacro(Dimension, unsigned int, TOutputMesh::PointType::Dimension);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(LabeledPointSetFileReader, MeshSource);
+  itkOverrideGetNameOfClassMacro(LabeledPointSetFileReader);
 
   /** Hold on to the type information specified by the template parameters. */
   typedef TOutputMesh                                     OutputMeshType;

--- a/Utilities/itkLabeledPointSetFileWriter.h
+++ b/Utilities/itkLabeledPointSetFileWriter.h
@@ -52,7 +52,7 @@ public:
   itkStaticConstMacro(Dimension, unsigned int, TInputMesh::PointType::Dimension);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(LabeledPointSetFileWriter, Object);
+  itkOverrideGetNameOfClassMacro(LabeledPointSetFileWriter);
 
   /** Hold on to the type information specified by the template parameters. */
   typedef TInputMesh                                          InputMeshType;

--- a/Utilities/itkMultiScaleLaplacianBlobDetectorImageFilter.h
+++ b/Utilities/itkMultiScaleLaplacianBlobDetectorImageFilter.h
@@ -56,7 +56,7 @@ public:
   itkStaticConstMacro(NumberOfDimensions, unsigned int, TDimension);
 
   itkNewMacro(Self);
-  itkTypeMacro(ScaleSpaceBlobSpatialObject, GaussianSpatialObject);
+  itkOverrideGetNameOfClassMacro(ScaleSpaceBlobSpatialObject);
 
   /** Set/Get the normalized laplacian value of the extrema */
   itkGetMacro(ScaleSpaceValue, double);
@@ -129,7 +129,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MultiScaleLaplacianBlobDetectorImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(MultiScaleLaplacianBlobDetectorImageFilter);
 
   /** Typedef to images */
   typedef TInputImage                           InputImageType;

--- a/Utilities/itkMultiplyByConstantVectorImageFilter.h
+++ b/Utilities/itkMultiplyByConstantVectorImageFilter.h
@@ -110,7 +110,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MultiplyByConstantVectorImageFilter, UnaryFunctorImageFilter);
+  itkOverrideGetNameOfClassMacro(MultiplyByConstantVectorImageFilter);
 
   /** Set the constant that will be used to multiply all the image pixels */
   void

--- a/Utilities/itkN3BiasFieldCorrectionImageFilter.h
+++ b/Utilities/itkN3BiasFieldCorrectionImageFilter.h
@@ -91,7 +91,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Runtime information support. */
-  itkTypeMacro(N3BiasFieldCorrectionImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(N3BiasFieldCorrectionImageFilter);
 
   /** Standard New method. */
   itkNewMacro(Self);

--- a/Utilities/itkN3MRIBiasFieldCorrectionImageFilter.h
+++ b/Utilities/itkN3MRIBiasFieldCorrectionImageFilter.h
@@ -93,7 +93,7 @@ public:
   typedef SmartPointer<const Self>     ConstPointer;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(N3BiasFieldScaleCostFunction, SingleValuedCostFunction);
+  itkOverrideGetNameOfClassMacro(N3BiasFieldScaleCostFunction);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -147,7 +147,7 @@ public:
   typedef SmartPointer<const Self>                      ConstPointer;
 
   /** Runtime information support. */
-  itkTypeMacro(N3MRIBiasFieldCorrectionImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(N3MRIBiasFieldCorrectionImageFilter);
 
   /** Standard New method. */
   itkNewMacro(Self);

--- a/Utilities/itkNeighborhoodFirstOrderStatisticsImageFilter.h
+++ b/Utilities/itkNeighborhoodFirstOrderStatisticsImageFilter.h
@@ -54,7 +54,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(NeighborhoodFirstOrderStatisticsImageFilter, MovingHistogramImageFilter);
+  itkOverrideGetNameOfClassMacro(NeighborhoodFirstOrderStatisticsImageFilter);
 
   /** Image related typedefs. */
   typedef TInputImage                                InputImageType;

--- a/Utilities/itkNonLocalSuperresolutionImageFilter.h
+++ b/Utilities/itkNonLocalSuperresolutionImageFilter.h
@@ -58,7 +58,7 @@ public:
   typedef SmartPointer<const Self>                                 ConstPointer;
 
   /** Runtime information support. */
-  itkTypeMacro(NonLocalSuperresolutionImageFilter, NonLocalPatchBasedImageFilter);
+  itkOverrideGetNameOfClassMacro(NonLocalSuperresolutionImageFilter);
 
   /** Standard New method. */
   itkNewMacro(Self);

--- a/Utilities/itkOptimalSharpeningImageFilter.h
+++ b/Utilities/itkOptimalSharpeningImageFilter.h
@@ -68,7 +68,7 @@ public:
   typedef SmartPointer<const Self> ConstPointer;
 
   /** Run-time type information (and related methods)  */
-  itkTypeMacro(OptimalSharpeningImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(OptimalSharpeningImageFilter);
 
   /** Method for creation through the object factory.  */
   itkNewMacro(Self);

--- a/Utilities/itkPointSetFunction.h
+++ b/Utilities/itkPointSetFunction.h
@@ -61,7 +61,7 @@ public:
   typedef SmartPointer<const Self>                                  ConstPointer;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(PointSetFunction, FunctionBase);
+  itkOverrideGetNameOfClassMacro(PointSetFunction);
 
   /** InputPointSetType typedef support. */
   typedef TInputPointSet InputPointSetType;

--- a/Utilities/itkPseudoContinuousArterialSpinLabeledCerebralBloodFlowImageFilter.h
+++ b/Utilities/itkPseudoContinuousArterialSpinLabeledCerebralBloodFlowImageFilter.h
@@ -61,7 +61,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(PseudoContinuousArterialSpinLabeledCerebralBloodFlowImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(PseudoContinuousArterialSpinLabeledCerebralBloodFlowImageFilter);
 
   /** Compiler can't inherit typedef? */
   typedef TInputImage                             InputImageType;

--- a/Utilities/itkPulsedArterialSpinLabeledCerebralBloodFlowImageFilter.h
+++ b/Utilities/itkPulsedArterialSpinLabeledCerebralBloodFlowImageFilter.h
@@ -60,7 +60,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(PulsedArterialSpinLabeledCerebralBloodFlowImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(PulsedArterialSpinLabeledCerebralBloodFlowImageFilter);
 
   /** Compiler can't inherit typedef? */
   typedef TInputImage                             InputImageType;

--- a/Utilities/itkSimulatedBSplineDisplacementFieldSource.h
+++ b/Utilities/itkSimulatedBSplineDisplacementFieldSource.h
@@ -54,7 +54,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SimulatedBSplineDisplacementFieldSource, SimulatedDisplacementFieldSource);
+  itkOverrideGetNameOfClassMacro(SimulatedBSplineDisplacementFieldSource);
 
   /** Number of dimensions */
   static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;

--- a/Utilities/itkSimulatedDisplacementFieldSource.h
+++ b/Utilities/itkSimulatedDisplacementFieldSource.h
@@ -54,7 +54,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SimulatedDisplacementFieldSource, ImageSource);
+  itkOverrideGetNameOfClassMacro(SimulatedDisplacementFieldSource);
 
   /** Number of dimensions. */
   static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;

--- a/Utilities/itkSimulatedExponentialDisplacementFieldSource.h
+++ b/Utilities/itkSimulatedExponentialDisplacementFieldSource.h
@@ -53,7 +53,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SimulatedExponentialDisplacementFieldSource, SimulatedDisplacementFieldSource);
+  itkOverrideGetNameOfClassMacro(SimulatedExponentialDisplacementFieldSource);
 
   /** Number of dimensions */
   static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;

--- a/Utilities/itkSliceTimingCorrectionImageFilter.h
+++ b/Utilities/itkSliceTimingCorrectionImageFilter.h
@@ -54,7 +54,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SliceTimingCorrectionImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(SliceTimingCorrectionImageFilter);
 
   /** Compiler can't inherit typedef? */
   typedef typename Superclass::InputImageType  InputImageType;

--- a/Utilities/itkSplitAlternatingTimeSeriesImageFilter.h
+++ b/Utilities/itkSplitAlternatingTimeSeriesImageFilter.h
@@ -60,7 +60,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SplitAlternatingTimeSeriesImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(SplitAlternatingTimeSeriesImageFilter);
 
   /** Compiler can't inherit typedef? */
   typedef typename Superclass::InputImageType  InputImageType;

--- a/Utilities/itkSurfaceCurvatureBase.h
+++ b/Utilities/itkSurfaceCurvatureBase.h
@@ -47,7 +47,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SurfaceCurvatureBase, ProcessObject);
+  itkOverrideGetNameOfClassMacro(SurfaceCurvatureBase);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Utilities/itkSurfaceImageCurvature.h
+++ b/Utilities/itkSurfaceImageCurvature.h
@@ -41,7 +41,7 @@ public:
   typedef SmartPointer<const Self>       ConstPointer;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SurfaceImageCurvature, SurfaceCurvatureBase);
+  itkOverrideGetNameOfClassMacro(SurfaceImageCurvature);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Utilities/itkSurfaceMeshCurvature.h
+++ b/Utilities/itkSurfaceMeshCurvature.h
@@ -36,7 +36,7 @@ public:
   typedef SmartPointer<const Self>       ConstPointer;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SurfaceMeshCurvature, SurfaceCurvatureBase);
+  itkOverrideGetNameOfClassMacro(SurfaceMeshCurvature);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Utilities/itkVectorFieldGradientImageFunction.h
+++ b/Utilities/itkVectorFieldGradientImageFunction.h
@@ -36,7 +36,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(VectorFieldGradientImageFunction, ImageFunction);
+  itkOverrideGetNameOfClassMacro(VectorFieldGradientImageFunction);
 
   /** Extract some information from the image types.  Dimensionality
    * of the two images is assumed to be the same. */

--- a/Utilities/itkVectorGaussianInterpolateImageFunction.h
+++ b/Utilities/itkVectorGaussianInterpolateImageFunction.h
@@ -42,7 +42,7 @@ public:
   typedef SmartPointer<const Self>                         ConstPointer;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VectorGaussianInterpolateImageFunction, InterpolateImageFunction);
+  itkOverrideGetNameOfClassMacro(VectorGaussianInterpolateImageFunction);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Utilities/itkVectorImageFileReader.h
+++ b/Utilities/itkVectorImageFileReader.h
@@ -28,7 +28,7 @@ class VectorImageFileReaderException : public ExceptionObject
 {
 public:
   /** Run-time information. */
-  itkTypeMacro(VectorImageFileReaderException, ExceptionObject);
+  itkOverrideGetNameOfClassMacro(VectorImageFileReaderException);
 
   /** Constructor. */
   VectorImageFileReaderException(const char * file,
@@ -92,7 +92,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VectorImageFileReader, ImageSource);
+  itkOverrideGetNameOfClassMacro(VectorImageFileReader);
 
   /** Image types */
   typedef typename TImage::RegionType        ImageRegionType;

--- a/Utilities/itkVectorImageFileWriter.h
+++ b/Utilities/itkVectorImageFileWriter.h
@@ -29,7 +29,7 @@ class VectorImageFileWriterException : public ExceptionObject
 {
 public:
   /** Run-time information. */
-  itkTypeMacro(VectorImageFileWriterException, ExceptionObject);
+  itkOverrideGetNameOfClassMacro(VectorImageFileWriterException);
 
   /** Constructor. */
   VectorImageFileWriterException(const char * file,
@@ -71,7 +71,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VectorImageFileWriter, VectorImageFileWriter);
+  itkOverrideGetNameOfClassMacro(VectorImageFileWriter);
 
   /** Some convenient typedefs. */
   typedef TVectorImage                         VectorImageType;

--- a/Utilities/itkWarpImageMultiTransformFilter.h
+++ b/Utilities/itkWarpImageMultiTransformFilter.h
@@ -99,7 +99,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(WarpImageMultiTransformFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(WarpImageMultiTransformFilter);
 
   /** Typedef to describe the output image region type. */
   typedef typename TOutputImage::RegionType OutputImageRegionType;

--- a/Utilities/itkWarpImageWAffineFilter.h
+++ b/Utilities/itkWarpImageWAffineFilter.h
@@ -94,7 +94,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(WarpImageWAffineFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(WarpImageWAffineFilter);
 
   /** Typedef to describe the output image region type. */
   typedef typename TOutputImage::RegionType OutputImageRegionType;

--- a/Utilities/itkWarpTensorImageMultiTransformFilter.h
+++ b/Utilities/itkWarpTensorImageMultiTransformFilter.h
@@ -98,7 +98,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(WarpTensorImageMultiTransformFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(WarpTensorImageMultiTransformFilter);
 
   /** Typedef to describe the output image region type. */
   typedef typename TOutputImage::RegionType OutputImageRegionType;


### PR DESCRIPTION
Added two new macro's, intended to replace the old 'itkTypeMacro' and
'itkTypeMacroNoParent'.

The main aim is to be clearer about what those macro's do: add a virtual
'GetNameOfClass()' member function and override it. Unlike 'itkTypeMacro',
'itkOverrideGetNameOfClassMacro' does not have a 'superclass' parameter, as it
was not used anyway.

Note that originally 'itkTypeMacro' did not use its 'superclass' parameter
either, looking at commit 699b66cb04d410e555656828e8892107add38ccb, Will
Schroeder, June 27, 2001:
https://github.com/InsightSoftwareConsortium/ITK/blob/699b66cb04d410e555656828e8892107add38ccb/Code/Common/itkMacro.h#L331-L337

<!--
Text in these brackets are comments, and won't be visible when you submit your
pull request.

We welcome contributions to ANTs. Pull requests will be reviewed by the
developers and if accepted, become part of ANTs, distributed under the license
terms in COPYING.txt.

Please title your PR according to what it does:
ENH: new or improved functionality
PERF: performance enhancements to existing functionality
BUG: fixing a run time bug
COMP: relating to compilation
DOC: documentation changes
WIP: work in progress, needs further commits to be ready
-->

# Description

<!--
Extended description of your PR.

If the PR can close an existing issue, you can say "Fixes #1234" or "Resolves
#1234". Otherwise you can say something like "Related to #1234".
-->


