### PR TITLE
Write composite transforms from antsApplyTransforms

### DIFF
--- a/Examples/CompositeTransformUtil.cxx
+++ b/Examples/CompositeTransformUtil.cxx
@@ -40,7 +40,12 @@ PrintGenericUsageStatement()
             << " <transform name prefix>" << std::endl
             << "or" << std::endl
             << "CompositeTransformUtil  --assemble <CompositeTransform> "
-            << "<transform 1> <transform 2 > ... <transform N>" << std::endl;
+            << "<transform 1> <transform 2 > ... <transform N>" << std::endl
+            << std::endl
+            << "Note: correct ordering of transforms differs from the command line order" << std::endl
+            << "in calls to antsApplyTransforms. You can now use antsApplyTransforms to produce" << std::endl
+            << "composite transforms directly, see its usage for the '--output' option."
+            << std::endl;
 }
 
 /**

--- a/Examples/antsApplyTransforms.cxx
+++ b/Examples/antsApplyTransforms.cxx
@@ -32,6 +32,8 @@
 #include "itkLabelImageGaussianInterpolateImageFunction.h"
 #include "itkLabelImageGenericInterpolateImageFunction.h"
 
+#include "itksys/SystemTools.hxx"
+
 namespace ants
 {
 template <typename TensorImageType, typename ImageType>
@@ -318,7 +320,7 @@ antsApplyTransforms(itk::ants::CommandLineParser::Pointer & parser, unsigned int
       // can only check files, so skip checks if using a pointer in ANTsR / ANTsPy
       if (verbose)
       {
-        std::cout << "Could not create ImageIO for the input file, assuming dimension = " << Dimension <<
+        std::cout << "Input is not a file, assuming dimension = " << Dimension <<
             " and scalar pixel type" << std::endl;
       }
     }
@@ -406,13 +408,28 @@ antsApplyTransforms(itk::ants::CommandLineParser::Pointer & parser, unsigned int
    * Reference image option
    */
   bool needReferenceImage = true;
+
   if (outputOption && outputOption->GetNumberOfFunctions())
   {
     std::string outputOptionName = outputOption->GetFunction(0)->GetName();
     ConvertToLowerCase(outputOptionName);
-    if (!std::strcmp(outputOptionName.c_str(), "linear"))
+
+    // Check if the function name matches keywords requiring no reference image
+    if (outputOptionName == "linear" || outputOptionName == "compositetransform")
     {
-      needReferenceImage = false;
+        if (outputOption->GetFunction(0)->GetNumberOfParameters() > 0)
+        {
+            needReferenceImage = false;
+        }
+        else
+        {
+          // no output parameter where we need one
+          if (verbose)
+          {
+            std::cerr << "An output parameter is required with -o Linear or -o CompositeTransform, see usage" << std::endl;
+          }
+          return EXIT_FAILURE;
+        }
     }
   }
 
@@ -646,15 +663,31 @@ antsApplyTransforms(itk::ants::CommandLineParser::Pointer & parser, unsigned int
         {
           transformWriter->SetInput(transform);
         }
-#if ITK_VERSION_MAJOR >= 5
+        // Use compression just to be consistent
         transformWriter->SetUseCompression(true);
-#endif
         transformWriter->Update();
       }
     }
-    else if (outputOption->GetFunction(0)->GetNumberOfParameters() > 1 &&
-             parser->Convert<unsigned int>(outputOption->GetFunction(0)->GetParameter(1)) != 0)
+    else if (!std::strcmp(outputOptionName.c_str(), "compositetransform"))
     {
+      // above should match -o [ compositeTransform.ext, 0 ] or the preferred -o CompositeTransform[output.ext]
+      if (verbose)
+      {
+        std::cout << "Output composite transform: " << outputOption->GetFunction(0)->GetParameter(0) << std::endl;
+      }
+
+      using TransformWriterType = itk::TransformFileWriterTemplate<T>;
+      typename TransformWriterType::Pointer transformWriter = TransformWriterType::New();
+      transformWriter->SetFileName((outputOption->GetFunction(0)->GetParameter(0)).c_str());
+      transformWriter->SetInput(compositeTransform);
+      transformWriter->SetUseCompression(true);
+      transformWriter->Update();
+    }
+    else if ((!std::strcmp(outputOptionName.c_str(), "compositedisplacementfield") ||
+                (outputOption->GetFunction(0)->GetNumberOfParameters() > 1 &&
+                    parser->Convert<unsigned int>(outputOption->GetFunction(0)->GetParameter(1)) != 0)))
+    {
+      // above should match -o [ compositeDisplacement.ext, 1 ] or the preferred -o CompositeDisplacementField[output.ext]
       if (verbose)
       {
         std::cout << "Output composite transform displacement field: " << outputOption->GetFunction(0)->GetParameter(0)
@@ -672,9 +705,12 @@ antsApplyTransforms(itk::ants::CommandLineParser::Pointer & parser, unsigned int
       converter->Update();
 
       if ((itksys::SystemTools::GetFilenameLastExtension(outputOption->GetFunction(0)->GetParameter(0)) == ".h5") ||
-          (itksys::SystemTools::GetFilenameLastExtension(outputOption->GetFunction(0)->GetParameter(0)) == ".hdf5"))
+          (itksys::SystemTools::GetFilenameLastExtension(outputOption->GetFunction(0)->GetParameter(0)) == ".hdf5") ||
+          (itksys::SystemTools::GetFilenameLastExtension(outputOption->GetFunction(0)->GetParameter(0)) == ".xfm"))
       {
-        // HDF5 transforms must be written by a TransformFileWriter to be valid ITK transforms
+        // unlike NIFTI images, xfm or hdf5 files must be written with a transform writer
+        // Note here we are just outputing a single combined displacement field as an hdf5 file, not the full composite
+        // transform with its components stored separately
         using DisplacementFieldTransformType = itk::DisplacementFieldTransform<RealType, Dimension>;
         typename DisplacementFieldTransformType::Pointer compositeDisplacementTransform = DisplacementFieldTransformType::New();
         compositeDisplacementTransform->SetDisplacementField(converter->GetOutput());
@@ -682,11 +718,13 @@ antsApplyTransforms(itk::ants::CommandLineParser::Pointer & parser, unsigned int
         using TransformWriterType = itk::TransformFileWriterTemplate<RealType>;
         typename TransformWriterType::Pointer transformWriter = TransformWriterType::New();
         transformWriter->SetFileName((outputOption->GetFunction(0)->GetParameter(0)).c_str());
+        transformWriter->SetUseCompression(true);
         transformWriter->SetInput(compositeDisplacementTransform);
         transformWriter->Update();
       }
       else
       {
+        // write as a vector image
         using DisplacementFieldWriterType = itk::ImageFileWriter<DisplacementFieldType>;
         typename DisplacementFieldWriterType::Pointer displacementFieldWriter = DisplacementFieldWriterType::New();
         displacementFieldWriter->SetInput(converter->GetOutput());
@@ -987,18 +1025,26 @@ antsApplyTransformsInitializeCommandLineOptions(itk::ants::CommandLineParser * p
   }
 
   {
-    std::string description = std::string("One can either output the warped image or, if the boolean ") +
-                              std::string("is set, one can print out the displacement field based on the ") +
-                              std::string("composite transform and the reference image.  A third option ") +
-                              std::string("is to compose all affine transforms and (if boolean is set) ") +
-                              std::string("calculate its inverse which is then written to an ITK file. ");
+    std::string description =
+        "One can either output a warped image, or the composite transform containing all input transforms, or a collapsed "
+        "affine or displacement field created from the input transforms. "
+        "If all input transforms are linear, they can be collapsed and (if boolean is set) inverted, then written to "
+        "an ITK transform file. "
+        "If the input transforms contain displacement fields, they can be collapsed into a single displacement field with "
+        "CompositeDisplacementField[compositeDFFileName]. This replaces the usage '-o [compositeDFFileName, 1]', which is "
+        "deprecated but still allowed for backwards compatibility. "
+        "To write a non-collapsed composite transform, use CompositeTransform[compositeTransform.h5].  The output file will "
+        "contain all the individual transforms.";
 
     OptionType::Pointer option = OptionType::New();
     option->SetLongName("output");
     option->SetShortName('o');
     option->SetUsageOption(0, "warpedOutputFileName");
-    option->SetUsageOption(1, "[warpedOutputFileName or compositeDisplacementField,<printOutCompositeWarpFile=0>]");
-    option->SetUsageOption(2, "Linear[genericAffineTransformFile,<calculateInverse=0>]");
+    option->SetUsageOption(1, "CompositeDisplacementField[compositeDFFileName]");
+    option->SetUsageOption(2, "CompositeTransform[compositeTransformFileName]");
+    option->SetUsageOption(3, "Linear[compositeAffine.mat, invert=0]");
+    option->SetUsageOption(4, "[compositeDisplacementField,1]");
+
     option->SetDescription(description);
     parser->AddOption(option);
   }
@@ -1237,12 +1283,6 @@ antsApplyTransforms(std::vector<std::string> args, std::ostream * /*out_stream =
   }
 
   unsigned int dimension = 3;
-
-  // BA - code below creates problems in ANTsR
-  //  itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-  //                                                            filename.c_str(),
-  //                                                            itk::ImageIOFactory::FileModeType::ReadMode );
-  //  dimension = imageIO->GetNumberOfDimensions();
 
   itk::ants::CommandLineParser::OptionType::Pointer dimOption = parser->GetOption("dimensionality");
   if (dimOption && dimOption->GetNumberOfFunctions())

--- a/Examples/antsApplyTransforms.cxx
+++ b/Examples/antsApplyTransforms.cxx
@@ -1042,15 +1042,15 @@ antsApplyTransformsInitializeCommandLineOptions(itk::ants::CommandLineParser * p
 
   {
     std::string description =
-        "One can either output a warped image, or the composite transform containing all input transforms, or a collapsed "
-        "affine or displacement field created from the input transforms. "
+        "The default output is the warped input image, resliced into the space of the reference image. Alternatively, one "
+        "can output the composite transform containing all input transforms, or a collapsed affine or displacement field "
+        "created from the input transforms. "
         "If all input transforms are linear, they can be collapsed and (if boolean is set) inverted, then written to "
         "an ITK transform file. "
         "If the input transforms contain displacement fields, they can be collapsed into a single displacement field with "
         "DisplacementField[collapsedDFFileName]. This replaces the usage '-o [collapsedDFFileName, 1]', which is "
         "deprecated but still allowed for backwards compatibility. "
-        "To write a non-collapsed composite transform, use CompositeTransform[compositeTransform.h5].  The output file will "
-        "contain all the individual transforms.";
+        "To write a non-collapsed composite transform, use CompositeTransform[compositeTransform.h5].";
 
     OptionType::Pointer option = OptionType::New();
     option->SetLongName("output");


### PR DESCRIPTION
antsApplyTransforms only allowed users to collapse linear transforms into a single .mat file, or composite transforms into a single displacement field.

Now allow users to write the full composite transform. This enables users familiar with `antsApplyTransforms` to write out composite transforms by specifying the components in the order they are applied when warping images. That is, one can call `antsApplyTransforms -o warpedImage` and then `antsApplyTransforms -o CompositeTransform[composite.h5]` without changing the `-t` options.

The motivation is to make it easier to write composite transforms, since CompositeTransformUtil requires users to use the internal "reverse queue order" of itkCompositeTransform.

The changes are backwards compatible, but I have noted in the usage that we prefer

`-o DisplacementField[ field.ext ]`

to

`-o [ field.ext, 1 ]`

Thus the output options are

```
-o warped.ext # apply transforms to input image
-o Linear[ collapsed.mat invert=0] # Write collapsed linear transform
-o DisplacementField[ collapsed.ext ] # Write collapsed displacement field
-o [ collapsed.ext, 1 ] # same as above, for backwards compatiblity
-o CompositeTransform[ composite.h5 ] # write composite transform
```
