### PR TITLE
CI: Move ubuntu 20.04 to Docker, revive Centos7

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -32,14 +32,6 @@ jobs:
             generators: "Ninja"
           }
         - {
-            name: "Ubuntu-20.04-GCC",
-            os: ubuntu-20.04,
-            cc: "gcc",
-            cxx: "g++",
-            build_type: "Release",
-            generators: "Ninja"
-          }
-        - {
             name: "Macos-14-clang",
             os: macos-14,
             cc: "clang",

--- a/.github/workflows/release-docker-binaries.yml
+++ b/.github/workflows/release-docker-binaries.yml
@@ -30,10 +30,29 @@ jobs:
             cxx: "g++",
             generators: "Unix Makefiles"
           }
+        - { name: "CentOS-7-GCC",
+            os_desc: centos7,
+            image: "cookpa/antscentos7base",
+            build_type: "Release",
+            cc: "gcc",
+            cxx: "g++",
+            generators: "Unix Makefiles"
+          }
         - {
             name: "Ubuntu-18.04-GCC",
             os_desc: ubuntu18.04,
+            ubuntu_repo_label: "bionic",
             image: "ubuntu:18.04",
+            build_type: "Release",
+            cc: "gcc",
+            cxx: "g++",
+            generators: "Ninja"
+          }
+        - {
+            name: "Ubuntu-20.04-GCC",
+            os_desc: ubuntu20.04,
+            image: "ubuntu:20.04",
+            ubuntu_repo_label: "focal",
             build_type: "Release",
             cc: "gcc",
             cxx: "g++",
@@ -73,9 +92,10 @@ jobs:
             gcc --version
           "
       - name: Install dependencies on Ubuntu
-        if: startsWith(matrix.config.name, 'Ubuntu-18.04')
+        if: startsWith(matrix.config.name, 'Ubuntu')
         run: |
           docker exec --user root build_container bash -c "
+            export DEBIAN_FRONTEND=noninteractive
             apt-get update
             apt-get install -y --no-install-recommends \
               apt-transport-https \
@@ -89,16 +109,16 @@ jobs:
               wget \
               zip
             wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -
-            apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ bionic main'
+            apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ ${{ matrix.config.ubuntu_repo_label }} main'
             apt-get update
-            apt-get -y install cmake=${CMAKE_VERSION}-0kitware1ubuntu18.04.1 cmake-data=${CMAKE_VERSION}-0kitware1ubuntu18.04.1
+            apt-get -y install cmake=${CMAKE_VERSION}-0kitware1${{ matrix.config.os_desc }}.1 cmake-data=${CMAKE_VERSION}-0kitware1${{ matrix.config.os_desc }}.1
             ninja --version
             cmake --version
             gcc --version
           "
-      - name: Configure
+      - name: Configure # Run with login shell to source bashrc, needed for centos
         run: |
-          docker exec --user root build_container bash -c "
+          docker exec --user root build_container bash --login -c "
             mkdir -p /workspace/build
             cd /workspace/build
             cmake \
@@ -112,25 +132,25 @@ jobs:
           "
       - name: Build
         run: |
-          docker exec --user root build_container bash -c "
+          docker exec --user root build_container bash --login -c "
             cd /workspace/build
             cmake --build . --config ${{ matrix.config.build_type }} --parallel 1
           "
       - name: Test
         run: |
-          docker exec --user root build_container bash -c "
+          docker exec --user root build_container bash --login -c "
             cd /workspace/build/ANTS-build
             ctest
           "
       - name: Install
         run: |
-          docker exec --user root build_container bash -c "
+          docker exec --user root build_container bash --login -c "
             cd /workspace/build/ANTS-build
             cmake --install .
           "
       - name: Pack
         run: |
-          docker exec --user root build_container bash -c "
+          docker exec --user root build_container bash --login -c "
             cd /workspace/install
             zip -r /artifact/${{ env.ARTIFACT }} .
           "


### PR DESCRIPTION
The Ubuntu 20.04 runner is being retired, so move that to the ubuntu build. Also bring back centos 7 builds.