### PR TITLE
use CoordinateType

### DIFF
--- a/Examples/ANTSIntegrateVectorField.cxx
+++ b/Examples/ANTSIntegrateVectorField.cxx
@@ -183,7 +183,7 @@ IntegrateLength(typename TImage::Pointer gmsurf,
     ContinuousIndexType Y4;
     for (unsigned int jj = 0; jj < ImageDimension; jj++)
     {
-      pointIn2[jj] = static_cast<typename DPointType::CoordRepType>(disp[jj]) + pointIn1[jj];
+      pointIn2[jj] = static_cast<typename DPointType::CoordinateType>(disp[jj]) + pointIn1[jj];
       vcontind[jj] = pointIn2[jj] / lapgrad->GetSpacing()[jj];
       Y1[jj] = vcontind[jj];
       Y2[jj] = vcontind[jj];
@@ -198,7 +198,7 @@ IntegrateLength(typename TImage::Pointer gmsurf,
     f1 = vinterp->EvaluateAtContinuousIndex(Y1);
     for (unsigned int jj = 0; jj < ImageDimension; jj++)
     {
-      Y2[jj] += static_cast<typename ContinuousIndexType::CoordRepType>(static_cast<float>(f1[jj]) * deltaTime * 0.5f);
+      Y2[jj] += static_cast<typename ContinuousIndexType::CoordinateType>(static_cast<float>(f1[jj]) * deltaTime * 0.5f);
     }
     bool isinside = true;
     for (unsigned int jj = 0; jj < ImageDimension; jj++)
@@ -214,7 +214,7 @@ IntegrateLength(typename TImage::Pointer gmsurf,
     }
     for (unsigned int jj = 0; jj < ImageDimension; jj++)
     {
-      Y3[jj] += static_cast<typename ContinuousIndexType::CoordRepType>(static_cast<float>(f2[jj]) * deltaTime * 0.5f);
+      Y3[jj] += static_cast<typename ContinuousIndexType::CoordinateType>(static_cast<float>(f2[jj]) * deltaTime * 0.5f);
     }
     isinside = true;
     for (unsigned int jj = 0; jj < ImageDimension; jj++)
@@ -230,7 +230,7 @@ IntegrateLength(typename TImage::Pointer gmsurf,
     }
     for (unsigned int jj = 0; jj < ImageDimension; jj++)
     {
-      Y4[jj] += static_cast<typename ContinuousIndexType::CoordRepType>(static_cast<float>(f3[jj]) * deltaTime);
+      Y4[jj] += static_cast<typename ContinuousIndexType::CoordinateType>(static_cast<float>(f3[jj]) * deltaTime);
     }
     isinside = true;
     for (unsigned int jj = 0; jj < ImageDimension; jj++)
@@ -244,14 +244,14 @@ IntegrateLength(typename TImage::Pointer gmsurf,
     {
       f4 = vinterp->EvaluateAtContinuousIndex(Y4);
     }
-    using DPointCoordRepType = typename DPointType::CoordRepType;
-    auto twoValue = static_cast<DPointCoordRepType>(2.0);
+    using DPointCoordinateType = typename DPointType::CoordinateType;
+    auto twoValue = static_cast<DPointCoordinateType>(2.0);
     for (unsigned int jj = 0; jj < ImageDimension; jj++)
     {
       pointIn3[jj] =
-        pointIn2[jj] + static_cast<DPointCoordRepType>(gradsign * vecsign * deltaTime / 6.0f) *
-                         (static_cast<DPointCoordRepType>(f1[jj]) + twoValue * static_cast<DPointCoordRepType>(f2[jj]) +
-                          twoValue * static_cast<DPointCoordRepType>(f3[jj]) + static_cast<DPointCoordRepType>(f4[jj]));
+        pointIn2[jj] + static_cast<DPointCoordinateType>(gradsign * vecsign * deltaTime / 6.0f) *
+                         (static_cast<DPointCoordinateType>(f1[jj]) + twoValue * static_cast<DPointCoordinateType>(f2[jj]) +
+                          twoValue * static_cast<DPointCoordinateType>(f3[jj]) + static_cast<DPointCoordinateType>(f4[jj]));
     }
 
     VectorType out;

--- a/Examples/ANTSUseDeformationFieldToGetAffineTransform.cxx
+++ b/Examples/ANTSUseDeformationFieldToGetAffineTransform.cxx
@@ -295,7 +295,7 @@ FetchLandmarkMappingFromDisplacementField(const std::string &                   
       VectorType displacement = field->GetPixel(index);
       for (unsigned int j = 0; j < ImageDimension; j++)
       {
-        point2[j] = point1[j] + static_cast<typename PointType::CoordRepType>(displacement[j]);
+        point2[j] = point1[j] + static_cast<typename PointType::CoordinateType>(displacement[j]);
       }
 
       fixedLandmarks.push_back(point1);

--- a/Examples/ANTSUseLandmarkImagesToGetAffineTransform.cxx
+++ b/Examples/ANTSUseLandmarkImagesToGetAffineTransform.cxx
@@ -316,7 +316,7 @@ LandmarkBasedTransformInitializerBA(int, char * argv[])
     }
     for (unsigned int i = 0; i < spacing.Size(); i++)
     {
-      myCenterOfMass[i] /= static_cast<typename LandmarkPointType::CoordRepType>(totalct);
+      myCenterOfMass[i] /= static_cast<typename LandmarkPointType::CoordinateType>(totalct);
     }
     //    std::cout << " pushing-mov " <<  myCenterOfMass << std::endl;
     movingLandmarks.push_back(myCenterOfMass);

--- a/Examples/LaplacianThickness.cxx
+++ b/Examples/LaplacianThickness.cxx
@@ -505,7 +505,7 @@ IntegrateLength(typename TImage::Pointer /* gmsurf */,
       typename DefaultInterpolatorType::ContinuousIndexType Y4;
       for (unsigned int jj = 0; jj < ImageDimension; jj++)
       {
-        pointIn2[jj] = static_cast<typename DPointType::CoordRepType>(disp[jj]) + pointIn1[jj];
+        pointIn2[jj] = static_cast<typename DPointType::CoordinateType>(disp[jj]) + pointIn1[jj];
         vcontind[jj] = pointIn2[jj] / lapgrad->GetSpacing()[jj];
         Y1[jj] = vcontind[jj];
         Y2[jj] = vcontind[jj];
@@ -518,13 +518,13 @@ IntegrateLength(typename TImage::Pointer /* gmsurf */,
       //      Y4[ImageDimension]=itime;
 
       using ContinuousIndexType = typename DefaultInterpolatorType::ContinuousIndexType;
-      using CoordRepType = typename ContinuousIndexType::CoordRepType;
+      using CoordinateType = typename ContinuousIndexType::CoordinateType;
 
       f1 = vinterp->EvaluateAtContinuousIndex(Y1);
       for (unsigned int jj = 0; jj < ImageDimension; jj++)
       {
         Y2[jj] +=
-          static_cast<CoordRepType>(f1[jj]) * static_cast<CoordRepType>(deltaTime) * static_cast<CoordRepType>(0.5);
+          static_cast<CoordinateType>(f1[jj]) * static_cast<CoordinateType>(deltaTime) * static_cast<CoordinateType>(0.5);
       }
       bool isinside = true;
       for (unsigned int jj = 0; jj < ImageDimension; jj++)
@@ -541,7 +541,7 @@ IntegrateLength(typename TImage::Pointer /* gmsurf */,
       for (unsigned int jj = 0; jj < ImageDimension; jj++)
       {
         Y3[jj] +=
-          static_cast<CoordRepType>(f2[jj]) * static_cast<CoordRepType>(deltaTime) * static_cast<CoordRepType>(0.5);
+          static_cast<CoordinateType>(f2[jj]) * static_cast<CoordinateType>(deltaTime) * static_cast<CoordinateType>(0.5);
       }
       isinside = true;
       for (unsigned int jj = 0; jj < ImageDimension; jj++)
@@ -557,7 +557,7 @@ IntegrateLength(typename TImage::Pointer /* gmsurf */,
       }
       for (unsigned int jj = 0; jj < ImageDimension; jj++)
       {
-        Y4[jj] += static_cast<CoordRepType>(f3[jj]) * static_cast<CoordRepType>(deltaTime);
+        Y4[jj] += static_cast<CoordinateType>(f3[jj]) * static_cast<CoordinateType>(deltaTime);
       }
       isinside = true;
       for (unsigned int jj = 0; jj < ImageDimension; jj++)
@@ -571,14 +571,14 @@ IntegrateLength(typename TImage::Pointer /* gmsurf */,
       {
         f4 = vinterp->EvaluateAtContinuousIndex(Y4);
       }
-      using DPointCoordRepType = typename DPointType::CoordRepType;
-      auto twoValue = static_cast<DPointCoordRepType>(2.0);
+      using DPointCoordinateType = typename DPointType::CoordinateType;
+      auto twoValue = static_cast<DPointCoordinateType>(2.0);
       for (unsigned int jj = 0; jj < ImageDimension; jj++)
       {
         pointIn3[jj] = pointIn2[jj] +
-                       static_cast<DPointCoordRepType>(gradsign * vecsign * deltaTime / 6.0f) *
-                         (static_cast<DPointCoordRepType>(f1[jj]) + twoValue * static_cast<DPointCoordRepType>(f2[jj]) +
-                          twoValue * static_cast<DPointCoordRepType>(f3[jj]) + static_cast<DPointCoordRepType>(f4[jj]));
+                       static_cast<DPointCoordinateType>(gradsign * vecsign * deltaTime / 6.0f) *
+                         (static_cast<DPointCoordinateType>(f1[jj]) + twoValue * static_cast<DPointCoordinateType>(f2[jj]) +
+                          twoValue * static_cast<DPointCoordinateType>(f3[jj]) + static_cast<DPointCoordinateType>(f4[jj]));
       }
 
       VectorType out;

--- a/Examples/MeasureImageSimilarity.cxx
+++ b/Examples/MeasureImageSimilarity.cxx
@@ -356,8 +356,8 @@ MeasureImageSimilarity(itk::ants::CommandLineParser * parser)
               // randomly perturb the point within a voxel (approximately)
               for (unsigned int d = 0; d < ImageDimension; d++)
               {
-                point[d] += static_cast<typename SamplePointType::CoordRepType>(randomizer->GetNormalVariate()) *
-                            static_cast<typename SamplePointType::CoordRepType>(oneThirdVirtualSpacing[d]);
+                point[d] += static_cast<typename SamplePointType::CoordinateType>(randomizer->GetNormalVariate()) *
+                            static_cast<typename SamplePointType::CoordinateType>(oneThirdVirtualSpacing[d]);
               }
               if (!fixedImageMask || fixedImageMask->IsInsideInWorldSpace(point))
               {
@@ -384,8 +384,8 @@ MeasureImageSimilarity(itk::ants::CommandLineParser * parser)
             // randomly perturb the point within a voxel (approximately)
             for (unsigned int d = 0; d < ImageDimension; d++)
             {
-              point[d] += static_cast<typename SamplePointType::CoordRepType>(randomizer->GetNormalVariate()) *
-                          static_cast<typename SamplePointType::CoordRepType>(oneThirdVirtualSpacing[d]);
+              point[d] += static_cast<typename SamplePointType::CoordinateType>(randomizer->GetNormalVariate()) *
+                          static_cast<typename SamplePointType::CoordinateType>(oneThirdVirtualSpacing[d]);
             }
             if (!fixedImageMask || fixedImageMask->IsInsideInWorldSpace(point))
             {

--- a/Examples/WarpImageMultiTransform.cxx
+++ b/Examples/WarpImageMultiTransform.cxx
@@ -364,7 +364,7 @@ WarpImageMultiTransform(char *           moving_image_filename,
   if (misc_opt.use_NN_interpolator)
   {
     using NNInterpolateType =
-      typename itk::NearestNeighborInterpolateImageFunction<ImageType, typename WarperType::CoordRepType>;
+      typename itk::NearestNeighborInterpolateImageFunction<ImageType, typename WarperType::CoordinateType>;
     typename NNInterpolateType::Pointer interpolator_NN = NNInterpolateType::New();
     std::cout << "User nearest neighbor interpolation (was Haha) " << std::endl;
     warper->SetInterpolator(interpolator_NN);
@@ -374,7 +374,7 @@ WarpImageMultiTransform(char *           moving_image_filename,
     std::cout << " Need to fix in main itk repository " << std::endl;
     //      typedef VectorPixelCompare<RealType, NVectorComponents> CompareType;
     //      typedef typename itk::LabelImageGaussianInterpolateImageFunction<ImageType,
-    //                                                                       typename WarperType::CoordRepType,
+    //                                                                       typename WarperType::CoordinateType,
     //                                                                       CompareType> MLInterpolateType;
     //      typename MLInterpolateType::Pointer interpolator_ML = MLInterpolateType::New();
     //
@@ -400,7 +400,7 @@ WarpImageMultiTransform(char *           moving_image_filename,
   {
     std::cout << " Not currently supported because of a lack of vector support " << std::endl;
     /*
-      typedef typename itk::BSplineInterpolateImageFunction<ImageType, typename WarperType::CoordRepType>
+      typedef typename itk::BSplineInterpolateImageFunction<ImageType, typename WarperType::CoordinateType>
       BSInterpolateType; typename BSInterpolateType::Pointer interpolator_BS = BSInterpolateType::New();
       interpolator_BS->SetSplineOrder(3);
       std::cout << "User B-spline interpolation " << std::endl;
@@ -410,7 +410,7 @@ WarpImageMultiTransform(char *           moving_image_filename,
   else
   {
     using LinInterpolateType =
-      typename itk::LinearInterpolateImageFunction<ImageType, typename WarperType::CoordRepType>;
+      typename itk::LinearInterpolateImageFunction<ImageType, typename WarperType::CoordinateType>;
     typename LinInterpolateType::Pointer interpolator_LN = LinInterpolateType::New();
     std::cout << "User Linear interpolation " << std::endl;
     warper->SetInterpolator(interpolator_LN);

--- a/Examples/WarpTensorImageMultiTransform.cxx
+++ b/Examples/WarpTensorImageMultiTransform.cxx
@@ -337,7 +337,7 @@ WarpImageMultiTransform(char *           moving_image_filename,
     if (misc_opt.use_NN_interpolator)
     {
       using NNInterpolateType =
-        typename itk::NearestNeighborInterpolateImageFunction<ImageType, typename WarperType::CoordRepType>;
+        typename itk::NearestNeighborInterpolateImageFunction<ImageType, typename WarperType::CoordinateType>;
       typename NNInterpolateType::Pointer interpolator_NN = NNInterpolateType::New();
       std::cout << "Haha" << std::endl;
       warper->SetInterpolator(interpolator_NN);

--- a/Examples/WarpTimeSeriesImageMultiTransform.cxx
+++ b/Examples/WarpTimeSeriesImageMultiTransform.cxx
@@ -311,7 +311,7 @@ WarpImageMultiTransformFourD(char *           moving_image_filename,
     if (misc_opt.use_NN_interpolator)
     {
       using NNInterpolateType =
-        typename itk::NearestNeighborInterpolateImageFunction<ImageType, typename WarperType::CoordRepType>;
+        typename itk::NearestNeighborInterpolateImageFunction<ImageType, typename WarperType::CoordinateType>;
       typename NNInterpolateType::Pointer interpolator_NN = NNInterpolateType::New();
       std::cout << " Use Nearest Neighbor interpolation " << std::endl;
       warper->SetInterpolator(interpolator_NN);
@@ -528,7 +528,7 @@ WarpImageMultiTransform(char *           moving_image_filename,
     if (misc_opt.use_NN_interpolator)
     {
       using NNInterpolateType =
-        typename itk::NearestNeighborInterpolateImageFunction<ImageType, typename WarperType::CoordRepType>;
+        typename itk::NearestNeighborInterpolateImageFunction<ImageType, typename WarperType::CoordinateType>;
       typename NNInterpolateType::Pointer interpolator_NN = NNInterpolateType::New();
       std::cout << "Haha" << std::endl;
       warper->SetInterpolator(interpolator_NN);

--- a/Examples/antsAI.cxx
+++ b/Examples/antsAI.cxx
@@ -208,7 +208,7 @@ PatchCorrelation(itk::NeighborhoodIterator<TImage> fixedNeighborhood,
       movingGradientImage->TransformIndexToPhysicalPoint(movingIndex, movingPoint);
       for (unsigned int d = 0; d < ImageDimension; d++)
       {
-        movingPointCentroid[d] += movingPoint[d] * static_cast<typename PointType::CoordRepType>(weight);
+        movingPointCentroid[d] += movingPoint[d] * static_cast<typename PointType::CoordinateType>(weight);
       }
       movingImagePatchPoints.push_back(movingPoint);
     }
@@ -276,7 +276,7 @@ PatchCorrelation(itk::NeighborhoodIterator<TImage> fixedNeighborhood,
     for (unsigned int d = 0; d < ImageDimension; d++)
     {
       movingImagePoint[d] =
-        static_cast<typename PointType::CoordRepType>(movingImagePointRotated[d]) + movingPointCentroid[d];
+        static_cast<typename PointType::CoordinateType>(movingImagePointRotated[d]) + movingPointCentroid[d];
     }
     if (movingInterpolator->IsInsideBuffer(movingImagePoint))
     {
@@ -1287,8 +1287,8 @@ antsAI(itk::ants::CommandLineParser * parser)
             // randomly perturb the point within a voxel (approximately)
             for (unsigned int d = 0; d < ImageDimension; d++)
             {
-              point[d] += static_cast<typename SamplePointType::CoordRepType>(randomizer->GetNormalVariate()) *
-                          static_cast<typename SamplePointType::CoordRepType>(oneThirdVirtualSpacing[d]);
+              point[d] += static_cast<typename SamplePointType::CoordinateType>(randomizer->GetNormalVariate()) *
+                          static_cast<typename SamplePointType::CoordinateType>(oneThirdVirtualSpacing[d]);
             }
             if (!fixedMaskSpatialObject || fixedMaskSpatialObject->IsInsideInWorldSpace(point))
             {
@@ -1315,7 +1315,7 @@ antsAI(itk::ants::CommandLineParser * parser)
           // randomly perturb the point within a voxel (approximately)
           for (unsigned int d = 0; d < ImageDimension; d++)
           {
-            point[d] += static_cast<typename SamplePointType::CoordRepType>(randomizer->GetNormalVariate() *
+            point[d] += static_cast<typename SamplePointType::CoordinateType>(randomizer->GetNormalVariate() *
                                                                             oneThirdVirtualSpacing[d]);
           }
           if (!fixedMaskSpatialObject || fixedMaskSpatialObject->IsInsideInWorldSpace(point))

--- a/Examples/antsCommandIterationUpdate.h
+++ b/Examples/antsCommandIterationUpdate.h
@@ -125,7 +125,7 @@ public:
   /**
    * Run-time type information (and related methods).
    */
-  itkTypeMacro(antsCommandIterationUpdate, itk::Command);
+  itkOverrideGetNameOfClassMacro(antsCommandIterationUpdate);
 
 
   /**

--- a/Examples/itkantsRegistrationHelper.h
+++ b/Examples/itkantsRegistrationHelper.h
@@ -461,7 +461,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(RegistrationHelper, Object);
+  itkOverrideGetNameOfClassMacro(RegistrationHelper);
 
   /** Dimension of the image.  This constant is used by functions that are
    * templated over image type (as opposed to being templated over pixel type

--- a/ImageRegistration/itkANTSAffine3DTransform.h
+++ b/ImageRegistration/itkANTSAffine3DTransform.h
@@ -30,8 +30,8 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods).   */
-  // itkTypeMacro( ANTSAffine3DTransform, Rigid3DTransform );
-  itkTypeMacro(ANTSAffine3DTransform, MatrixOffsetTransformBase);
+  // itkOverrideGetNameOfClassMacro( ANTSAffine3DTransform);
+  itkOverrideGetNameOfClassMacro(ANTSAffine3DTransform);
 
   /** Dimension of parameters   */
   static constexpr unsigned int InputSpaceDimension = 3;

--- a/ImageRegistration/itkANTSCenteredAffine2DTransform.h
+++ b/ImageRegistration/itkANTSCenteredAffine2DTransform.h
@@ -22,8 +22,8 @@ public:
   typedef SmartPointer<const Self>                     ConstPointer;
 
   /** Run-time type information (and related methods). */
-  // itkTypeMacro( Rigid2DTransform, MatrixOffsetTransformBase );
-  itkTypeMacro(ANTSCenteredAffine2DTransform, MatrixOffsetTransformBase);
+  // itkOverrideGetNameOfClassMacro( Rigid2DTransform);
+  itkOverrideGetNameOfClassMacro(ANTSCenteredAffine2DTransform);
 
   /** New macro for creation of through a Smart Pointer */
   itkNewMacro(Self);

--- a/ImageRegistration/itkANTSImageRegistrationOptimizer.cxx
+++ b/ImageRegistration/itkANTSImageRegistrationOptimizer.cxx
@@ -449,7 +449,7 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>::ComposeDiffs(DisplacementFiel
                                                                 DisplacementFieldPointer fieldout,
                                                                 TReal                    timesign)
 {
-  typedef Point<TReal, itkGetStaticConstMacro(ImageDimension)> VPointType;
+  typedef Point<TReal, Self::ImageDimension> VPointType;
 
   //  field->SetSpacing( fieldtowarpby->GetSpacing() );
   //  field->SetOrigin( fieldtowarpby->GetOrigin() );
@@ -2597,7 +2597,7 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>::IntegratePointVelocity(TReal 
                                                                           TReal     finishtimein,
                                                                           IndexType velind)
 {
-  typedef Point<TReal, itkGetStaticConstMacro(ImageDimension + 1)> xPointType;
+  typedef Point<TReal, Self::ImageDimension + 1> xPointType;
   this->m_Debug = false;
 
 

--- a/ImageRegistration/itkANTSImageRegistrationOptimizer.cxx
+++ b/ImageRegistration/itkANTSImageRegistrationOptimizer.cxx
@@ -505,8 +505,8 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>::ComposeDiffs(DisplacementFiel
       }
       for (unsigned int jj = 0; jj < ImageDimension; jj++)
       {
-        pointIn3[jj] = static_cast<typename VPointType::CoordRepType>(disp2[jj]) *
-                         static_cast<typename VPointType::CoordRepType>(timesign) +
+        pointIn3[jj] = static_cast<typename VPointType::CoordinateType>(disp2[jj]) *
+                         static_cast<typename VPointType::CoordinateType>(timesign) +
                        pointIn2[jj];
       }
 
@@ -2758,14 +2758,14 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>::IntegratePointVelocity(TReal 
     {
       f4 = this->m_VelocityFieldInterpolator->Evaluate(Y4x);
     }
-    using xPointCoordRepType = typename xPointType::CoordRepType;
-    xPointCoordRepType twoValue = static_cast<xPointCoordRepType>(2.0);
+    using xPointCoordinateType = typename xPointType::CoordinateType;
+    xPointCoordinateType twoValue = static_cast<xPointCoordinateType>(2.0);
     for (unsigned int jj = 0; jj < TDimension; jj++)
     {
       pointIn3[jj] =
-        pointIn2[jj] + static_cast<xPointCoordRepType>(vecsign * deltaTime / 6.0f) *
-                         (static_cast<xPointCoordRepType>(f1[jj]) + twoValue * static_cast<xPointCoordRepType>(f2[jj]) +
-                          twoValue * static_cast<xPointCoordRepType>(f3[jj]) + static_cast<xPointCoordRepType>(f4[jj]));
+        pointIn2[jj] + static_cast<xPointCoordinateType>(vecsign * deltaTime / 6.0f) *
+                         (static_cast<xPointCoordinateType>(f1[jj]) + twoValue * static_cast<xPointCoordinateType>(f2[jj]) +
+                          twoValue * static_cast<xPointCoordinateType>(f3[jj]) + static_cast<xPointCoordinateType>(f4[jj]));
     }
     pointIn3[TDimension] = itime * static_cast<TReal>(m_NumberOfTimePoints - 1);
 
@@ -2908,14 +2908,14 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>::IntegratePointVelocity(TReal 
       {
         f4 = this->m_VelocityFieldInterpolator->Evaluate(Y4x);
       }
-      using xPointCoordRepType = typename xPointType::CoordRepType;
-      xPointCoordRepType twoValue = static_cast<xPointCoordRepType>(2.0);
+      using xPointCoordinateType = typename xPointType::CoordinateType;
+      xPointCoordinateType twoValue = static_cast<xPointCoordinateType>(2.0);
       for (unsigned int jj = 0; jj < TDimension; jj++)
       {
         pointIn3[jj] = pointIn2[jj] +
-                       static_cast<xPointCoordRepType>(vecsign * deltaTime / 6.0f) *
-                         (static_cast<xPointCoordRepType>(f1[jj]) + twoValue * static_cast<xPointCoordRepType>(f2[jj]) +
-                          twoValue * static_cast<xPointCoordRepType>(f3[jj]) + static_cast<xPointCoordRepType>(f4[jj]));
+                       static_cast<xPointCoordinateType>(vecsign * deltaTime / 6.0f) *
+                         (static_cast<xPointCoordinateType>(f1[jj]) + twoValue * static_cast<xPointCoordinateType>(f2[jj]) +
+                          twoValue * static_cast<xPointCoordinateType>(f3[jj]) + static_cast<xPointCoordinateType>(f4[jj]));
       }
       pointIn3[TDimension] = itime * static_cast<TReal>(m_NumberOfTimePoints - 1);
 

--- a/ImageRegistration/itkANTSImageRegistrationOptimizer.h
+++ b/ImageRegistration/itkANTSImageRegistrationOptimizer.h
@@ -73,7 +73,7 @@ public:
   typedef double TComp;
   typedef TReal  RealType;
 
-  typedef Image<RealType, itkGetStaticConstMacro(Dimension)> ImageType;
+  typedef Image<RealType, Self::Dimension> ImageType;
   typedef typename ImageType::Pointer                        ImagePointer;
 
   typedef itk::MatrixOffsetTransformBase<TComp, ImageDimension, ImageDimension> TransformType;
@@ -106,10 +106,10 @@ public:
   typedef typename ParserType::OptionType OptionType;
 
   typedef GeneralToBSplineDisplacementFieldFilter<DisplacementFieldType> BSplineFilterType;
-  typedef FixedArray<RealType, itkGetStaticConstMacro(ImageDimension)>   ArrayType;
+  typedef FixedArray<RealType, Self::ImageDimension>   ArrayType;
 
   /** Typedefs for similarity metrics */
-  typedef ANTSSimilarityMetric<itkGetStaticConstMacro(Dimension), TReal> SimilarityMetricType;
+  typedef ANTSSimilarityMetric<Self::Dimension, TReal> SimilarityMetricType;
   typedef typename SimilarityMetricType::Pointer                         SimilarityMetricPointer;
   typedef std::vector<SimilarityMetricPointer>                           SimilarityMetricListType;
 

--- a/ImageRegistration/itkANTSImageRegistrationOptimizer.h
+++ b/ImageRegistration/itkANTSImageRegistrationOptimizer.h
@@ -66,7 +66,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ANTSImageRegistrationOptimizer, Object);
+  itkOverrideGetNameOfClassMacro(ANTSImageRegistrationOptimizer);
   static constexpr unsigned int Dimension = TDimension;
   static constexpr unsigned int ImageDimension = TDimension;
 

--- a/ImageRegistration/itkANTSImageTransformation.h
+++ b/ImageRegistration/itkANTSImageTransformation.h
@@ -46,7 +46,7 @@ public:
 
   typedef double TComp;
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ANTSImageTransformation, Object);
+  itkOverrideGetNameOfClassMacro(ANTSImageTransformation);
   static constexpr unsigned int Dimension = TDimension;
   static constexpr unsigned int ImageDimension = TDimension;
 

--- a/ImageRegistration/itkANTSImageTransformation.h
+++ b/ImageRegistration/itkANTSImageTransformation.h
@@ -51,7 +51,7 @@ public:
   static constexpr unsigned int ImageDimension = TDimension;
 
   typedef TReal                                              RealType;
-  typedef Image<RealType, itkGetStaticConstMacro(Dimension)> ImageType;
+  typedef Image<RealType, Self::Dimension> ImageType;
   /** declare transformation types */
 
   typedef itk::MatrixOffsetTransformBase<TComp, TDimension, TDimension> AffineTransformType;

--- a/ImageRegistration/itkANTSLabeledPointSet.h
+++ b/ImageRegistration/itkANTSLabeledPointSet.h
@@ -37,7 +37,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ANTSLabeledPointSet, Object);
+  itkOverrideGetNameOfClassMacro(ANTSLabeledPointSet);
   static constexpr unsigned int Dimension = TDimension;
 
   typedef float                                                RealType;

--- a/ImageRegistration/itkANTSLabeledPointSet.h
+++ b/ImageRegistration/itkANTSLabeledPointSet.h
@@ -41,10 +41,10 @@ public:
   static constexpr unsigned int Dimension = TDimension;
 
   typedef float                                                RealType;
-  typedef Image<RealType, itkGetStaticConstMacro(Dimension)>   ImageType;
+  typedef Image<RealType, Self::Dimension>   ImageType;
   typedef typename ImageType::Pointer                          ImagePointer;
-  typedef Vector<RealType, itkGetStaticConstMacro(Dimension)>  VectorType;
-  typedef Image<VectorType, itkGetStaticConstMacro(Dimension)> DisplacementFieldType;
+  typedef Vector<RealType, Self::Dimension>  VectorType;
+  typedef Image<VectorType, Self::Dimension> DisplacementFieldType;
 
   /** Point Types  for landmarks and labeled point-sets */
   typedef long                                          PointDataVectorType;

--- a/ImageRegistration/itkANTSSimilarityMetric.h
+++ b/ImageRegistration/itkANTSSimilarityMetric.h
@@ -38,7 +38,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ANTSSimilarityMetric, Object);
+  itkOverrideGetNameOfClassMacro(ANTSSimilarityMetric);
   static constexpr unsigned int Dimension = TDimension;
 
   typedef TReal                                                RealType;

--- a/ImageRegistration/itkANTSSimilarityMetric.h
+++ b/ImageRegistration/itkANTSSimilarityMetric.h
@@ -42,10 +42,10 @@ public:
   static constexpr unsigned int Dimension = TDimension;
 
   typedef TReal                                                RealType;
-  typedef Image<RealType, itkGetStaticConstMacro(Dimension)>   ImageType;
+  typedef Image<RealType, Self::Dimension>   ImageType;
   typedef typename ImageType::Pointer                          ImagePointer;
-  typedef Vector<RealType, itkGetStaticConstMacro(Dimension)>  VectorType;
-  typedef Image<VectorType, itkGetStaticConstMacro(Dimension)> DisplacementFieldType;
+  typedef Vector<RealType, Self::Dimension>  VectorType;
+  typedef Image<VectorType, Self::Dimension> DisplacementFieldType;
 
   /** Point Types  for landmarks and labeled point-sets */
   typedef itk::ANTSLabeledPointSet<Dimension>        LabeledPointSetType;

--- a/ImageRegistration/itkAvantsMutualInformationRegistrationFunction.h
+++ b/ImageRegistration/itkAvantsMutualInformationRegistrationFunction.h
@@ -132,7 +132,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(AvantsMutualInformationRegistrationFunction, AvantsPDEDeformableRegistrationFunction);
+  itkOverrideGetNameOfClassMacro(AvantsMutualInformationRegistrationFunction);
 
   /** MovingImage image type. */
   typedef typename Superclass::MovingImageType    MovingImageType;

--- a/ImageRegistration/itkAvantsMutualInformationRegistrationFunction.h
+++ b/ImageRegistration/itkAvantsMutualInformationRegistrationFunction.h
@@ -161,14 +161,14 @@ public:
   typedef typename Superclass::TimeStepType     TimeStepType;
 
   /** Interpolator type. */
-  typedef double CoordRepType;
-  typedef //       //    LinearInterpolateImageFunction<MovingImageType,CoordRepType>
-    BSplineInterpolateImageFunction<MovingImageType, CoordRepType>
+  typedef double CoordinateType;
+  typedef //       //    LinearInterpolateImageFunction<MovingImageType,CoordinateType>
+    BSplineInterpolateImageFunction<MovingImageType, CoordinateType>
                                                InterpolatorType;
   typedef typename InterpolatorType::Pointer   InterpolatorPointer;
   typedef typename InterpolatorType::PointType PointType;
   typedef InterpolatorType                     DefaultInterpolatorType;
-  //  typedef LinearInterpolateImageFunction<MovingImageType,CoordRepType>
+  //  typedef LinearInterpolateImageFunction<MovingImageType,CoordinateType>
   // DefaultInterpolatorType;
 
   /** Covariant vector type. */

--- a/ImageRegistration/itkAvantsMutualInformationRegistrationFunction.h
+++ b/ImageRegistration/itkAvantsMutualInformationRegistrationFunction.h
@@ -172,7 +172,7 @@ public:
   // DefaultInterpolatorType;
 
   /** Covariant vector type. */
-  typedef CovariantVector<double, itkGetStaticConstMacro(ImageDimension)> CovariantVectorType;
+  typedef CovariantVector<double, Self::ImageDimension> CovariantVectorType;
 
   /** Gradient calculator type. */
   typedef CentralDifferenceImageFunction<FixedImageType> GradientCalculatorType;
@@ -227,8 +227,8 @@ public:
 
   /** Types inherited from Superclass. */
   typedef TranslationTransform<CoordinateRepresentationType,
-                               //                    itkGetStaticConstMacro(ImageDimension),
-                               itkGetStaticConstMacro(ImageDimension)>
+                               //                    Self::ImageDimension,
+                               Self::ImageDimension>
     TransformType;
 
   typedef ImageToImageMetric<TFixedImage, TMovingImage> Metricclass;
@@ -738,7 +738,7 @@ private:
    * image derivatives from the BSpline interpolator. Otherwise,
    * image derivatives are computed using central differencing.
    */
-  typedef CovariantVector<double, itkGetStaticConstMacro(ImageDimension)> ImageDerivativesType;
+  typedef CovariantVector<double, Self::ImageDimension> ImageDerivativesType;
 
   /** Boolean to indicate if the interpolator BSpline. */
   bool m_InterpolatorIsBSpline;

--- a/ImageRegistration/itkAvantsPDEDeformableRegistrationFunction.h
+++ b/ImageRegistration/itkAvantsPDEDeformableRegistrationFunction.h
@@ -45,7 +45,7 @@ public:
   typedef SmartPointer<const Self>                                                         ConstPointer;
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(AvantsPDEDeformableRegistrationFunction, PDEDeformableRegistrationFunction);
+  itkOverrideGetNameOfClassMacro(AvantsPDEDeformableRegistrationFunction);
 
   /** MovingImage image type. */
   typedef TMovingImage                           MovingImageType;

--- a/ImageRegistration/itkCrossCorrelationRegistrationFunction.h
+++ b/ImageRegistration/itkCrossCorrelationRegistrationFunction.h
@@ -104,11 +104,11 @@ public:
   typedef typename Superclass::TimeStepType    TimeStepType;
 
   /** Interpolator type. */
-  typedef double                                                        CoordRepType;
-  typedef InterpolateImageFunction<MovingImageType, CoordRepType>       InterpolatorType;
+  typedef double                                                        CoordinateType;
+  typedef InterpolateImageFunction<MovingImageType, CoordinateType>       InterpolatorType;
   typedef typename InterpolatorType::Pointer                            InterpolatorPointer;
   typedef typename InterpolatorType::PointType                          PointType;
-  typedef LinearInterpolateImageFunction<MovingImageType, CoordRepType> DefaultInterpolatorType;
+  typedef LinearInterpolateImageFunction<MovingImageType, CoordinateType> DefaultInterpolatorType;
 
   /** Covariant vector type. */
   typedef CovariantVector<double, Self::ImageDimension> CovariantVectorType;

--- a/ImageRegistration/itkCrossCorrelationRegistrationFunction.h
+++ b/ImageRegistration/itkCrossCorrelationRegistrationFunction.h
@@ -84,12 +84,12 @@ public:
   typedef typename Superclass::DisplacementFieldTypePointer DisplacementFieldTypePointer;
   typedef typename TDisplacementField::PixelType            VectorType;
 
-  typedef CovariantVector<float, itkGetStaticConstMacro(ImageDimension)>           GradientPixelType;
-  typedef Image<GradientPixelType, itkGetStaticConstMacro(ImageDimension)>         GradientImageType;
+  typedef CovariantVector<float, Self::ImageDimension>           GradientPixelType;
+  typedef Image<GradientPixelType, Self::ImageDimension>         GradientImageType;
   typedef SmartPointer<GradientImageType>                                          GradientImagePointer;
   typedef GradientRecursiveGaussianImageFilter<MetricImageType, GradientImageType> GradientImageFilterType;
   typedef typename GradientImageFilterType::Pointer                                GradientImageFilterPointer;
-  typedef Image<float, itkGetStaticConstMacro(ImageDimension)>                     BinaryImageType;
+  typedef Image<float, Self::ImageDimension>                     BinaryImageType;
   typedef typename BinaryImageType::Pointer                                        BinaryImagePointer;
 
   /** Inherit some enums from the superclass. */
@@ -111,7 +111,7 @@ public:
   typedef LinearInterpolateImageFunction<MovingImageType, CoordRepType> DefaultInterpolatorType;
 
   /** Covariant vector type. */
-  typedef CovariantVector<double, itkGetStaticConstMacro(ImageDimension)> CovariantVectorType;
+  typedef CovariantVector<double, Self::ImageDimension> CovariantVectorType;
 
   /** Gradient calculator type. */
   typedef CentralDifferenceImageFunction<FixedImageType> GradientCalculatorType;

--- a/ImageRegistration/itkCrossCorrelationRegistrationFunction.h
+++ b/ImageRegistration/itkCrossCorrelationRegistrationFunction.h
@@ -65,7 +65,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(CrossCorrelationRegistrationFunction, AvantsPDEDeformableRegistrationFunction);
+  itkOverrideGetNameOfClassMacro(CrossCorrelationRegistrationFunction);
 
   /** MovingImage image type. */
   typedef typename Superclass::MovingImageType    MovingImageType;

--- a/ImageRegistration/itkExpectationBasedPointSetRegistrationFunction.h
+++ b/ImageRegistration/itkExpectationBasedPointSetRegistrationFunction.h
@@ -111,7 +111,7 @@ public:
   using PointDataType = typename PointSetType::PixelType;
   using LabelSetType = std::vector<PointDataType>;
   //  typedef long PointDataType;
-  using MeasurementVectorType = Vector<typename PointSetType::CoordRepType, MeasurementDimension>;
+  using MeasurementVectorType = Vector<typename PointSetType::CoordinateType, MeasurementDimension>;
   using SampleType = typename Statistics::ListSample<MeasurementVectorType>;
   using TreeGeneratorType = typename Statistics::WeightedCentroidKdTreeGenerator<SampleType>;
   using NeighborhoodIdentifierType = typename TreeGeneratorType::KdTreeType::InstanceIdentifierVectorType;

--- a/ImageRegistration/itkExpectationBasedPointSetRegistrationFunction.h
+++ b/ImageRegistration/itkExpectationBasedPointSetRegistrationFunction.h
@@ -71,7 +71,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ExpectationBasedPointSetRegistrationFunction, PDEDeformableRegistrationFunction);
+  itkOverrideGetNameOfClassMacro(ExpectationBasedPointSetRegistrationFunction);
 
   /** MovingImage image type. */
   using MovingImageType = typename Superclass::MovingImageType;

--- a/ImageRegistration/itkExpectationBasedPointSetRegistrationFunction.hxx
+++ b/ImageRegistration/itkExpectationBasedPointSetRegistrationFunction.hxx
@@ -724,8 +724,8 @@ ExpectationBasedPointSetRegistrationFunction<TFixedImage, TMovingImage, TDisplac
           {
             for (unsigned int j = 0; j < ImageDimension; j++)
             {
-              mpt[j] += static_cast<typename ImagePointType::CoordRepType>(pp) *
-                        static_cast<typename ImagePointType::CoordRepType>(npt[j]);
+              mpt[j] += static_cast<typename ImagePointType::CoordinateType>(pp) *
+                        static_cast<typename ImagePointType::CoordinateType>(npt[j]);
             }
           }
           //

--- a/ImageRegistration/itkJensenHavrdaCharvatTsallisLabeledPointSetMetric.h
+++ b/ImageRegistration/itkJensenHavrdaCharvatTsallisLabeledPointSetMetric.h
@@ -41,7 +41,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(JensenHavrdaCharvatTsallisLabeledPointSetMetric, PointSetToLabelPointSetMetric);
+  itkOverrideGetNameOfClassMacro(JensenHavrdaCharvatTsallisLabeledPointSetMetric);
 
   itkStaticConstMacro(PointDimension, unsigned int, TPointSet::PointDimension);
 

--- a/ImageRegistration/itkJensenHavrdaCharvatTsallisLabeledPointSetMetric.h
+++ b/ImageRegistration/itkJensenHavrdaCharvatTsallisLabeledPointSetMetric.h
@@ -43,7 +43,7 @@ public:
   /** Run-time type information (and related methods) */
   itkOverrideGetNameOfClassMacro(JensenHavrdaCharvatTsallisLabeledPointSetMetric);
 
-  itkStaticConstMacro(PointDimension, unsigned int, TPointSet::PointDimension);
+  static constexpr unsigned int PointDimension = TPointSet::PointDimension;
 
   /** Types transferred from the base class */
   typedef typename Superclass::TransformType           TransformType;

--- a/ImageRegistration/itkJensenHavrdaCharvatTsallisPointSetMetric.h
+++ b/ImageRegistration/itkJensenHavrdaCharvatTsallisPointSetMetric.h
@@ -42,7 +42,7 @@ public:
   /** Run-time type information (and related methods) */
   itkOverrideGetNameOfClassMacro(JensenHavrdaCharvatTsallisPointSetMetric);
 
-  itkStaticConstMacro(PointDimension, unsigned int, TPointSet::PointDimension);
+  static constexpr unsigned int PointDimension = TPointSet::PointDimension;
 
   /** Types transferred from the base class */
   typedef typename Superclass::TransformType           TransformType;

--- a/ImageRegistration/itkJensenHavrdaCharvatTsallisPointSetMetric.h
+++ b/ImageRegistration/itkJensenHavrdaCharvatTsallisPointSetMetric.h
@@ -40,7 +40,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(JensenHavrdaCharvatTsallisPointSetMetric, PointSetToPointSetMetric);
+  itkOverrideGetNameOfClassMacro(JensenHavrdaCharvatTsallisPointSetMetric);
 
   itkStaticConstMacro(PointDimension, unsigned int, TPointSet::PointDimension);
 

--- a/ImageRegistration/itkJensenTsallisBSplineRegistrationFunction.h
+++ b/ImageRegistration/itkJensenTsallisBSplineRegistrationFunction.h
@@ -50,8 +50,8 @@ public:
   /**
    * Inherit some enums from the superclass.
    */
-  itkStaticConstMacro(ImageDimension, unsigned int, Superclass::ImageDimension);
-  itkStaticConstMacro(PointDimension, unsigned int, TFixedPointSet::PointDimension);
+  static constexpr unsigned int ImageDimension = Superclass::ImageDimension;
+  static constexpr unsigned int PointDimension = TFixedPointSet::PointDimension;
 
   typedef typename Superclass::NeighborhoodType NeighborhoodType;
   typedef typename Superclass::FloatOffsetType  FloatOffsetType;
@@ -87,7 +87,7 @@ public:
    * BSpline typedefs
    */
   /** Typedefs for B-spline filter */
-  typedef PointSet<VectorType, itkGetStaticConstMacro(ImageDimension)>                          BSplinePointSetType;
+  typedef PointSet<VectorType, Self::ImageDimension>                          BSplinePointSetType;
   typedef BSplineScatteredDataPointSetToImageFilter<BSplinePointSetType, DisplacementFieldType> BSplineFilterType;
   typedef typename BSplineFilterType::WeightsContainerType                                      BSplineWeightsType;
   typedef typename BSplineFilterType::PointDataImageType                                        ControlPointLatticeType;

--- a/ImageRegistration/itkJensenTsallisBSplineRegistrationFunction.h
+++ b/ImageRegistration/itkJensenTsallisBSplineRegistrationFunction.h
@@ -45,7 +45,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(JensenTsallisBSplineRegistrationFunction, AvantsPDEDeformableRegistrationFunction);
+  itkOverrideGetNameOfClassMacro(JensenTsallisBSplineRegistrationFunction);
 
   /**
    * Inherit some enums from the superclass.

--- a/ImageRegistration/itkPICSLAdvancedNormalizationToolKit.h
+++ b/ImageRegistration/itkPICSLAdvancedNormalizationToolKit.h
@@ -41,7 +41,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(PICSLAdvancedNormalizationToolKit, Object);
+  itkOverrideGetNameOfClassMacro(PICSLAdvancedNormalizationToolKit);
   static constexpr unsigned int                              Dimension = TDimension;
   typedef double                                             TComp;
   typedef TReal                                              RealType;

--- a/ImageRegistration/itkPICSLAdvancedNormalizationToolKit.h
+++ b/ImageRegistration/itkPICSLAdvancedNormalizationToolKit.h
@@ -45,7 +45,7 @@ public:
   static constexpr unsigned int                              Dimension = TDimension;
   typedef double                                             TComp;
   typedef TReal                                              RealType;
-  typedef Image<RealType, itkGetStaticConstMacro(Dimension)> ImageType;
+  typedef Image<RealType, Self::Dimension> ImageType;
   typedef typename ImageType::Pointer                        ImagePointer;
   typedef typename ImageType::PixelType                      PixelType;
 
@@ -63,7 +63,7 @@ public:
   typedef typename LabeledPointSetType::PointSetType PointSetType;
 
   /** Typedefs for similarity metrics */
-  typedef ANTSSimilarityMetric<itkGetStaticConstMacro(Dimension), TReal> SimilarityMetricType;
+  typedef ANTSSimilarityMetric<Self::Dimension, TReal> SimilarityMetricType;
   typedef typename SimilarityMetricType::Pointer                         SimilarityMetricPointer;
   typedef std::vector<SimilarityMetricPointer>                           SimilarityMetricListType;
   typedef typename SimilarityMetricType::MetricType                      MetricBaseType;

--- a/ImageRegistration/itkProbabilisticRegistrationFunction.h
+++ b/ImageRegistration/itkProbabilisticRegistrationFunction.h
@@ -65,7 +65,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ProbabilisticRegistrationFunction, AvantsPDEDeformableRegistrationFunction);
+  itkOverrideGetNameOfClassMacro(ProbabilisticRegistrationFunction);
 
   /** MovingImage image type. */
   typedef typename Superclass::MovingImageType    MovingImageType;

--- a/ImageRegistration/itkProbabilisticRegistrationFunction.h
+++ b/ImageRegistration/itkProbabilisticRegistrationFunction.h
@@ -104,11 +104,11 @@ public:
   typedef typename Superclass::TimeStepType    TimeStepType;
 
   /** Interpolator type. */
-  typedef double                                                        CoordRepType;
-  typedef InterpolateImageFunction<MovingImageType, CoordRepType>       InterpolatorType;
+  typedef double                                                        CoordinateType;
+  typedef InterpolateImageFunction<MovingImageType, CoordinateType>       InterpolatorType;
   typedef typename InterpolatorType::Pointer                            InterpolatorPointer;
   typedef typename InterpolatorType::PointType                          PointType;
-  typedef LinearInterpolateImageFunction<MovingImageType, CoordRepType> DefaultInterpolatorType;
+  typedef LinearInterpolateImageFunction<MovingImageType, CoordinateType> DefaultInterpolatorType;
 
   /** Covariant vector type. */
   typedef CovariantVector<double, Self::ImageDimension> CovariantVectorType;

--- a/ImageRegistration/itkProbabilisticRegistrationFunction.h
+++ b/ImageRegistration/itkProbabilisticRegistrationFunction.h
@@ -84,12 +84,12 @@ public:
   typedef typename Superclass::DisplacementFieldTypePointer DisplacementFieldTypePointer;
   typedef typename TDisplacementField::PixelType            VectorType;
 
-  typedef CovariantVector<float, itkGetStaticConstMacro(ImageDimension)>           GradientPixelType;
-  typedef Image<GradientPixelType, itkGetStaticConstMacro(ImageDimension)>         GradientImageType;
+  typedef CovariantVector<float, Self::ImageDimension>           GradientPixelType;
+  typedef Image<GradientPixelType, Self::ImageDimension>         GradientImageType;
   typedef SmartPointer<GradientImageType>                                          GradientImagePointer;
   typedef GradientRecursiveGaussianImageFilter<MetricImageType, GradientImageType> GradientImageFilterType;
   typedef typename GradientImageFilterType::Pointer                                GradientImageFilterPointer;
-  typedef Image<float, itkGetStaticConstMacro(ImageDimension)>                     BinaryImageType;
+  typedef Image<float, Self::ImageDimension>                     BinaryImageType;
   typedef typename BinaryImageType::Pointer                                        BinaryImagePointer;
 
   /** Inherit some enums from the superclass. */
@@ -111,7 +111,7 @@ public:
   typedef LinearInterpolateImageFunction<MovingImageType, CoordRepType> DefaultInterpolatorType;
 
   /** Covariant vector type. */
-  typedef CovariantVector<double, itkGetStaticConstMacro(ImageDimension)> CovariantVectorType;
+  typedef CovariantVector<double, Self::ImageDimension> CovariantVectorType;
 
   /** Gradient calculator type. */
   typedef CentralDifferenceImageFunction<FixedImageType> GradientCalculatorType;

--- a/ImageRegistration/itkSpatialMutualInformationRegistrationFunction.h
+++ b/ImageRegistration/itkSpatialMutualInformationRegistrationFunction.h
@@ -158,14 +158,14 @@ public:
   typedef typename Superclass::TimeStepType     TimeStepType;
 
   /** Interpolator type. */
-  typedef double CoordRepType;
-  typedef //       //    LinearInterpolateImageFunction<MovingImageType,CoordRepType>
-    BSplineInterpolateImageFunction<MovingImageType, CoordRepType>
+  typedef double CoordinateType;
+  typedef //       //    LinearInterpolateImageFunction<MovingImageType,CoordinateType>
+    BSplineInterpolateImageFunction<MovingImageType, CoordinateType>
                                                InterpolatorType;
   typedef typename InterpolatorType::Pointer   InterpolatorPointer;
   typedef typename InterpolatorType::PointType PointType;
   typedef InterpolatorType                     DefaultInterpolatorType;
-  //  typedef LinearInterpolateImageFunction<MovingImageType,CoordRepType>
+  //  typedef LinearInterpolateImageFunction<MovingImageType,CoordinateType>
   // DefaultInterpolatorType;
 
   /** Covariant vector type. */

--- a/ImageRegistration/itkSpatialMutualInformationRegistrationFunction.h
+++ b/ImageRegistration/itkSpatialMutualInformationRegistrationFunction.h
@@ -129,7 +129,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SpatialMutualInformationRegistrationFunction, AvantsPDEDeformableRegistrationFunction);
+  itkOverrideGetNameOfClassMacro(SpatialMutualInformationRegistrationFunction);
 
   /** MovingImage image type. */
   typedef typename Superclass::MovingImageType    MovingImageType;

--- a/ImageRegistration/itkSpatialMutualInformationRegistrationFunction.h
+++ b/ImageRegistration/itkSpatialMutualInformationRegistrationFunction.h
@@ -169,7 +169,7 @@ public:
   // DefaultInterpolatorType;
 
   /** Covariant vector type. */
-  typedef CovariantVector<double, itkGetStaticConstMacro(ImageDimension)> CovariantVectorType;
+  typedef CovariantVector<double, Self::ImageDimension> CovariantVectorType;
 
   /** Gradient calculator type. */
   typedef CentralDifferenceImageFunction<FixedImageType> GradientCalculatorType;
@@ -224,8 +224,8 @@ public:
 
   /** Types inherited from Superclass. */
   typedef TranslationTransform<CoordinateRepresentationType,
-                               //                    itkGetStaticConstMacro(ImageDimension),
-                               itkGetStaticConstMacro(ImageDimension)>
+                               //                    Self::ImageDimension,
+                               Self::ImageDimension>
     TransformType;
 
   typedef ImageToImageMetric<TFixedImage, TMovingImage> Metricclass;
@@ -742,7 +742,7 @@ private:
    * image derivatives from the BSpline interpolator. Otherwise,
    * image derivatives are computed using central differencing.
    */
-  typedef CovariantVector<double, itkGetStaticConstMacro(ImageDimension)> ImageDerivativesType;
+  typedef CovariantVector<double, Self::ImageDimension> ImageDerivativesType;
 
   /** Boolean to indicate if the interpolator BSpline. */
   bool m_InterpolatorIsBSpline;

--- a/ImageRegistration/itkSyNDemonsRegistrationFunction.h
+++ b/ImageRegistration/itkSyNDemonsRegistrationFunction.h
@@ -89,11 +89,11 @@ public:
   typedef typename Superclass::TimeStepType     TimeStepType;
 
   /** Interpolator type. */
-  typedef double                                                        CoordRepType;
-  typedef InterpolateImageFunction<MovingImageType, CoordRepType>       InterpolatorType;
+  typedef double                                                        CoordinateType;
+  typedef InterpolateImageFunction<MovingImageType, CoordinateType>       InterpolatorType;
   typedef typename InterpolatorType::Pointer                            InterpolatorPointer;
   typedef typename InterpolatorType::PointType                          PointType;
-  typedef LinearInterpolateImageFunction<MovingImageType, CoordRepType> DefaultInterpolatorType;
+  typedef LinearInterpolateImageFunction<MovingImageType, CoordinateType> DefaultInterpolatorType;
 
   /** Covariant vector type. */
   typedef CovariantVector<double, Self::ImageDimension> CovariantVectorType;
@@ -103,7 +103,7 @@ public:
   typedef typename GradientCalculatorType::Pointer       GradientCalculatorPointer;
 
   /** Moving image gradient calculator type. */
-  typedef CentralDifferenceImageFunction<MovingImageType, CoordRepType> MovingImageGradientCalculatorType;
+  typedef CentralDifferenceImageFunction<MovingImageType, CoordinateType> MovingImageGradientCalculatorType;
   typedef typename MovingImageGradientCalculatorType::Pointer           MovingImageGradientCalculatorPointer;
 
   /** Set the moving image interpolator. */

--- a/ImageRegistration/itkSyNDemonsRegistrationFunction.h
+++ b/ImageRegistration/itkSyNDemonsRegistrationFunction.h
@@ -61,7 +61,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SyNDemonsRegistrationFunction, PDEDeformableRegistrationFunction);
+  itkOverrideGetNameOfClassMacro(SyNDemonsRegistrationFunction);
 
   /** MovingImage image type. */
   typedef typename Superclass::MovingImageType    MovingImageType;

--- a/ImageRegistration/itkSyNDemonsRegistrationFunction.h
+++ b/ImageRegistration/itkSyNDemonsRegistrationFunction.h
@@ -79,7 +79,7 @@ public:
   typedef typename Superclass::DisplacementFieldTypePointer DisplacementFieldTypePointer;
 
   /** Inherit some enums from the superclass. */
-  itkStaticConstMacro(ImageDimension, unsigned int, Superclass::ImageDimension);
+  static constexpr unsigned int ImageDimension = Superclass::ImageDimension;
 
   /** Inherit some enums from the superclass. */
   typedef typename Superclass::PixelType        PixelType;
@@ -96,7 +96,7 @@ public:
   typedef LinearInterpolateImageFunction<MovingImageType, CoordRepType> DefaultInterpolatorType;
 
   /** Covariant vector type. */
-  typedef CovariantVector<double, itkGetStaticConstMacro(ImageDimension)> CovariantVectorType;
+  typedef CovariantVector<double, Self::ImageDimension> CovariantVectorType;
 
   /** Fixed image gradient calculator type. */
   typedef CentralDifferenceImageFunction<FixedImageType> GradientCalculatorType;

--- a/ImageRegistration/itkVectorParameterizedNeighborhoodOperatorImageFilter.h
+++ b/ImageRegistration/itkVectorParameterizedNeighborhoodOperatorImageFilter.h
@@ -65,7 +65,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(VectorParameterizedNeighborhoodOperatorImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(VectorParameterizedNeighborhoodOperatorImageFilter);
 
   /** Extract some information from the image types.  Dimensionality
    * of the two images is assumed to be the same. */

--- a/ImageRegistration/itkVectorParameterizedNeighborhoodOperatorImageFilter.h
+++ b/ImageRegistration/itkVectorParameterizedNeighborhoodOperatorImageFilter.h
@@ -81,7 +81,7 @@ public:
   typedef typename TParamImage::PixelType          ParameterImageTypePixelType;
 
   /** Determine image dimension. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 
   /** Image typedef support */
   typedef TInputImage  InputImageType;
@@ -93,8 +93,8 @@ public:
   /** Superclass typedefs. */
   typedef typename Superclass::OutputImageRegionType OutputImageRegionType;
 
-  typedef itk::GaussianOperator<ScalarValueType, itkGetStaticConstMacro(ImageDimension)> OperatorType;
-  //  Neighborhood<ScalarValueType, itkGetStaticConstMacro(ImageDimension)>
+  typedef itk::GaussianOperator<ScalarValueType, Self::ImageDimension> OperatorType;
+  //  Neighborhood<ScalarValueType, Self::ImageDimension>
 
   /** Sets the operator that is used to filter the image. Note
    * that the operator is stored as an internal COPY (it

--- a/ImageSegmentation/antsAtroposSegmentationImageFilter.h
+++ b/ImageSegmentation/antsAtroposSegmentationImageFilter.h
@@ -78,9 +78,9 @@ public:
   itkOverrideGetNameOfClassMacro(AtroposSegmentationImageFilter);
 
   /** Dimension of the images. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(ClassifiedImageDimension, unsigned int, TClassifiedImage::ImageDimension);
-  itkStaticConstMacro(MaskImageDimension, unsigned int, TMaskImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
+  static constexpr unsigned int ClassifiedImageDimension = TClassifiedImage::ImageDimension;
+  static constexpr unsigned int MaskImageDimension = TMaskImage::ImageDimension;
 
   /** Typedef support of input types. */
   typedef TInputImage                   ImageType;

--- a/ImageSegmentation/antsAtroposSegmentationImageFilter.h
+++ b/ImageSegmentation/antsAtroposSegmentationImageFilter.h
@@ -75,7 +75,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(AtroposSegmentationImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(AtroposSegmentationImageFilter);
 
   /** Dimension of the images. */
   itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);

--- a/ImageSegmentation/antsBoxPlotQuantileListSampleFilter.h
+++ b/ImageSegmentation/antsBoxPlotQuantileListSampleFilter.h
@@ -46,7 +46,7 @@ public:
   /**
    * Standard macros
    */
-  itkTypeMacro(BoxPlotQuantileListSampleFilter, ListSampleToScalarListSampleFilter);
+  itkOverrideGetNameOfClassMacro(BoxPlotQuantileListSampleFilter);
 
   /**
    * Method for creation through the object factory.

--- a/ImageSegmentation/antsGaussianListSampleFunction.h
+++ b/ImageSegmentation/antsGaussianListSampleFunction.h
@@ -42,7 +42,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(GaussianListSampleFunction, ListSampleFunction);
+  itkOverrideGetNameOfClassMacro(GaussianListSampleFunction);
 
   typedef typename Superclass::InputListSampleType        InputListSampleType;
   typedef typename Superclass::InputMeasurementVectorType InputMeasurementVectorType;

--- a/ImageSegmentation/antsGrubbsRosnerListSampleFilter.h
+++ b/ImageSegmentation/antsGrubbsRosnerListSampleFilter.h
@@ -46,7 +46,7 @@ public:
   /**
    * Standard macros
    */
-  itkTypeMacro(GrubbsRosnerListSampleFilter, ListSampleToScalarListSampleFilter);
+  itkOverrideGetNameOfClassMacro(GrubbsRosnerListSampleFilter);
 
   /**
    * Method for creation through the object factory.

--- a/ImageSegmentation/antsHistogramParzenWindowsListSampleFunction.h
+++ b/ImageSegmentation/antsHistogramParzenWindowsListSampleFunction.h
@@ -44,7 +44,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(HistogramParzenWindowsListSampleFunction, ListSampleFunction);
+  itkOverrideGetNameOfClassMacro(HistogramParzenWindowsListSampleFunction);
 
   typedef typename Superclass::InputListSampleType        InputListSampleType;
   typedef typename Superclass::InputMeasurementVectorType InputMeasurementVectorType;

--- a/ImageSegmentation/antsHistogramParzenWindowsListSampleFunction.hxx
+++ b/ImageSegmentation/antsHistogramParzenWindowsListSampleFunction.hxx
@@ -98,10 +98,10 @@ HistogramParzenWindowsListSampleFunction<TListSample, TOutput, TCoordRep>::SetIn
 
     using HistogramPointType = typename HistogramImageType::PointType;
     HistogramPointType origin;
-    origin[0] = static_cast<typename HistogramPointType::CoordRepType>(minValues[d]) -
-                static_cast<typename HistogramPointType::CoordRepType>(3.0) *
-                  (static_cast<typename HistogramPointType::CoordRepType>(this->m_Sigma) *
-                   static_cast<typename HistogramPointType::CoordRepType>(spacing[0]));
+    origin[0] = static_cast<typename HistogramPointType::CoordinateType>(minValues[d]) -
+                static_cast<typename HistogramPointType::CoordinateType>(3.0) *
+                  (static_cast<typename HistogramPointType::CoordinateType>(this->m_Sigma) *
+                   static_cast<typename HistogramPointType::CoordinateType>(spacing[0]));
 
     typename HistogramImageType::SizeType size;
     size[0] = static_cast<unsigned int>(

--- a/ImageSegmentation/antsJointHistogramParzenShapeAndOrientationListSampleFunction.h
+++ b/ImageSegmentation/antsJointHistogramParzenShapeAndOrientationListSampleFunction.h
@@ -44,7 +44,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(JointHistogramParzenShapeAndOrientationListSampleFunction, ListSampleFunction);
+  itkOverrideGetNameOfClassMacro(JointHistogramParzenShapeAndOrientationListSampleFunction);
 
   typedef typename Superclass::InputListSampleType        InputListSampleType;
   typedef typename Superclass::InputMeasurementVectorType InputMeasurementVectorType;

--- a/ImageSegmentation/antsJointHistogramParzenShapeAndOrientationListSampleFunction.hxx
+++ b/ImageSegmentation/antsJointHistogramParzenShapeAndOrientationListSampleFunction.hxx
@@ -265,10 +265,10 @@ JointHistogramParzenShapeAndOrientationListSampleFunction<TListSample, TOutput, 
 
   // note, if a point maps to 0 or 2*pi then it should contribute to both bins -- pretty much only difference between
   // this function and matlab code is the next 15 or so lines, as far as we see
-  orientPoint[0] = static_cast<typename JointHistogramImagePointType::CoordRepType>(
+  orientPoint[0] = static_cast<typename JointHistogramImagePointType::CoordinateType>(
     psi / static_cast<RealType>(Math::pi) * static_cast<RealType>(this->m_NumberOfOrientationJointHistogramBins - 1) +
     NumericTraits<RealType>::OneValue());
-  orientPoint[1] = static_cast<typename JointHistogramImagePointType::CoordRepType>(
+  orientPoint[1] = static_cast<typename JointHistogramImagePointType::CoordinateType>(
     (theta + static_cast<RealType>(Math::pi_over_2)) / static_cast<RealType>(Math::pi) *
     static_cast<RealType>(this->m_NumberOfOrientationJointHistogramBins - 1));
 

--- a/ImageSegmentation/antsJointHistogramParzenWindowsListSampleFunction.h
+++ b/ImageSegmentation/antsJointHistogramParzenWindowsListSampleFunction.h
@@ -42,7 +42,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(JointHistogramParzenWindowsListSampleFunction, ListSampleFunction);
+  itkOverrideGetNameOfClassMacro(JointHistogramParzenWindowsListSampleFunction);
 
   typedef typename Superclass::InputListSampleType        InputListSampleType;
   typedef typename Superclass::InputMeasurementVectorType InputMeasurementVectorType;

--- a/ImageSegmentation/antsListSampleFunction.h
+++ b/ImageSegmentation/antsListSampleFunction.h
@@ -50,7 +50,7 @@ public:
   typedef SmartPointer<const Self>                ConstPointer;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ListSampleFunction, FunctionBase);
+  itkOverrideGetNameOfClassMacro(ListSampleFunction);
 
   /** InputListSampleType typedef support. */
   typedef TInputListSample InputListSampleType;

--- a/ImageSegmentation/antsListSampleFunction.h
+++ b/ImageSegmentation/antsListSampleFunction.h
@@ -65,8 +65,8 @@ public:
   /** OutputType typedef support. */
   typedef TOutput OutputType;
 
-  /** CoordRepType typedef support. */
-  typedef TCoordRep CoordRepType;
+  /** CoordinateType typedef support. */
+  typedef TCoordRep CoordinateType;
 
   /** Set the input point set.
    * \warning this method caches BufferedRegion information.

--- a/ImageSegmentation/antsListSampleToListSampleFilter.h
+++ b/ImageSegmentation/antsListSampleToListSampleFilter.h
@@ -46,7 +46,7 @@ public:
   typedef SmartPointer<const Self>     ConstPointer;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ListSampleToListSampleFilter, ProcessObject);
+  itkOverrideGetNameOfClassMacro(ListSampleToListSampleFilter);
 
   /** Some convenient typedefs. */
   typedef TInputListSample  InputListSampleType;

--- a/ImageSegmentation/antsLogEuclideanGaussianListSampleFunction.h
+++ b/ImageSegmentation/antsLogEuclideanGaussianListSampleFunction.h
@@ -42,7 +42,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(LogEuclideanGaussianListSampleFunction, ListSampleFunction);
+  itkOverrideGetNameOfClassMacro(LogEuclideanGaussianListSampleFunction);
 
   typedef typename Superclass::InputListSampleType        InputListSampleType;
   typedef typename Superclass::InputMeasurementVectorType InputMeasurementVectorType;

--- a/ImageSegmentation/antsManifoldParzenWindowsListSampleFunction.h
+++ b/ImageSegmentation/antsManifoldParzenWindowsListSampleFunction.h
@@ -45,7 +45,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ManifoldParzenWindowsListSampleFunction, ListSampleFunction);
+  itkOverrideGetNameOfClassMacro(ManifoldParzenWindowsListSampleFunction);
 
   typedef typename Superclass::InputListSampleType        InputListSampleType;
   typedef typename Superclass::InputMeasurementVectorType InputMeasurementVectorType;

--- a/ImageSegmentation/antsPartialVolumeGaussianListSampleFunction.h
+++ b/ImageSegmentation/antsPartialVolumeGaussianListSampleFunction.h
@@ -42,7 +42,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(PartialVolumeGaussianListSampleFunction, ListSampleFunction);
+  itkOverrideGetNameOfClassMacro(PartialVolumeGaussianListSampleFunction);
 
   typedef typename Superclass::InputListSampleType        InputListSampleType;
   typedef typename Superclass::InputMeasurementVectorType InputMeasurementVectorType;

--- a/ImageSegmentation/antsPassThroughListSampleFilter.h
+++ b/ImageSegmentation/antsPassThroughListSampleFilter.h
@@ -43,7 +43,7 @@ public:
   /**
    * Standard macros
    */
-  itkTypeMacro(PassThroughListSampleFilter, ListSampleToScalarListSampleFilter);
+  itkOverrideGetNameOfClassMacro(PassThroughListSampleFilter);
 
   /**
    * Method for creation through the object factory.

--- a/ImageSegmentation/itkWeightedVotingFusionImageFilter.h
+++ b/ImageSegmentation/itkWeightedVotingFusionImageFilter.h
@@ -61,7 +61,7 @@ public:
   typedef SmartPointer<const Self>                                 ConstPointer;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(WeightedVotingFusionImageFilter, NonLocalPatchBasedImageFilter);
+  itkOverrideGetNameOfClassMacro(WeightedVotingFusionImageFilter);
 
   itkNewMacro(Self);
 

--- a/Temporary/antsFastMarchingImageFilter.h
+++ b/Temporary/antsFastMarchingImageFilter.h
@@ -111,7 +111,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(FMarchingImageFilter, ImageSource);
+  itkOverrideGetNameOfClassMacro(FMarchingImageFilter);
 
   /** Typedef support of level set method types. */
   typedef LevelSetTypeDefault<TLevelSet>              LevelSetType;

--- a/Temporary/antsFastMarchingImageFilter.h
+++ b/Temporary/antsFastMarchingImageFilter.h
@@ -163,11 +163,11 @@ public:
   typedef typename SpeedImageType::ConstPointer SpeedImageConstPointer;
 
   /** Dimension of the level set and the speed image. */
-  itkStaticConstMacro(SetDimension, unsigned int, LevelSetType::SetDimension);
-  itkStaticConstMacro(SpeedImageDimension, unsigned int, SpeedImageType::ImageDimension);
+  static constexpr unsigned int SetDimension = LevelSetType::SetDimension;
+  static constexpr unsigned int SpeedImageDimension = SpeedImageType::ImageDimension;
 
   /** Index typedef support. */
-  typedef Index<itkGetStaticConstMacro(SetDimension)> IndexType;
+  typedef Index<Self::SetDimension> IndexType;
 
   /** Enum of Fast Marching algorithm point types. FarPoints represent far
    * away points; TrialPoints represent points within a narrowband of the
@@ -185,14 +185,14 @@ public:
   };
 
   /** LabelImage typedef support. */
-  typedef Image<unsigned char, itkGetStaticConstMacro(SetDimension)> LabelImageType;
+  typedef Image<unsigned char, Self::SetDimension> LabelImageType;
   typedef NeighborhoodIterator<LabelImageType>                       NeighborhoodIteratorType;
 
   /** LabelImagePointer typedef support. */
   typedef typename LabelImageType::Pointer LabelImagePointer;
 
   /** ConnectedComponentImage typedef support. */
-  typedef Image<unsigned int, itkGetStaticConstMacro(SetDimension)> ConnectedComponentImageType;
+  typedef Image<unsigned int, Self::SetDimension> ConnectedComponentImageType;
 
   /** ConnectedComponentImagePointer typedef support. */
   typedef typename ConnectedComponentImageType::Pointer ConnectedComponentImagePointer;

--- a/Temporary/itkAddConstantToImageFilter.h
+++ b/Temporary/itkAddConstantToImageFilter.h
@@ -103,7 +103,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(AddConstantToImageFilter, UnaryFunctorImageFilter);
+  itkOverrideGetNameOfClassMacro(AddConstantToImageFilter);
 
   /** Set the constant that will be used to multiply all the image
    * pixels */

--- a/Temporary/itkDijkstrasAlgorithm.h
+++ b/Temporary/itkDijkstrasAlgorithm.h
@@ -77,7 +77,7 @@ public:
   typedef LightObject              Superclass;
   typedef SmartPointer<Self>       Pointer;
   typedef SmartPointer<const Self> ConstPointer;
-  itkTypeMacro(GraphSearchNode, LightObject);
+  itkOverrideGetNameOfClassMacro(GraphSearchNode);
   itkNewMacro(Self); /** Method for creation through the object factory.   */
 
   enum StateType
@@ -315,7 +315,7 @@ typedef DijkstrasAlgorithmQueue  Self;
 typedef LightObject              Superclass;
 typedef SmartPointer<Self>       Pointer;
 typedef SmartPointer<const Self> ConstPointer;
-itkTypeMacro(DijkstrasAlgorithmQueue, LightObject);
+itkOverrideGetNameOfClassMacro(DijkstrasAlgorithmQueue);
 itkNewMacro(Self); /** Method for creation through the object factory.   */
 
 typedef typename TGraphSearchNode::Pointer   TGraphSearchNodePointer;
@@ -440,7 +440,7 @@ public:
   typedef LightObject              Superclass;
   typedef SmartPointer<Self>       Pointer;
   typedef SmartPointer<const Self> ConstPointer;
-  itkTypeMacro(DijkstrasAlgorithm, LightObject);
+  itkOverrideGetNameOfClassMacro(DijkstrasAlgorithm);
   itkNewMacro(Self);
 
   // Computation Data

--- a/Temporary/itkFEMConformalMap.h
+++ b/Temporary/itkFEMConformalMap.h
@@ -106,7 +106,7 @@ public:
 
   typedef double                                                             RealType;
   typedef vnl_vector<RealType>                                               VectorType;
-  typedef vnl_vector_fixed<RealType, itkGetStaticConstMacro(ImageDimension)> FixedVectorType;
+  typedef vnl_vector_fixed<RealType, Self::ImageDimension> FixedVectorType;
   typedef vnl_matrix<double>                                                 MatrixType;
 
   /** FEM types */

--- a/Temporary/itkFEMConformalMap.h
+++ b/Temporary/itkFEMConformalMap.h
@@ -83,7 +83,7 @@ public:
   typedef SmartPointer<const Self> ConstPointer;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(FEMConformalMap, ProcessObject);
+  itkOverrideGetNameOfClassMacro(FEMConformalMap);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Temporary/itkFEMDiscConformalMap.h
+++ b/Temporary/itkFEMDiscConformalMap.h
@@ -111,7 +111,7 @@ public:
 
   typedef float                                                              RealType;
   typedef vnl_vector<RealType>                                               VectorType;
-  typedef vnl_vector_fixed<RealType, itkGetStaticConstMacro(ImageDimension)> FixedVectorType;
+  typedef vnl_vector_fixed<RealType, Self::ImageDimension> FixedVectorType;
   typedef vnl_matrix<double>                                                 MatrixType;
 
   typedef Image<float, 2>                                   FlatImageType;

--- a/Temporary/itkFEMDiscConformalMap.h
+++ b/Temporary/itkFEMDiscConformalMap.h
@@ -87,7 +87,7 @@ public:
   typedef SmartPointer<const Self> ConstPointer;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(FEMDiscConformalMap, ProcessObject);
+  itkOverrideGetNameOfClassMacro(FEMDiscConformalMap);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Temporary/itkManifoldIntegrationAlgorithm.h
+++ b/Temporary/itkManifoldIntegrationAlgorithm.h
@@ -51,7 +51,7 @@ public:
   typedef LightObject                  Superclass;
   typedef SmartPointer<Self>           Pointer;
   typedef SmartPointer<const Self>     ConstPointer;
-  itkTypeMacro(ManifoldIntegrationAlgorithm, LightObject);
+  itkOverrideGetNameOfClassMacro(ManifoldIntegrationAlgorithm);
   itkNewMacro(Self);
 
   // Computation Data

--- a/Temporary/itkMeanSquaresPointSetToPointSetIntensityMetricv4.h
+++ b/Temporary/itkMeanSquaresPointSetToPointSetIntensityMetricv4.h
@@ -59,7 +59,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MeanSquaresPointSetToPointSetIntensityMetricv4, PointSetToPointSetMetricv4);
+  itkOverrideGetNameOfClassMacro(MeanSquaresPointSetToPointSetIntensityMetricv4);
 
   /**  Type of the fixed point set. */
   typedef TFixedPointSet                              FixedPointSetType;

--- a/Temporary/itkMultiplyByConstantImageFilter.h
+++ b/Temporary/itkMultiplyByConstantImageFilter.h
@@ -49,7 +49,7 @@ public:
   /** method for creation through object factory */
   itkNewMacro(Self);
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MultiplyByConstantImageFilter, MultiplyImageFilter);
+  itkOverrideGetNameOfClassMacro(MultiplyByConstantImageFilter);
 
 protected:
   MultiplyByConstantImageFilter() = default;

--- a/Tensor/itkExpTensorImageFilter.h
+++ b/Tensor/itkExpTensorImageFilter.h
@@ -41,8 +41,8 @@ class ExpTensorImageFilter : public ImageToImageFilter<TInputImage, TOutputImage
 {
 public:
   /** Extract dimension from input and output image. */
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(OutputImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+  static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
   /** Convenient typedefs for simplifying declarations. */
   typedef TInputImage  InputImageType;

--- a/Tensor/itkExpTensorImageFilter.h
+++ b/Tensor/itkExpTensorImageFilter.h
@@ -58,7 +58,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ExpTensorImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(ExpTensorImageFilter);
 
   /** Image typedef support. */
   typedef typename InputImageType::ConstPointer InputImagePointer;

--- a/Tensor/itkLogTensorImageFilter.h
+++ b/Tensor/itkLogTensorImageFilter.h
@@ -58,7 +58,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(LogTensorImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(LogTensorImageFilter);
 
   /** Image typedef support. */
   typedef typename InputImageType::ConstPointer InputImagePointer;

--- a/Tensor/itkLogTensorImageFilter.h
+++ b/Tensor/itkLogTensorImageFilter.h
@@ -41,8 +41,8 @@ class LogTensorImageFilter : public ImageToImageFilter<TInputImage, TOutputImage
 {
 public:
   /** Extract dimension from input and output image. */
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(OutputImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+  static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
   /** Convenient typedefs for simplifying declarations. */
   typedef TInputImage  InputImageType;

--- a/Tensor/itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.h
+++ b/Tensor/itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.h
@@ -113,7 +113,7 @@ public:
   itkGetMacro(UseImageDirection, bool);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(PreservationOfPrincipalDirectionTensorReorientationImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(PreservationOfPrincipalDirectionTensorReorientationImageFilter);
 
   /** Image typedef support. */
   typedef typename InputImageType::ConstPointer InputImagePointer;

--- a/Tensor/itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.h
+++ b/Tensor/itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.h
@@ -61,7 +61,7 @@ public:
   // typedef Vector<RealType, 3> VectorType;
   typedef VariableSizeMatrix<RealType> VariableMatrixType;
 
-  itkStaticConstMacro(ImageDimension, unsigned int, TTensorImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TTensorImage::ImageDimension;
 
   typedef itk::Image<RealType, ImageDimension> RealTypeImageType;
 

--- a/Tensor/itkWarpTensorImageMultiTransformFilter.h
+++ b/Tensor/itkWarpTensorImageMultiTransformFilter.h
@@ -132,15 +132,15 @@ public:
   typedef typename TransformType::Pointer TransformTypePointer;
 
   /** Interpolator typedef support. */
-  typedef double                                                                    CoordRepType;
-  typedef VectorInterpolateImageFunction<InputImageType, CoordRepType>              InterpolatorType;
+  typedef double                                                                    CoordinateType;
+  typedef VectorInterpolateImageFunction<InputImageType, CoordinateType>              InterpolatorType;
   typedef typename InterpolatorType::Pointer                                        InterpolatorPointer;
-  typedef VectorLinearInterpolateImageFunction<InputImageType, CoordRepType>        DefaultInterpolatorType;
-  typedef VectorLinearInterpolateImageFunction<DisplacementFieldType, CoordRepType> DefaultVectorInterpolatorType;
+  typedef VectorLinearInterpolateImageFunction<InputImageType, CoordinateType>        DefaultInterpolatorType;
+  typedef VectorLinearInterpolateImageFunction<DisplacementFieldType, CoordinateType> DefaultVectorInterpolatorType;
   typedef typename DefaultVectorInterpolatorType::Pointer                           VectorInterpolatorPointer;
 
   /** Point type */
-  typedef Point<CoordRepType, Self::ImageDimension> PointType;
+  typedef Point<CoordinateType, Self::ImageDimension> PointType;
 
   typedef struct _DeformationTypeEx
   {

--- a/Tensor/itkWarpTensorImageMultiTransformFilter.h
+++ b/Tensor/itkWarpTensorImageMultiTransformFilter.h
@@ -99,7 +99,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(WarpTensorImageMultiTransformFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(WarpTensorImageMultiTransformFilter);
 
   /** Typedef to describe the output image region type. */
   typedef typename TOutputImage::RegionType OutputImageRegionType;

--- a/Tensor/itkWarpTensorImageMultiTransformFilter.h
+++ b/Tensor/itkWarpTensorImageMultiTransformFilter.h
@@ -117,9 +117,9 @@ public:
   typedef typename OutputImageType::DirectionType     DirectionType;
 
   /** Determine the image dimension. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TOutputImage::ImageDimension);
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(DisplacementFieldDimension, unsigned int, TDisplacementField::ImageDimension);
+  static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+  static constexpr unsigned int DisplacementFieldDimension = TDisplacementField::ImageDimension;
 
   /** Deformation field typedef support. */
   typedef TDisplacementField                        DisplacementFieldType;
@@ -140,7 +140,7 @@ public:
   typedef typename DefaultVectorInterpolatorType::Pointer                           VectorInterpolatorPointer;
 
   /** Point type */
-  typedef Point<CoordRepType, itkGetStaticConstMacro(ImageDimension)> PointType;
+  typedef Point<CoordRepType, Self::ImageDimension> PointType;
 
   typedef struct _DeformationTypeEx
   {

--- a/Utilities/ReadWriteData.h
+++ b/Utilities/ReadWriteData.h
@@ -669,8 +669,8 @@ ReadWarpFromFile(std::string warpfn, std::string ext)
   typedef itk::Image<float, ImageDimension> RealImageType;
   typedef RealImageType                     ImageType;
 
-  //  typedef itk::Vector<float,itkGetStaticConstMacro(ImageDimension)>         VectorType;
-  //  typedef itk::Image<VectorType,itkGetStaticConstMacro(ImageDimension)>     FieldType;
+  //  typedef itk::Vector<float,Self::ImageDimension>         VectorType;
+  //  typedef itk::Image<VectorType,Self::ImageDimension>     FieldType;
   // std::cout << " warp file name " << warpfn + ext << std::endl;
 
   // First - read the vector fields

--- a/Utilities/antsCommandLineOption.h
+++ b/Utilities/antsCommandLineOption.h
@@ -59,7 +59,7 @@ public:
 
   itkNewMacro(Self);
 
-  itkTypeMacro(OptionFunction, DataObject);
+  itkOverrideGetNameOfClassMacro(OptionFunction);
 
   typedef std::deque<std::string> ParameterStackType;
 
@@ -122,7 +122,7 @@ public:
 
   itkNewMacro(Self);
 
-  itkTypeMacro(CommandLineOption, DataObject);
+  itkOverrideGetNameOfClassMacro(CommandLineOption);
 
   typedef OptionFunction OptionFunctionType;
 

--- a/Utilities/antsCommandLineParser.h
+++ b/Utilities/antsCommandLineParser.h
@@ -62,7 +62,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(CommandLineParser, DataObject);
+  itkOverrideGetNameOfClassMacro(CommandLineParser);
 
   typedef CommandLineOption              OptionType;
   typedef std::list<OptionType::Pointer> OptionListType;

--- a/Utilities/antsMatrixUtilities.h
+++ b/Utilities/antsMatrixUtilities.h
@@ -35,7 +35,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(antsMatrixUtilities, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(antsMatrixUtilities);
 
   /** Dimension of the images. */
   itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);

--- a/Utilities/antsMatrixUtilities.h
+++ b/Utilities/antsMatrixUtilities.h
@@ -38,7 +38,7 @@ public:
   itkOverrideGetNameOfClassMacro(antsMatrixUtilities);
 
   /** Dimension of the images. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
   static constexpr unsigned int MatrixDimension = 2;
 
@@ -50,7 +50,7 @@ public:
 
   /** Some convenient typedefs. */
   typedef TRealType                                               RealType;
-  typedef Image<RealType, itkGetStaticConstMacro(ImageDimension)> RealImageType;
+  typedef Image<RealType, Self::ImageDimension> RealImageType;
 
   /** note, eigen for pseudo-eigenvals  */
   typedef vnl_matrix<RealType>      MatrixType;

--- a/Utilities/antsSCCANObject.h
+++ b/Utilities/antsSCCANObject.h
@@ -48,7 +48,7 @@ public:
   itkOverrideGetNameOfClassMacro(antsSCCANObject);
 
   /** Dimension of the images. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
   static constexpr unsigned int MatrixDimension = 2;
 
@@ -60,8 +60,8 @@ public:
 
   /** Some convenient typedefs. */
   typedef TRealType                                                   RealType;
-  typedef Image<RealType, itkGetStaticConstMacro(ImageDimension)>     RealImageType;
-  typedef Image<RealType, itkGetStaticConstMacro(ImageDimension - 1)> RealImageTypeDminus1;
+  typedef Image<RealType, Self::ImageDimension>     RealImageType;
+  typedef Image<RealType, Self::ImageDimension - 1> RealImageTypeDminus1;
 
   /** Define eigen types */
   //  typedef Eigen::Matrix<RealType, Eigen::Dynamic, Eigen::Dynamic> eMatrix;

--- a/Utilities/antsSCCANObject.h
+++ b/Utilities/antsSCCANObject.h
@@ -45,7 +45,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(antsSCCANObject, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(antsSCCANObject);
 
   /** Dimension of the images. */
   itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);

--- a/Utilities/itkAlternatingValueDifferenceImageFilter.h
+++ b/Utilities/itkAlternatingValueDifferenceImageFilter.h
@@ -71,8 +71,8 @@ public:
   typedef typename InterpolatorType::Pointer               InterpolatorPointerType;
 
   /** Compiler can't inherit ImageDimension enumeration? */
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(OutputImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+  static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
   itkGetMacro(SubtractionDimension, unsigned int);
   itkSetMacro(SubtractionDimension, unsigned int);

--- a/Utilities/itkAlternatingValueDifferenceImageFilter.h
+++ b/Utilities/itkAlternatingValueDifferenceImageFilter.h
@@ -54,7 +54,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(AlternatingValueDifferenceImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(AlternatingValueDifferenceImageFilter);
 
   /** Compiler can't inherit typedef? */
   typedef typename Superclass::InputImageType  InputImageType;

--- a/Utilities/itkAlternatingValueSimpleSubtractionImageFilter.h
+++ b/Utilities/itkAlternatingValueSimpleSubtractionImageFilter.h
@@ -50,7 +50,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(AlternatingValueSimpleSubtractionImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(AlternatingValueSimpleSubtractionImageFilter);
 
   /** Compiler can't inherit typedef? */
   typedef typename Superclass::InputImageType  InputImageType;

--- a/Utilities/itkAlternatingValueSimpleSubtractionImageFilter.h
+++ b/Utilities/itkAlternatingValueSimpleSubtractionImageFilter.h
@@ -61,8 +61,8 @@ public:
   typedef typename OutputImageType::RegionType OutputImageRegionType;
 
   /** Compiler can't inherit ImageDimension enumeration? */
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(OutputImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+  static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
   /** Set/Get dimension to subtract over */
   itkGetMacro(SubtractionDimension, unsigned int);

--- a/Utilities/itkAverageOverDimensionImageFilter.h
+++ b/Utilities/itkAverageOverDimensionImageFilter.h
@@ -100,7 +100,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(AverageOverDimensionImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(AverageOverDimensionImageFilter);
 
   /** Image type information. */
   typedef TInputImage  InputImageType;

--- a/Utilities/itkAverageOverDimensionImageFilter.h
+++ b/Utilities/itkAverageOverDimensionImageFilter.h
@@ -208,11 +208,11 @@ public:
 
 
   /** ImageDimension enumeration */
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(OutputImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+  static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
-  typedef ImageToImageFilterDetail::ExtractImageFilterRegionCopier<itkGetStaticConstMacro(InputImageDimension),
-                                                                   itkGetStaticConstMacro(OutputImageDimension)>
+  typedef ImageToImageFilterDetail::ExtractImageFilterRegionCopier<Self::InputImageDimension,
+                                                                   Self::OutputImageDimension>
     ExtractImageFilterRegionCopierType;
 
   /** Set/Get the output image region.

--- a/Utilities/itkComposeDiffeomorphismsImageFilter.h
+++ b/Utilities/itkComposeDiffeomorphismsImageFilter.h
@@ -46,7 +46,7 @@ public:
   itkNewMacro(Self);
 
   /** Extract dimension from input image. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
   typedef TInputImage  InputFieldType;
   typedef TOutputImage OutputFieldType;

--- a/Utilities/itkDecomposeTensorFunction.h
+++ b/Utilities/itkDecomposeTensorFunction.h
@@ -40,7 +40,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(DecomposeTensorFunction, ProcessObject);
+  itkOverrideGetNameOfClassMacro(DecomposeTensorFunction);
 
   /** Extract some information from the image types.  Dimensionality
    * of the two images is assumed to be the same. */

--- a/Utilities/itkDeformationFieldGradientTensorImageFilter.h
+++ b/Utilities/itkDeformationFieldGradientTensorImageFilter.h
@@ -41,7 +41,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(DeformationFieldGradientTensorImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(DeformationFieldGradientTensorImageFilter);
 
   /** Extract some information from the image types.  Dimensionality
    * of the two images is assumed to be the same. */

--- a/Utilities/itkDeformationFieldGradientTensorImageFilter.h
+++ b/Utilities/itkDeformationFieldGradientTensorImageFilter.h
@@ -55,10 +55,10 @@ public:
   typedef typename OutputImageType::Pointer OutputImagePointer;
 
   /** The dimensionality of the input and output images. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 
   /** Length of the vector pixel type of the input image. */
-  itkStaticConstMacro(VectorDimension, unsigned int, InputPixelType::Dimension);
+  static constexpr unsigned int VectorDimension = InputPixelType::Dimension;
 
   /** Define the data type and the vector of data type used in calculations. */
   typedef TRealType                                         RealType;

--- a/Utilities/itkDeterminantTensorImageFilter.h
+++ b/Utilities/itkDeterminantTensorImageFilter.h
@@ -38,7 +38,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(DeterminantTensorImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(DeterminantTensorImageFilter);
 
   /** Extract some information from the image types.  Dimensionality
    * of the two images is assumed to be the same. */

--- a/Utilities/itkDeterminantTensorImageFilter.h
+++ b/Utilities/itkDeterminantTensorImageFilter.h
@@ -53,7 +53,7 @@ public:
   typedef typename OutputImageType::RegionType OutputImageRegionType;
 
   /** The dimensionality of the input and output images. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 
   /** Define the data type and the vector of data type used in calculations. */
   typedef TRealType RealType;

--- a/Utilities/itkDiReCTImageFilter.h
+++ b/Utilities/itkDiReCTImageFilter.h
@@ -60,7 +60,7 @@ public:
   itkNewMacro(Self);
 
   /** Extract dimension from input and output image. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
   /** Convenient typedefs for simplifying declarations. */
   using InputImageType = TInputImage;

--- a/Utilities/itkDisplacementFieldFromMultiTransformFilter.h
+++ b/Utilities/itkDisplacementFieldFromMultiTransformFilter.h
@@ -21,7 +21,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(DisplacementFieldFromMultiTransformFilter, WarpImageMultiTransformFilter);
+  itkOverrideGetNameOfClassMacro(DisplacementFieldFromMultiTransformFilter);
 
   /** Typedef to describe the output image region type. */
   typedef typename TOutputImage::RegionType OutputImageRegionType;

--- a/Utilities/itkDisplacementFieldFromMultiTransformFilter.h
+++ b/Utilities/itkDisplacementFieldFromMultiTransformFilter.h
@@ -38,9 +38,9 @@ public:
   typedef typename OutputImageType::SpacingType       SpacingType;
 
   /** Determine the image dimension. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TOutputImage::ImageDimension);
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(DisplacementFieldDimension, unsigned int, TDisplacementField::ImageDimension);
+  static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+  static constexpr unsigned int DisplacementFieldDimension = TDisplacementField::ImageDimension;
 
   /** Displacement field typedef support. */
   typedef TDisplacementField                        DisplacementFieldType;

--- a/Utilities/itkGeneralToBSplineDisplacementFieldFilter.h
+++ b/Utilities/itkGeneralToBSplineDisplacementFieldFilter.h
@@ -36,7 +36,7 @@ public:
   itkNewMacro(Self);
 
   /** Extract dimension from input and output image. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
   /** Convenient typedefs for simplifying declarations. */
   typedef TInputImage  InputImageType;
@@ -51,7 +51,7 @@ public:
   typedef InputPixelComponentType         RealType;
   typedef Image<RealType, ImageDimension> RealImageType;
 
-  typedef PointSet<InputPixelType, itkGetStaticConstMacro(ImageDimension)>         PointSetType;
+  typedef PointSet<InputPixelType, Self::ImageDimension>         PointSetType;
   typedef BSplineScatteredDataPointSetToImageFilter<PointSetType, OutputImageType> BSplineFilterType;
   typedef typename BSplineFilterType::ArrayType                                    ArrayType;
 

--- a/Utilities/itkGeometricJacobianDeterminantImageFilter.h
+++ b/Utilities/itkGeometricJacobianDeterminantImageFilter.h
@@ -53,7 +53,7 @@ public:
   typedef typename OutputImageType::Pointer OutputImagePointer;
 
   /** The dimensionality of the input and output images. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 
   /** Define the data type and the vector of data type used in calculations. */
   typedef TRealType                             RealType;

--- a/Utilities/itkGeometricJacobianDeterminantImageFilter.h
+++ b/Utilities/itkGeometricJacobianDeterminantImageFilter.h
@@ -39,7 +39,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(GeometricJacobianDeterminantImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(GeometricJacobianDeterminantImageFilter);
 
   /** Extract some information from the image types.  Dimensionality
    * of the two images is assumed to be the same. */

--- a/Utilities/itkImageIntensityAndGradientToPointSetFilter.h
+++ b/Utilities/itkImageIntensityAndGradientToPointSetFilter.h
@@ -44,7 +44,7 @@ public:
   itkStaticConstMacro(Dimension, unsigned int, TInputImage::ImageDimension);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ImageIntensityAndGradientToPointSetFilter, MeshSource);
+  itkOverrideGetNameOfClassMacro(ImageIntensityAndGradientToPointSetFilter);
 
   /** Hold on to the type information specified by the template parameters. */
   typedef TInputImage                        InputImageType;

--- a/Utilities/itkImageIntensityAndGradientToPointSetFilter.h
+++ b/Utilities/itkImageIntensityAndGradientToPointSetFilter.h
@@ -41,7 +41,7 @@ public:
   itkNewMacro(Self);
 
   /** Extract dimension from the input image. */
-  itkStaticConstMacro(Dimension, unsigned int, TInputImage::ImageDimension);
+  static constexpr unsigned int Dimension = TInputImage::ImageDimension;
 
   /** Run-time type information (and related methods). */
   itkOverrideGetNameOfClassMacro(ImageIntensityAndGradientToPointSetFilter);

--- a/Utilities/itkLabeledPointSetFileReader.h
+++ b/Utilities/itkLabeledPointSetFileReader.h
@@ -44,7 +44,7 @@ public:
   itkNewMacro(Self);
 
   /** Extract dimension from the output mesh. */
-  itkStaticConstMacro(Dimension, unsigned int, TOutputMesh::PointType::Dimension);
+  static constexpr unsigned int Dimension = TOutputMesh::PointType::Dimension;
 
   /** Run-time type information (and related methods). */
   itkOverrideGetNameOfClassMacro(LabeledPointSetFileReader);
@@ -60,7 +60,7 @@ public:
   typedef VectorContainer<long, MultiComponentScalarType> MultiComponentScalarSetType;
   typedef VectorContainer<long, LineType>                 LineSetType;
 
-  typedef Image<PixelType, itkGetStaticConstMacro(Dimension)> LabeledPointSetImageType;
+  typedef Image<PixelType, Self::Dimension> LabeledPointSetImageType;
 
   typedef std::vector<PixelType> LabelSetType;
 

--- a/Utilities/itkLabeledPointSetFileReader.h
+++ b/Utilities/itkLabeledPointSetFileReader.h
@@ -47,7 +47,7 @@ public:
   itkStaticConstMacro(Dimension, unsigned int, TOutputMesh::PointType::Dimension);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(LabeledPointSetFileReader, MeshSource);
+  itkOverrideGetNameOfClassMacro(LabeledPointSetFileReader);
 
   /** Hold on to the type information specified by the template parameters. */
   typedef TOutputMesh                                     OutputMeshType;

--- a/Utilities/itkLabeledPointSetFileWriter.h
+++ b/Utilities/itkLabeledPointSetFileWriter.h
@@ -49,7 +49,7 @@ public:
   Write();
 
   /** Extract dimension from the output mesh. */
-  itkStaticConstMacro(Dimension, unsigned int, TInputMesh::PointType::Dimension);
+  static constexpr unsigned int Dimension = TInputMesh::PointType::Dimension;
 
   /** Run-time type information (and related methods). */
   itkOverrideGetNameOfClassMacro(LabeledPointSetFileWriter);
@@ -65,7 +65,7 @@ public:
   typedef Array<unsigned long>                                LineType;
   typedef VectorContainer<long, MultiComponentScalarType>     MultiComponentScalarSetType;
   typedef VectorContainer<long, LineType>                     LineSetType;
-  typedef Image<PixelType, itkGetStaticConstMacro(Dimension)> LabeledPointSetImageType;
+  typedef Image<PixelType, Self::Dimension> LabeledPointSetImageType;
   typedef typename LabeledPointSetImageType::SizeType         ImageSizeType;
   typedef typename LabeledPointSetImageType::PointType        ImageOriginType;
   typedef typename LabeledPointSetImageType::SpacingType      ImageSpacingType;

--- a/Utilities/itkLabeledPointSetFileWriter.h
+++ b/Utilities/itkLabeledPointSetFileWriter.h
@@ -52,7 +52,7 @@ public:
   itkStaticConstMacro(Dimension, unsigned int, TInputMesh::PointType::Dimension);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(LabeledPointSetFileWriter, Object);
+  itkOverrideGetNameOfClassMacro(LabeledPointSetFileWriter);
 
   /** Hold on to the type information specified by the template parameters. */
   typedef TInputMesh                                          InputMeshType;

--- a/Utilities/itkLabeledPointSetFileWriter.hxx
+++ b/Utilities/itkLabeledPointSetFileWriter.hxx
@@ -86,7 +86,7 @@ LabeledPointSetFileWriter<TInputMesh>::GenerateData()
   {
     typedef BoundingBox<unsigned long,
                         Dimension,
-                        typename TInputMesh::CoordRepType,
+                        typename TInputMesh::CoordinateType,
                         typename TInputMesh::PointsContainer>
                                       BoundingBoxType;
     typename BoundingBoxType::Pointer bbox = BoundingBoxType::New();

--- a/Utilities/itkManifoldParzenWindowsPointSetFunction.h
+++ b/Utilities/itkManifoldParzenWindowsPointSetFunction.h
@@ -57,7 +57,7 @@ public:
   typedef typename PointSetType::PointType                     PointType;
   typedef typename PointSetType ::PointsContainerConstIterator PointsContainerConstIterator;
 
-  typedef Vector<typename PointSetType::CoordRepType, Self::Dimension> MeasurementVectorType;
+  typedef Vector<typename PointSetType::CoordinateType, Self::Dimension> MeasurementVectorType;
   typedef typename Statistics::ListSample<MeasurementVectorType>                         SampleType;
   typedef typename Statistics ::WeightedCentroidKdTreeGenerator<SampleType>              TreeGeneratorType;
   typedef typename TreeGeneratorType::KdTreeType                                         KdTreeType;

--- a/Utilities/itkManifoldParzenWindowsPointSetFunction.h
+++ b/Utilities/itkManifoldParzenWindowsPointSetFunction.h
@@ -47,7 +47,7 @@ public:
   itkNewMacro(Self);
 
   /** Extract dimension from output image. */
-  itkStaticConstMacro(Dimension, unsigned int, TPointSet::PointDimension);
+  static constexpr unsigned int Dimension = TPointSet::PointDimension;
 
   typedef typename Superclass::InputPointSetType InputPointSetType;
   typedef typename Superclass::InputPointType    InputPointType;
@@ -57,7 +57,7 @@ public:
   typedef typename PointSetType::PointType                     PointType;
   typedef typename PointSetType ::PointsContainerConstIterator PointsContainerConstIterator;
 
-  typedef Vector<typename PointSetType::CoordRepType, itkGetStaticConstMacro(Dimension)> MeasurementVectorType;
+  typedef Vector<typename PointSetType::CoordRepType, Self::Dimension> MeasurementVectorType;
   typedef typename Statistics::ListSample<MeasurementVectorType>                         SampleType;
   typedef typename Statistics ::WeightedCentroidKdTreeGenerator<SampleType>              TreeGeneratorType;
   typedef typename TreeGeneratorType::KdTreeType                                         KdTreeType;

--- a/Utilities/itkMultiScaleLaplacianBlobDetectorImageFilter.h
+++ b/Utilities/itkMultiScaleLaplacianBlobDetectorImageFilter.h
@@ -53,7 +53,7 @@ public:
   typedef Image<RealPixelType, TDimension>  RealImageType;
   typedef typename RealImageType::IndexType CenterType;
 
-  itkStaticConstMacro(NumberOfDimensions, unsigned int, TDimension);
+  static constexpr unsigned int NumberOfDimensions = TDimension;
 
   itkNewMacro(Self);
   itkOverrideGetNameOfClassMacro(ScaleSpaceBlobSpatialObject);

--- a/Utilities/itkMultiScaleLaplacianBlobDetectorImageFilter.h
+++ b/Utilities/itkMultiScaleLaplacianBlobDetectorImageFilter.h
@@ -56,7 +56,7 @@ public:
   itkStaticConstMacro(NumberOfDimensions, unsigned int, TDimension);
 
   itkNewMacro(Self);
-  itkTypeMacro(ScaleSpaceBlobSpatialObject, GaussianSpatialObject);
+  itkOverrideGetNameOfClassMacro(ScaleSpaceBlobSpatialObject);
 
   /** Set/Get the normalized laplacian value of the extrema */
   itkGetMacro(ScaleSpaceValue, double);
@@ -129,7 +129,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MultiScaleLaplacianBlobDetectorImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(MultiScaleLaplacianBlobDetectorImageFilter);
 
   /** Typedef to images */
   typedef TInputImage                           InputImageType;

--- a/Utilities/itkMultiplyByConstantVectorImageFilter.h
+++ b/Utilities/itkMultiplyByConstantVectorImageFilter.h
@@ -110,7 +110,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MultiplyByConstantVectorImageFilter, UnaryFunctorImageFilter);
+  itkOverrideGetNameOfClassMacro(MultiplyByConstantVectorImageFilter);
 
   /** Set the constant that will be used to multiply all the image pixels */
   void

--- a/Utilities/itkN3BiasFieldCorrectionImageFilter.h
+++ b/Utilities/itkN3BiasFieldCorrectionImageFilter.h
@@ -91,7 +91,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Runtime information support. */
-  itkTypeMacro(N3BiasFieldCorrectionImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(N3BiasFieldCorrectionImageFilter);
 
   /** Standard New method. */
   itkNewMacro(Self);

--- a/Utilities/itkN3MRIBiasFieldCorrectionImageFilter.h
+++ b/Utilities/itkN3MRIBiasFieldCorrectionImageFilter.h
@@ -153,7 +153,7 @@ public:
   itkNewMacro(Self);
 
   /** ImageDimension constants */
-  itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
   /** Some convenient typedefs. */
   typedef TInputImage                       InputImageType;
@@ -166,8 +166,8 @@ public:
 
   /** B-spline smoothing filter typedefs */
   typedef Vector<RealType, 1>                                                      ScalarType;
-  typedef PointSet<ScalarType, itkGetStaticConstMacro(ImageDimension)>             PointSetType;
-  typedef Image<ScalarType, itkGetStaticConstMacro(ImageDimension)>                ScalarImageType;
+  typedef PointSet<ScalarType, Self::ImageDimension>             PointSetType;
+  typedef Image<ScalarType, Self::ImageDimension>                ScalarImageType;
   typedef BSplineScatteredDataPointSetToImageFilter<PointSetType, ScalarImageType> BSplineFilterType;
   typedef typename BSplineFilterType::PointDataImageType                           BiasFieldControlPointLatticeType;
   typedef typename BSplineFilterType::ArrayType                                    ArrayType;

--- a/Utilities/itkN3MRIBiasFieldCorrectionImageFilter.h
+++ b/Utilities/itkN3MRIBiasFieldCorrectionImageFilter.h
@@ -93,7 +93,7 @@ public:
   typedef SmartPointer<const Self>     ConstPointer;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(N3BiasFieldScaleCostFunction, SingleValuedCostFunction);
+  itkOverrideGetNameOfClassMacro(N3BiasFieldScaleCostFunction);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -147,7 +147,7 @@ public:
   typedef SmartPointer<const Self>                      ConstPointer;
 
   /** Runtime information support. */
-  itkTypeMacro(N3MRIBiasFieldCorrectionImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(N3MRIBiasFieldCorrectionImageFilter);
 
   /** Standard New method. */
   itkNewMacro(Self);

--- a/Utilities/itkNeighborhoodFirstOrderStatisticsImageFilter.h
+++ b/Utilities/itkNeighborhoodFirstOrderStatisticsImageFilter.h
@@ -54,7 +54,7 @@ public:
   itkNewMacro(Self);
 
   /** Runtime information support. */
-  itkTypeMacro(NeighborhoodFirstOrderStatisticsImageFilter, MovingHistogramImageFilter);
+  itkOverrideGetNameOfClassMacro(NeighborhoodFirstOrderStatisticsImageFilter);
 
   /** Image related typedefs. */
   typedef TInputImage                                InputImageType;

--- a/Utilities/itkNonLocalSuperresolutionImageFilter.h
+++ b/Utilities/itkNonLocalSuperresolutionImageFilter.h
@@ -58,7 +58,7 @@ public:
   typedef SmartPointer<const Self>                                 ConstPointer;
 
   /** Runtime information support. */
-  itkTypeMacro(NonLocalSuperresolutionImageFilter, NonLocalPatchBasedImageFilter);
+  itkOverrideGetNameOfClassMacro(NonLocalSuperresolutionImageFilter);
 
   /** Standard New method. */
   itkNewMacro(Self);

--- a/Utilities/itkNonLocalSuperresolutionImageFilter.h
+++ b/Utilities/itkNonLocalSuperresolutionImageFilter.h
@@ -64,7 +64,7 @@ public:
   itkNewMacro(Self);
 
   /** ImageDimension constants */
-  itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
   /** Some convenient typedefs. */
   typedef TInputImage                            InputImageType;

--- a/Utilities/itkOptimalSharpeningImageFilter.h
+++ b/Utilities/itkOptimalSharpeningImageFilter.h
@@ -68,7 +68,7 @@ public:
   typedef SmartPointer<const Self> ConstPointer;
 
   /** Run-time type information (and related methods)  */
-  itkTypeMacro(OptimalSharpeningImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(OptimalSharpeningImageFilter);
 
   /** Method for creation through the object factory.  */
   itkNewMacro(Self);

--- a/Utilities/itkOptimalSharpeningImageFilter.h
+++ b/Utilities/itkOptimalSharpeningImageFilter.h
@@ -56,7 +56,7 @@ public:
   typedef typename NumericTraits<OutputPixelType>::RealType RealType;
   typedef typename TInputImage::PixelType                   InputPixelType;
   typedef typename TInputImage::InternalPixelType           InputInternalPixelType;
-  itkStaticConstMacro(ImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 
   /** Image typedef support. */
   typedef TInputImage                      InputImageType;

--- a/Utilities/itkPointSetFunction.h
+++ b/Utilities/itkPointSetFunction.h
@@ -61,7 +61,7 @@ public:
   typedef SmartPointer<const Self>                                  ConstPointer;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(PointSetFunction, FunctionBase);
+  itkOverrideGetNameOfClassMacro(PointSetFunction);
 
   /** InputPointSetType typedef support. */
   typedef TInputPointSet InputPointSetType;

--- a/Utilities/itkPointSetFunction.h
+++ b/Utilities/itkPointSetFunction.h
@@ -52,7 +52,7 @@ class PointSetFunction : public FunctionBase<typename TInputPointSet::PointType,
 {
 public:
   /** Dimension underlying input point set. */
-  itkStaticConstMacro(Dimension, unsigned int, TInputPointSet::PointDimension);
+  static constexpr unsigned int Dimension = TInputPointSet::PointDimension;
 
   /** Standard class typedefs. */
   typedef PointSetFunction                                          Self;

--- a/Utilities/itkPointSetFunction.h
+++ b/Utilities/itkPointSetFunction.h
@@ -76,8 +76,8 @@ public:
   /** OutputType typedef support. */
   typedef TOutput OutputType;
 
-  /** CoordRepType typedef support. */
-  typedef TCoordRep CoordRepType;
+  /** CoordinateType typedef support. */
+  typedef TCoordRep CoordinateType;
 
   /** Set the input point set.
    * \warning this method caches BufferedRegion information.

--- a/Utilities/itkPseudoContinuousArterialSpinLabeledCerebralBloodFlowImageFilter.h
+++ b/Utilities/itkPseudoContinuousArterialSpinLabeledCerebralBloodFlowImageFilter.h
@@ -75,9 +75,9 @@ public:
   typedef typename ReferenceImageType::RegionType ReferenceImageRegionType;
 
   /** Compiler can't inherit ImageDimension enumeration? */
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(OutputImageDimension, unsigned int, TOutputImage::ImageDimension);
-  itkStaticConstMacro(ReferenceImageDimension, unsigned int, TReferenceImage::ImageDimension);
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+  static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
+  static constexpr unsigned int ReferenceImageDimension = TReferenceImage::ImageDimension;
 
   itkGetMacro(TI1, float);
   itkSetMacro(TI1, float);

--- a/Utilities/itkPseudoContinuousArterialSpinLabeledCerebralBloodFlowImageFilter.h
+++ b/Utilities/itkPseudoContinuousArterialSpinLabeledCerebralBloodFlowImageFilter.h
@@ -61,7 +61,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(PseudoContinuousArterialSpinLabeledCerebralBloodFlowImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(PseudoContinuousArterialSpinLabeledCerebralBloodFlowImageFilter);
 
   /** Compiler can't inherit typedef? */
   typedef TInputImage                             InputImageType;

--- a/Utilities/itkPulsedArterialSpinLabeledCerebralBloodFlowImageFilter.h
+++ b/Utilities/itkPulsedArterialSpinLabeledCerebralBloodFlowImageFilter.h
@@ -74,9 +74,9 @@ public:
   typedef typename ReferenceImageType::RegionType ReferenceImageRegionType;
 
   /** Compiler can't inherit ImageDimension enumeration? */
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(OutputImageDimension, unsigned int, TOutputImage::ImageDimension);
-  itkStaticConstMacro(ReferenceImageDimension, unsigned int, TReferenceImage::ImageDimension);
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+  static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
+  static constexpr unsigned int ReferenceImageDimension = TReferenceImage::ImageDimension;
 
   itkGetMacro(TI1, float);
   itkSetMacro(TI1, float);

--- a/Utilities/itkPulsedArterialSpinLabeledCerebralBloodFlowImageFilter.h
+++ b/Utilities/itkPulsedArterialSpinLabeledCerebralBloodFlowImageFilter.h
@@ -60,7 +60,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(PulsedArterialSpinLabeledCerebralBloodFlowImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(PulsedArterialSpinLabeledCerebralBloodFlowImageFilter);
 
   /** Compiler can't inherit typedef? */
   typedef TInputImage                             InputImageType;

--- a/Utilities/itkSimulatedBSplineDisplacementFieldSource.h
+++ b/Utilities/itkSimulatedBSplineDisplacementFieldSource.h
@@ -54,7 +54,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SimulatedBSplineDisplacementFieldSource, SimulatedDisplacementFieldSource);
+  itkOverrideGetNameOfClassMacro(SimulatedBSplineDisplacementFieldSource);
 
   /** Number of dimensions */
   static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;

--- a/Utilities/itkSimulatedDisplacementFieldSource.h
+++ b/Utilities/itkSimulatedDisplacementFieldSource.h
@@ -54,7 +54,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SimulatedDisplacementFieldSource, ImageSource);
+  itkOverrideGetNameOfClassMacro(SimulatedDisplacementFieldSource);
 
   /** Number of dimensions. */
   static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;

--- a/Utilities/itkSimulatedExponentialDisplacementFieldSource.h
+++ b/Utilities/itkSimulatedExponentialDisplacementFieldSource.h
@@ -53,7 +53,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SimulatedExponentialDisplacementFieldSource, SimulatedDisplacementFieldSource);
+  itkOverrideGetNameOfClassMacro(SimulatedExponentialDisplacementFieldSource);
 
   /** Number of dimensions */
   static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;

--- a/Utilities/itkSliceTimingCorrectionImageFilter.h
+++ b/Utilities/itkSliceTimingCorrectionImageFilter.h
@@ -74,8 +74,8 @@ public:
   typedef double TimingType;
 
   /** Compiler can't inherit ImageDimension enumeration? */
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(OutputImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+  static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
   itkGetMacro(TimeDimension, unsigned int);
   itkSetMacro(TimeDimension, unsigned int);

--- a/Utilities/itkSliceTimingCorrectionImageFilter.h
+++ b/Utilities/itkSliceTimingCorrectionImageFilter.h
@@ -54,7 +54,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SliceTimingCorrectionImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(SliceTimingCorrectionImageFilter);
 
   /** Compiler can't inherit typedef? */
   typedef typename Superclass::InputImageType  InputImageType;

--- a/Utilities/itkSplitAlternatingTimeSeriesImageFilter.h
+++ b/Utilities/itkSplitAlternatingTimeSeriesImageFilter.h
@@ -60,7 +60,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SplitAlternatingTimeSeriesImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(SplitAlternatingTimeSeriesImageFilter);
 
   /** Compiler can't inherit typedef? */
   typedef typename Superclass::InputImageType  InputImageType;

--- a/Utilities/itkSplitAlternatingTimeSeriesImageFilter.h
+++ b/Utilities/itkSplitAlternatingTimeSeriesImageFilter.h
@@ -71,8 +71,8 @@ public:
   typedef typename OutputImageType::RegionType OutputImageRegionType;
 
   /** Compiler can't inherit ImageDimension enumeration? */
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(OutputImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+  static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */

--- a/Utilities/itkSurfaceCurvatureBase.h
+++ b/Utilities/itkSurfaceCurvatureBase.h
@@ -47,7 +47,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SurfaceCurvatureBase, ProcessObject);
+  itkOverrideGetNameOfClassMacro(SurfaceCurvatureBase);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Utilities/itkSurfaceImageCurvature.h
+++ b/Utilities/itkSurfaceImageCurvature.h
@@ -41,7 +41,7 @@ public:
   typedef SmartPointer<const Self>       ConstPointer;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SurfaceImageCurvature, SurfaceCurvatureBase);
+  itkOverrideGetNameOfClassMacro(SurfaceImageCurvature);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Utilities/itkSurfaceImageCurvature.h
+++ b/Utilities/itkSurfaceImageCurvature.h
@@ -52,7 +52,7 @@ public:
   {
     ImageDimension = TSurface::ImageDimension
   };
-  typedef Image<PixelType, itkGetStaticConstMacro(ImageDimension)> ImageType;
+  typedef Image<PixelType, Self::ImageDimension> ImageType;
   typedef typename ImageType::IndexType                            IndexType;
   typedef typename ImageType::SpacingType                          SpacingType;
   typedef typename ImageType::SizeType                             SizeType;
@@ -67,16 +67,16 @@ public:
   typedef typename Superclass::MatrixType MatrixType;
   typedef typename ImageType::PointType   ImagePointType;
 
-  typedef Image<PixelType, itkGetStaticConstMacro(ImageDimension)> OutputImageType;
+  typedef Image<PixelType, Self::ImageDimension> OutputImageType;
   typedef ImageRegionIteratorWithIndex<OutputImageType>            OutputImageIteratorType;
 
   typedef typename OutputImageType::Pointer OutputImagePointer;
 
-  typedef Image<MatrixType, itkGetStaticConstMacro(ImageDimension)> FrameImageType;
+  typedef Image<MatrixType, Self::ImageDimension> FrameImageType;
 
   /** Gradient filtering */
-  typedef CovariantVector<RealType, itkGetStaticConstMacro(ImageDimension)>        GradientPixelType;
-  typedef Image<GradientPixelType, itkGetStaticConstMacro(ImageDimension)>         GradientImageType;
+  typedef CovariantVector<RealType, Self::ImageDimension>        GradientPixelType;
+  typedef Image<GradientPixelType, Self::ImageDimension>         GradientImageType;
   typedef itk::VectorLinearInterpolateImageFunction<GradientImageType, RealType>   VectorInterpolatorType;
   typedef SmartPointer<GradientImageType>                                          GradientImagePointer;
   typedef GradientRecursiveGaussianImageFilter<OutputImageType, GradientImageType> GradientImageFilterType;

--- a/Utilities/itkSurfaceMeshCurvature.h
+++ b/Utilities/itkSurfaceMeshCurvature.h
@@ -36,7 +36,7 @@ public:
   typedef SmartPointer<const Self>       ConstPointer;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SurfaceMeshCurvature, SurfaceCurvatureBase);
+  itkOverrideGetNameOfClassMacro(SurfaceMeshCurvature);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Utilities/itkVectorFieldGradientImageFunction.h
+++ b/Utilities/itkVectorFieldGradientImageFunction.h
@@ -50,10 +50,10 @@ public:
   typedef typename Superclass::ContinuousIndexType ContinuousIndexType;
 
   /** The dimensionality of the input and output images. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TInputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
   /** Length of the vector pixel type of the input image. */
-  itkStaticConstMacro(VectorDimension, unsigned int, VectorType::Dimension);
+  static constexpr unsigned int VectorDimension = VectorType::Dimension;
 
   /** Define the data type and the vector of data type used in calculations. */
   typedef TRealType RealType;

--- a/Utilities/itkVectorFieldGradientImageFunction.h
+++ b/Utilities/itkVectorFieldGradientImageFunction.h
@@ -36,7 +36,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(VectorFieldGradientImageFunction, ImageFunction);
+  itkOverrideGetNameOfClassMacro(VectorFieldGradientImageFunction);
 
   /** Extract some information from the image types.  Dimensionality
    * of the two images is assumed to be the same. */

--- a/Utilities/itkVectorGaussianInterpolateImageFunction.h
+++ b/Utilities/itkVectorGaussianInterpolateImageFunction.h
@@ -42,7 +42,7 @@ public:
   typedef SmartPointer<const Self>                         ConstPointer;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VectorGaussianInterpolateImageFunction, InterpolateImageFunction);
+  itkOverrideGetNameOfClassMacro(VectorGaussianInterpolateImageFunction);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/Utilities/itkVectorImageFileReader.h
+++ b/Utilities/itkVectorImageFileReader.h
@@ -28,7 +28,7 @@ class VectorImageFileReaderException : public ExceptionObject
 {
 public:
   /** Run-time information. */
-  itkTypeMacro(VectorImageFileReaderException, ExceptionObject);
+  itkOverrideGetNameOfClassMacro(VectorImageFileReaderException);
 
   /** Constructor. */
   VectorImageFileReaderException(const char * file,
@@ -92,7 +92,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VectorImageFileReader, ImageSource);
+  itkOverrideGetNameOfClassMacro(VectorImageFileReader);
 
   /** Image types */
   typedef typename TImage::RegionType        ImageRegionType;

--- a/Utilities/itkVectorImageFileWriter.h
+++ b/Utilities/itkVectorImageFileWriter.h
@@ -29,7 +29,7 @@ class VectorImageFileWriterException : public ExceptionObject
 {
 public:
   /** Run-time information. */
-  itkTypeMacro(VectorImageFileWriterException, ExceptionObject);
+  itkOverrideGetNameOfClassMacro(VectorImageFileWriterException);
 
   /** Constructor. */
   VectorImageFileWriterException(const char * file,
@@ -71,7 +71,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(VectorImageFileWriter, VectorImageFileWriter);
+  itkOverrideGetNameOfClassMacro(VectorImageFileWriter);
 
   /** Some convenient typedefs. */
   typedef TVectorImage                         VectorImageType;

--- a/Utilities/itkWarpImageMultiTransformFilter.h
+++ b/Utilities/itkWarpImageMultiTransformFilter.h
@@ -99,7 +99,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(WarpImageMultiTransformFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(WarpImageMultiTransformFilter);
 
   /** Typedef to describe the output image region type. */
   typedef typename TOutputImage::RegionType OutputImageRegionType;

--- a/Utilities/itkWarpImageMultiTransformFilter.h
+++ b/Utilities/itkWarpImageMultiTransformFilter.h
@@ -135,16 +135,16 @@ public:
   typedef typename TransformType::Pointer TransformTypePointer;
 
   /** Interpolator typedef support. */
-  typedef double                                                                      CoordRepType;
-  typedef InterpolateImageFunction<InputImageType, CoordRepType>                      InterpolatorType;
+  typedef double                                                                      CoordinateType;
+  typedef InterpolateImageFunction<InputImageType, CoordinateType>                      InterpolatorType;
   typedef typename InterpolatorType::Pointer                                          InterpolatorPointer;
-  typedef LinearInterpolateImageFunction<InputImageType, CoordRepType>                DefaultInterpolatorType;
-  typedef VectorLinearInterpolateImageFunction<DisplacementFieldType, CoordRepType>   DefaultVectorInterpolatorType;
-  typedef VectorGaussianInterpolateImageFunction<DisplacementFieldType, CoordRepType> DefaultVectorInterpolatorType2;
+  typedef LinearInterpolateImageFunction<InputImageType, CoordinateType>                DefaultInterpolatorType;
+  typedef VectorLinearInterpolateImageFunction<DisplacementFieldType, CoordinateType>   DefaultVectorInterpolatorType;
+  typedef VectorGaussianInterpolateImageFunction<DisplacementFieldType, CoordinateType> DefaultVectorInterpolatorType2;
   typedef typename DefaultVectorInterpolatorType::Pointer                             VectorInterpolatorPointer;
 
   /** Point type */
-  typedef Point<CoordRepType, Self::ImageDimension> PointType;
+  typedef Point<CoordinateType, Self::ImageDimension> PointType;
 
   typedef struct _DeformationTypeEx
   {

--- a/Utilities/itkWarpImageMultiTransformFilter.h
+++ b/Utilities/itkWarpImageMultiTransformFilter.h
@@ -117,12 +117,12 @@ public:
   typedef typename OutputImageType::DirectionType     DirectionType;
 
   /** Determine the image dimension. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TOutputImage::ImageDimension);
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(DisplacementFieldDimension, unsigned int, TDisplacementField::ImageDimension);
+  static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+  static constexpr unsigned int DisplacementFieldDimension = TDisplacementField::ImageDimension;
 
   /** base type for images of the current ImageDimension */
-  typedef ImageBase<itkGetStaticConstMacro(ImageDimension)> ImageBaseType;
+  typedef ImageBase<Self::ImageDimension> ImageBaseType;
 
   /** Deformation field typedef support. */
   typedef TDisplacementField                        DisplacementFieldType;
@@ -144,7 +144,7 @@ public:
   typedef typename DefaultVectorInterpolatorType::Pointer                             VectorInterpolatorPointer;
 
   /** Point type */
-  typedef Point<CoordRepType, itkGetStaticConstMacro(ImageDimension)> PointType;
+  typedef Point<CoordRepType, Self::ImageDimension> PointType;
 
   typedef struct _DeformationTypeEx
   {

--- a/Utilities/itkWarpImageWAffineFilter.h
+++ b/Utilities/itkWarpImageWAffineFilter.h
@@ -125,13 +125,13 @@ public:
   typedef typename TransformType::Pointer TransformTypePointer;
 
   /** Interpolator typedef support. */
-  typedef double                                                       CoordRepType;
-  typedef InterpolateImageFunction<InputImageType, CoordRepType>       InterpolatorType;
+  typedef double                                                       CoordinateType;
+  typedef InterpolateImageFunction<InputImageType, CoordinateType>       InterpolatorType;
   typedef typename InterpolatorType::Pointer                           InterpolatorPointer;
-  typedef LinearInterpolateImageFunction<InputImageType, CoordRepType> DefaultInterpolatorType;
+  typedef LinearInterpolateImageFunction<InputImageType, CoordinateType> DefaultInterpolatorType;
 
   /** Point type */
-  typedef Point<CoordRepType, Self::ImageDimension> PointType;
+  typedef Point<CoordinateType, Self::ImageDimension> PointType;
 
   /** Set the deformation field. */
   void

--- a/Utilities/itkWarpImageWAffineFilter.h
+++ b/Utilities/itkWarpImageWAffineFilter.h
@@ -111,9 +111,9 @@ public:
   typedef typename OutputImageType::SpacingType       SpacingType;
 
   /** Determine the image dimension. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TOutputImage::ImageDimension);
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(DisplacementFieldDimension, unsigned int, TDisplacementField::ImageDimension);
+  static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+  static constexpr unsigned int DisplacementFieldDimension = TDisplacementField::ImageDimension;
 
   /** Deformation field typedef support. */
   typedef TDisplacementField                        DisplacementFieldType;
@@ -131,7 +131,7 @@ public:
   typedef LinearInterpolateImageFunction<InputImageType, CoordRepType> DefaultInterpolatorType;
 
   /** Point type */
-  typedef Point<CoordRepType, itkGetStaticConstMacro(ImageDimension)> PointType;
+  typedef Point<CoordRepType, Self::ImageDimension> PointType;
 
   /** Set the deformation field. */
   void

--- a/Utilities/itkWarpImageWAffineFilter.h
+++ b/Utilities/itkWarpImageWAffineFilter.h
@@ -94,7 +94,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(WarpImageWAffineFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(WarpImageWAffineFilter);
 
   /** Typedef to describe the output image region type. */
   typedef typename TOutputImage::RegionType OutputImageRegionType;

--- a/Utilities/itkWarpTensorImageMultiTransformFilter.h
+++ b/Utilities/itkWarpTensorImageMultiTransformFilter.h
@@ -116,9 +116,9 @@ public:
   typedef typename OutputImageType::DirectionType     DirectionType;
 
   /** Determine the image dimension. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TOutputImage::ImageDimension);
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(DisplacementFieldDimension, unsigned int, TDisplacementField::ImageDimension);
+  static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+  static constexpr unsigned int DisplacementFieldDimension = TDisplacementField::ImageDimension;
 
   /** Deformation field typedef support. */
   typedef TDisplacementField                        DisplacementFieldType;
@@ -139,7 +139,7 @@ public:
   typedef typename DefaultVectorInterpolatorType::Pointer                           VectorInterpolatorPointer;
 
   /** Point type */
-  typedef Point<CoordRepType, itkGetStaticConstMacro(ImageDimension)> PointType;
+  typedef Point<CoordRepType, Self::ImageDimension> PointType;
 
   typedef struct _DeformationTypeEx
   {

--- a/Utilities/itkWarpTensorImageMultiTransformFilter.h
+++ b/Utilities/itkWarpTensorImageMultiTransformFilter.h
@@ -98,7 +98,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods) */
-  itkTypeMacro(WarpTensorImageMultiTransformFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(WarpTensorImageMultiTransformFilter);
 
   /** Typedef to describe the output image region type. */
   typedef typename TOutputImage::RegionType OutputImageRegionType;

--- a/Utilities/itkWarpTensorImageMultiTransformFilter.h
+++ b/Utilities/itkWarpTensorImageMultiTransformFilter.h
@@ -131,15 +131,15 @@ public:
   typedef typename TransformType::Pointer TransformTypePointer;
 
   /** Interpolator typedef support. */
-  typedef double                                                                    CoordRepType;
-  typedef VectorInterpolateImageFunction<InputImageType, CoordRepType>              InterpolatorType;
+  typedef double                                                                    CoordinateType;
+  typedef VectorInterpolateImageFunction<InputImageType, CoordinateType>              InterpolatorType;
   typedef typename InterpolatorType::Pointer                                        InterpolatorPointer;
-  typedef VectorLinearInterpolateImageFunction<InputImageType, CoordRepType>        DefaultInterpolatorType;
-  typedef VectorLinearInterpolateImageFunction<DisplacementFieldType, CoordRepType> DefaultVectorInterpolatorType;
+  typedef VectorLinearInterpolateImageFunction<InputImageType, CoordinateType>        DefaultInterpolatorType;
+  typedef VectorLinearInterpolateImageFunction<DisplacementFieldType, CoordinateType> DefaultVectorInterpolatorType;
   typedef typename DefaultVectorInterpolatorType::Pointer                           VectorInterpolatorPointer;
 
   /** Point type */
-  typedef Point<CoordRepType, Self::ImageDimension> PointType;
+  typedef Point<CoordinateType, Self::ImageDimension> PointType;
 
   typedef struct _DeformationTypeEx
   {


### PR DESCRIPTION
This is most appropriate for ITKv6.  It is supported after ITKv5.4.2, but not much before.

- **STYLE: Add itkVirtualGetNameOfClassMacro + itkOverrideGetNameOfClassMacro**
- **STYLE: Replace itkStaticConstMacro with static constexpr**
- **STYLE: CoordRepType -> CoordinateType code readability**
