### PR TITLE
ENH: use prefix of 1st param from --output for --write-interval-volumes

### DIFF
--- a/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
+++ b/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
@@ -173,6 +173,12 @@ public:
   itkSetMacro(CurrentStageNumber, unsigned int);
 
   void
+  SetOutputPrefix(const std::string & outputPrefix)
+  {
+    this->m_OutputPrefix = outputPrefix;
+  }
+
+  void
   SetNumberOfIterations(const std::vector<unsigned int> & iterations)
   {
     this->m_NumberOfIterations = iterations;
@@ -382,7 +388,7 @@ public:
 
     // write the results to the disk
     std::stringstream currentFileName;
-    currentFileName << "Stage" << this->m_CurrentStageNumber + 1 << "_level" << this->m_CurrentLevel;
+    currentFileName << this->m_OutputPrefix << "Stage" << this->m_CurrentStageNumber + 1 << "_level" << this->m_CurrentLevel;
     /*
     The name arrangement of written files are important to us.
     To prevent: "Iter1 Iter10 Iter2 Iter20" we use the following style.
@@ -439,6 +445,7 @@ private:
    */
   itk::WeakPointer<OptimizerType> m_Optimizer;
 
+  std::string                       m_OutputPrefix;
   std::vector<unsigned int>         m_NumberOfIterations;
   std::ostream *                    m_LogStream;
   itk::TimeProbe                    m_clock;

--- a/Examples/antsRegistrationTemplateHeader.h
+++ b/Examples/antsRegistrationTemplateHeader.h
@@ -931,6 +931,7 @@ DoRegistration(typename ParserType::Pointer & parser)
   }
 
   // set the vector-vector parameters accumulated
+  regHelper->SetOutputPrefix(outputPrefix);
   regHelper->SetIterations(iterationList);
   regHelper->SetRestrictDeformationOptimizerWeights(restrictDeformationWeightsList);
   regHelper->SetConvergenceWindowSizes(convergenceWindowSizeList);

--- a/Examples/itkantsRegistrationHelper.h
+++ b/Examples/itkantsRegistrationHelper.h
@@ -677,6 +677,11 @@ public:
                                  std::vector<unsigned int> & VelocityFieldMeshSizeAtBaseLevel,
                                  unsigned int                NumberOfIntegrationSteps,
                                  unsigned int                SplineOrder);
+  /**
+   * Add the collected output prefix
+   */
+  void
+  SetOutputPrefix(const std::string & outputPrefix);
 
   /**
    * Add the collected iterations list
@@ -1102,6 +1107,7 @@ private:
   unsigned int                           m_NumberOfStages;
   MetricListType                         m_Metrics;
   TransformMethodListType                m_TransformMethods;
+  std::string                            m_OutputPrefix;
   std::vector<std::vector<unsigned int>> m_Iterations;
   std::vector<RealType>                  m_ConvergenceThresholds;
   std::vector<unsigned int>              m_ConvergenceWindowSizes;

--- a/Examples/itkantsRegistrationHelper.hxx
+++ b/Examples/itkantsRegistrationHelper.hxx
@@ -47,6 +47,7 @@ RegistrationHelper<TComputeType, VImageDimension>::RegistrationHelper()
   , m_NumberOfStages(0)
   , m_Metrics()
   , m_TransformMethods()
+  , m_OutputPrefix()
   , m_Iterations()
   , m_SmoothingSigmas()
   , m_RestrictDeformationOptimizerWeights()
@@ -524,6 +525,14 @@ RegistrationHelper<TComputeType, VImageDimension>::AddBSplineExponentialTransfor
   init.m_NumberOfTimeIndices = NumberOfIntegrationSteps;
 
   this->m_TransformMethods.push_back(init);
+}
+
+template <typename TComputeType, unsigned VImageDimension>
+void
+RegistrationHelper<TComputeType, VImageDimension>::SetOutputPrefix(
+  const std::string & OutputPrefix)
+{
+  this->m_OutputPrefix = OutputPrefix;
 }
 
 template <typename TComputeType, unsigned VImageDimension>
@@ -1373,6 +1382,7 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
     optimizerObserver->SetLogStream(*this->m_LogStream);
     optimizerObserver->SetNumberOfIterations(currentStageIterations);
     optimizerObserver->SetOptimizer(optimizer);
+    optimizerObserver->SetOutputPrefix(this->m_OutputPrefix);
 
     if (!this->IsPointSetMetric(this->m_Metrics[0].m_MetricType))
     {


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your
pull request.

We welcome contributions to ANTs. Pull requests will be reviewed by the
developers and if accepted, become part of ANTs, distributed under the license
terms in COPYING.txt.

Please title your PR according to what it does:
ENH: new or improved functionality
PERF: performance enhancements to existing functionality
BUG: fixing a run time bug
COMP: relating to compilation
DOC: documentation changes
WIP: work in progress, needs further commits to be ready
-->

# Description
This PR changes the behavior of `--write-interval-volume` to use the prefix of the first parameter from `--output` as the write location, instead of `$PWD`.

Fixes #1836 
<!--
Extended description of your PR.

If the PR can close an existing issue, you can say "Fixes #1234" or "Resolves
#1234". Otherwise you can say something like "Related to #1234".
-->


