### PR TITLE
ENH: use prefix from --output for --write-interval-volumes

### DIFF
--- a/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
+++ b/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
@@ -197,6 +197,12 @@ public:
   itkSetMacro(CurrentStageNumber, unsigned int);
 
   void
+  SetOutputPrefix(const std::string & outputPrefix)
+  {
+    this->m_OutputPrefix = outputPrefix;
+  }
+
+  void
   SetNumberOfIterations(const std::vector<unsigned int> & iterations)
   {
     this->m_NumberOfIterations = iterations;
@@ -446,7 +452,7 @@ public:
     const unsigned int curLevel = filter->GetCurrentLevel();
     const unsigned int curIter = filter->GetCurrentIteration();
     std::stringstream  currentFileName;
-    currentFileName << "Stage" << this->m_CurrentStageNumber + 1 << "_level" << curLevel + 1;
+    currentFileName << this->m_OutputPrefix << "Stage" << this->m_CurrentStageNumber + 1 << "_level" << curLevel + 1;
     /*
      The name arrangement of written files are important to us.
      To prevent: "Iter1 Iter10 Iter2 Iter20" we use the following style.
@@ -500,6 +506,7 @@ private:
    */
   // itk::WeakPointer<OptimizerType>   m_Optimizer;
 
+  std::string                       m_OutputPrefix;
   std::vector<unsigned int>         m_NumberOfIterations;
   std::ostream *                    m_LogStream;
   itk::TimeProbe                    m_clock;

--- a/Examples/itkantsRegistrationHelper.hxx
+++ b/Examples/itkantsRegistrationHelper.hxx
@@ -2165,6 +2165,7 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
         displacementFieldRegistrationObserver2->SetNumberOfIterations(currentStageIterations);
         displacementFieldRegistrationObserver2->SetOrigFixedImage(this->m_Metrics[0].m_FixedImage);
         displacementFieldRegistrationObserver2->SetOrigMovingImage(this->m_Metrics[0].m_MovingImage);
+        displacementFieldRegistrationObserver2->SetOutputPrefix(this->m_OutputPrefix);
         if (this->m_PrintSimilarityMeasureInterval != 0)
         {
           displacementFieldRegistrationObserver2->SetComputeFullScaleCCInterval(this->m_PrintSimilarityMeasureInterval);


### PR DESCRIPTION
<!--
Text in these brackets are comments, and won't be visible when you submit your
pull request.

We welcome contributions to ANTs. Pull requests will be reviewed by the
developers and if accepted, become part of ANTs, distributed under the license
terms in COPYING.txt.

Please title your PR according to what it does:
ENH: new or improved functionality
PERF: performance enhancements to existing functionality
BUG: fixing a run time bug
COMP: relating to compilation
DOC: documentation changes
WIP: work in progress, needs further commits to be ready
-->

# Description
While doing more testing with the changes from #1838, I realized that `Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h` also needed to be changed to write interval volumes using the first prefix of `--output` when using SyN transform.

Related to #1838 
<!--
Extended description of your PR.

If the PR can close an existing issue, you can say "Fixes #1234" or "Resolves
#1234". Otherwise you can say something like "Related to #1234".
-->


