### PR TITLE
BUG: Set scales estimator for antsAI

### DIFF
--- a/Examples/antsAI.cxx
+++ b/Examples/antsAI.cxx
@@ -1376,13 +1376,13 @@ antsAI(itk::ants::CommandLineParser * parser)
   localOptimizer->SetNumberOfIterations(numberOfIterations);
   localOptimizer->SetMinimumConvergenceValue(convergenceThreshold);
   localOptimizer->SetConvergenceWindowSize(convergenceWindowSize);
-  localOptimizer->SetDoEstimateLearningRateOnce(true);
-  localOptimizer->SetScales(movingScales);
+  localOptimizer->SetScalesEstimator(scalesEstimator);
+  localOptimizer->SetDoEstimateLearningRateOnce(true); // this is always true for conjugate gradient optimizer
   localOptimizer->SetMetric(imageMetric);
 
   using MultiStartOptimizerType = itk::MultiStartOptimizerv4;
   typename MultiStartOptimizerType::Pointer multiStartOptimizer = MultiStartOptimizerType::New();
-  multiStartOptimizer->SetScales(movingScales);
+  multiStartOptimizer->SetDoEstimateScales(false); // multi-start optimizer doesn't use the scales
   multiStartOptimizer->SetMetric(imageMetric);
 
   unsigned int trialCounter = 0;


### PR DESCRIPTION
Prevents the learning rate being carried over to new start points

Should fix (#1860) without having to bump ITK

Somewhat inefficient but doesn't appear to have a large impact on run time (about 10% longer)