### PR TITLE
ENH: Strip carriage returns from template input

### DIFF
--- a/Scripts/antsMultivariateTemplateConstruction.sh
+++ b/Scripts/antsMultivariateTemplateConstruction.sh
@@ -734,6 +734,7 @@ if [[ ${NINFILES} -eq 0 ]];
         IMAGECOUNT=0
         while read line
             do
+            line=$(echo "$line" | tr -d '\r') # remove carriage return from python / windows line-endings
             files=(`echo $line | tr ',' ' '`)
             if [[ ${#files[@]} -ne $NUMBEROFMODALITIES ]];
                 then

--- a/Scripts/antsMultivariateTemplateConstruction2.sh
+++ b/Scripts/antsMultivariateTemplateConstruction2.sh
@@ -907,6 +907,7 @@ elif [[ ${NINFILES} -eq 1 ]];
         IMAGECOUNT=0
         while read line
             do
+            line=$(echo "$line" | tr -d '\r') # remove carriage return from python / windows line-endings
             files=(`echo $line | tr "," "\n"`)
             if [[ ${#files[@]} -ne $NUMBEROFMODALITIES ]];
                 then


### PR DESCRIPTION
CSV parsing problems like #1844 have happened before, removing the carriage return avoids the problem