### PR TITLE
BUG: Fix tensor reorientation with displacement fields

### DIFF
--- a/Examples/ImageMath.cxx
+++ b/Examples/ImageMath.cxx
@@ -328,6 +328,14 @@ ImageMath(std::vector<std::string> args, std::ostream * itkNotUsed(out_stream))
               << std::endl;
     std::cout << "    Usage        : ComponentTo3DTensor component_image_prefix[xx,xy,xz,yy,yz,zz] extension"
               << std::endl;
+    std::cout << "  FSLTensorToITK    : Converts a tensor image from FSL 4D format. Will flip the x-axis if the image "
+                 "is in neurological orientation."
+              << std::endl;
+    std::cout << "    Usage        : FSLTensorToITK 4D_DTImage.ext" << std::endl;
+    std::cout << "  ITKTensorToFSL    : Converts a tensor image to FSL 4D format. Will flip the x-axis if the "
+                 "image is in neurological orientation."
+              << std::endl;
+    std::cout << "    Usage        : ITKTensorToFSL 3D_DTImage.ext" << std::endl;
     std::cout << "  ExtractComponentFrom3DTensor    : Outputs a component images. " << std::endl;
     std::cout << "    Usage        : ExtractComponentFrom3DTensor dtImage.ext which={xx,xy,xz,yy,yz,zz}" << std::endl;
     std::cout << "  ExtractVectorComponent: Produces the WhichVec component of the vector " << std::endl;

--- a/Tensor/itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.cxx
+++ b/Tensor/itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.cxx
@@ -24,19 +24,7 @@
 #include "itkObjectFactory.h"
 #include "itkVector.h"
 #include "itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.h"
-#include "itkVectorLinearInterpolateImageFunction.h"
-#include "itkNumericTraitsFixedArrayPixel.h"
-#include "itkCentralDifferenceImageFunction.h"
-
-#include "itkVariableSizeMatrix.h"
-#include "itkDecomposeTensorFunction.h"
-#include "itkSymmetricSecondRankTensor.h"
-
-#include <vnl/vnl_cross.h>
-#include <vnl/vnl_inverse.h>
-#include "vnl/algo/vnl_qr.h"
-#include "vnl/algo/vnl_svd.h"
-// #include <vnl/vnl_inverse_transpose.h>
+#include "TensorFunctions.h"
 
 namespace itk
 {
@@ -47,221 +35,9 @@ PreservationOfPrincipalDirectionTensorReorientationImageFilter<TTensorImage, TVe
   m_DisplacementField = nullptr;
   m_DirectionTransform = nullptr;
   m_AffineTransform = nullptr;
-  m_InverseAffineTransform = nullptr;
   m_UseAffine = false;
-  m_UseImageDirection = true;
 }
 
-template <typename TTensorImage, typename TVectorImage>
-void
-PreservationOfPrincipalDirectionTensorReorientationImageFilter<TTensorImage, TVectorImage>::DirectionCorrectTransform(
-  AffineTransformPointer transform,
-  AffineTransformPointer direction)
-{
-  AffineTransformPointer directionTranspose = AffineTransformType::New();
-
-  directionTranspose->SetIdentity();
-
-  typename AffineTransformType::MatrixType dirTransposeMatrix(direction->GetMatrix().GetTranspose());
-  directionTranspose->SetMatrix(dirTransposeMatrix);
-
-  transform->Compose(direction, true);
-  transform->Compose(directionTranspose, false);
-}
-
-template <typename TTensorImage, typename TVectorImage>
-typename PreservationOfPrincipalDirectionTensorReorientationImageFilter<TTensorImage, TVectorImage>::TensorType
-PreservationOfPrincipalDirectionTensorReorientationImageFilter<TTensorImage, TVectorImage>::ApplyReorientation(
-  InverseTransformPointer deformation,
-  TensorType              tensor)
-{
-  VnlMatrixType DT(3, 3);
-
-  DT.fill(0);
-  DT(0, 0) = tensor[0];
-  DT(1, 1) = tensor[3];
-  DT(2, 2) = tensor[5];
-  DT(1, 0) = DT(0, 1) = tensor[1];
-  DT(2, 0) = DT(0, 2) = tensor[2];
-  DT(2, 1) = DT(1, 2) = tensor[4];
-
-  vnl_symmetric_eigensystem<RealType> eig(DT);
-  TensorType                          outTensor;
-
-  TransformInputVectorType ev1;
-  TransformInputVectorType ev2;
-  TransformInputVectorType ev3;
-  for (unsigned int i = 0; i < 3; i++)
-  {
-    ev1[i] = eig.get_eigenvector(2)[i];
-    ev2[i] = eig.get_eigenvector(1)[i];
-    ev3[i] = eig.get_eigenvector(0)[i];
-  }
-
-  TransformOutputVectorType ev1r = deformation->TransformVector(ev1);
-  ev1r.Normalize();
-
-  // Get aspect of rotated e2 that is perpendicular to rotated e1
-  TransformOutputVectorType ev2a = deformation->TransformVector(ev2);
-  if ((ev2a * ev1r) < 0)
-  {
-    ev2a = ev2a * (-1.0);
-  }
-  TransformOutputVectorType ev2r = ev2a - (ev2a * ev1r) * ev1r;
-  ev2r.Normalize();
-
-  TransformOutputVectorType ev3r = CrossProduct(ev1r, ev2r);
-  ev3r.Normalize();
-
-  VnlVectorType e1(3);
-  VnlVectorType e2(3);
-  VnlVectorType e3(3);
-  for (unsigned int i = 0; i < 3; i++)
-  {
-    e1[i] = ev1r[i];
-    e2[i] = ev2r[i];
-    e3[i] = ev3r[i];
-  }
-
-  VnlMatrixType DTrotated = eig.get_eigenvalue(2) * outer_product(e1, e1) +
-                            eig.get_eigenvalue(1) * outer_product(e2, e2) +
-                            eig.get_eigenvalue(0) * outer_product(e3, e3);
-
-  outTensor[0] = DTrotated(0, 0);
-  outTensor[1] = DTrotated(0, 1);
-  outTensor[2] = DTrotated(0, 2);
-  outTensor[3] = DTrotated(1, 1);
-  outTensor[4] = DTrotated(1, 2);
-  outTensor[5] = DTrotated(2, 2);
-
-  return outTensor;
-}
-
-template <typename TTensorImage, typename TVectorImage>
-typename PreservationOfPrincipalDirectionTensorReorientationImageFilter<TTensorImage,
-                                                                        TVectorImage>::AffineTransformPointer
-PreservationOfPrincipalDirectionTensorReorientationImageFilter<TTensorImage, TVectorImage>::GetLocalDeformation(
-  DisplacementFieldPointer                  field,
-  typename DisplacementFieldType::IndexType index)
-{
-  AffineTransformPointer affineTransform = AffineTransformType::New();
-
-  affineTransform->SetIdentity();
-
-  typename AffineTransformType::MatrixType jMatrix;
-  jMatrix.Fill(0.0);
-
-  typename DisplacementFieldType::SizeType    size = field->GetLargestPossibleRegion().GetSize();
-  typename DisplacementFieldType::SpacingType spacing = field->GetSpacing();
-
-  typename DisplacementFieldType::IndexType ddrindex;
-  typename DisplacementFieldType::IndexType ddlindex;
-
-  typename DisplacementFieldType::IndexType difIndex[ImageDimension][2];
-
-  unsigned int posoff = 1;
-  RealType     space = 1.0;
-  RealType     mindist = 1.0;
-  RealType     dist = 100.0;
-  bool         oktosample = true;
-  for (unsigned int row = 0; row < ImageDimension; row++)
-  {
-    dist = fabs((RealType)index[row]);
-    if (dist < mindist)
-    {
-      oktosample = false;
-    }
-    dist = fabs((RealType)size[row] - (RealType)index[row]);
-    if (dist < mindist)
-    {
-      oktosample = false;
-    }
-  }
-
-  if (oktosample)
-  {
-    typename DisplacementFieldType::PixelType cpix = m_DisplacementField->GetPixel(index);
-    cpix = this->TransformVectorByDirection(cpix);
-    // itkCentralDifferenceImageFunction does not support vector images so do this manually here
-    for (unsigned int row = 0; row < ImageDimension; row++)
-    {
-      difIndex[row][0] = index;
-      difIndex[row][1] = index;
-      ddrindex = index;
-      ddlindex = index;
-      if ((int)index[row] < (int)(size[row] - 2))
-      {
-        difIndex[row][0][row] = index[row] + posoff;
-        ddrindex[row] = index[row] + posoff * 2;
-      }
-      if (index[row] > 1)
-      {
-        difIndex[row][1][row] = index[row] - 1;
-        ddlindex[row] = index[row] - 2;
-      }
-
-      RealType h = 1;
-      space = 1.0; // should use image spacing here?
-
-      typename DisplacementFieldType::PixelType rpix = m_DisplacementField->GetPixel(difIndex[row][1]);
-      typename DisplacementFieldType::PixelType lpix = m_DisplacementField->GetPixel(difIndex[row][0]);
-      typename DisplacementFieldType::PixelType rrpix = m_DisplacementField->GetPixel(ddrindex);
-      typename DisplacementFieldType::PixelType llpix = m_DisplacementField->GetPixel(ddlindex);
-
-      if (this->m_UseImageDirection)
-      {
-        rpix = this->TransformVectorByDirection(rpix);
-        lpix = this->TransformVectorByDirection(lpix);
-        rrpix = this->TransformVectorByDirection(rrpix);
-        llpix = this->TransformVectorByDirection(llpix);
-      }
-
-      rpix = rpix * h + cpix * (1. - h);
-      lpix = lpix * h + cpix * (1. - h);
-      rrpix = rrpix * h + rpix * (1. - h);
-      llpix = llpix * h + lpix * (1. - h);
-
-      typename DisplacementFieldType::PixelType dPix =
-        (lpix * 8.0 + llpix - rrpix - rpix * 8.0) * space / (12.0); // 4th order centered difference
-      // typename DisplacementFieldType::PixelType dPix=( lpix - rpix )*space/(2.0*h); //4th order centered difference
-      for (unsigned int col = 0; col < ImageDimension; col++)
-      {
-        RealType val = dPix[col] / spacing[col];
-
-        if (row == col)
-        {
-          val += 1.0;
-        }
-
-        jMatrix(col, row) = val;
-      }
-    }
-  }
-  for (unsigned int jx = 0; jx < ImageDimension; jx++)
-  {
-    for (unsigned int jy = 0; jy < ImageDimension; jy++)
-    {
-      if (!std::isfinite(jMatrix(jx, jy)))
-      {
-        oktosample = false;
-      }
-    }
-  }
-
-  if (!oktosample)
-  {
-    jMatrix.Fill(0.0);
-    for (unsigned int i = 0; i < ImageDimension; i++)
-    {
-      jMatrix(i, i) = 1.0;
-    }
-  }
-
-  affineTransform->SetMatrix(jMatrix);
-  // this->DirectionCorrectTransform( affineTransform, this->m_DirectionTransform );
-
-  return affineTransform;
-}
 
 template <typename TTensorImage, typename TVectorImage>
 void
@@ -273,19 +49,10 @@ PreservationOfPrincipalDirectionTensorReorientationImageFilter<TTensorImage, TVe
   OutputImagePointer output = this->GetOutput();
 
   this->m_DirectionTransform = AffineTransformType::New();
-  this->m_DirectionTransform->SetIdentity();
-  AffineTransformPointer directionTranspose = AffineTransformType::New();
-  directionTranspose->SetIdentity();
+  this->m_DirectionTransform->SetMatrix(input->GetDirection());
 
   if (this->m_UseAffine)
   {
-    this->m_DirectionTransform->SetMatrix(input->GetDirection());
-    if (this->m_UseImageDirection)
-    {
-      this->DirectionCorrectTransform(this->m_AffineTransform, this->m_DirectionTransform);
-    }
-    this->m_InverseAffineTransform = this->m_AffineTransform->GetInverseTransform();
-
     output->SetRegions(input->GetLargestPossibleRegion());
     output->SetSpacing(input->GetSpacing());
     output->SetOrigin(input->GetOrigin());
@@ -294,10 +61,6 @@ PreservationOfPrincipalDirectionTensorReorientationImageFilter<TTensorImage, TVe
   }
   else
   {
-    // Retain input image space as that should be handled in antsApplyTransforms
-
-    this->m_DirectionTransform->SetMatrix(m_DisplacementField->GetDirection());
-
     output->SetRegions(input->GetLargestPossibleRegion());
     output->SetSpacing(input->GetSpacing());
     output->SetOrigin(input->GetOrigin());
@@ -310,29 +73,27 @@ PreservationOfPrincipalDirectionTensorReorientationImageFilter<TTensorImage, TVe
 
   ImageRegionIteratorWithIndex<OutputImageType> outputIt(output, output->GetLargestPossibleRegion());
 
-  VariableMatrixType jMatrixAvg;
-  jMatrixAvg.SetSize(ImageDimension, ImageDimension);
-  jMatrixAvg.Fill(0.0);
-
   std::cout << "Iterating over image" << std::endl;
+
+  using DirectionType = typename TTensorImage::DirectionType;
+
+  auto directionTransformMatrix = input->GetDirection().GetVnlMatrix();
+  auto directionTransformMatrixTranspose = input->GetDirection().GetTranspose();
+
+  using TensorType = typename TTensorImage::PixelType;
+  using TensorMatrixType = typename DirectionType::InternalMatrixType;
+
   // for all voxels
   for (outputIt.GoToBegin(); !outputIt.IsAtEnd(); ++outputIt)
   {
-    InverseTransformPointer localDeformation;
-
-    // FIXME - eventually this will be callable via a generic transform base class
-    if (this->m_UseAffine)
-    {
-      localDeformation = this->m_InverseAffineTransform;
-    }
-    else
-    {
-      AffineTransformPointer deformation = this->GetLocalDeformation(this->m_DisplacementField, outputIt.GetIndex());
-      localDeformation = deformation->GetInverseTransform();
-    }
 
     TensorType inTensor = input->GetPixel(outputIt.GetIndex());
-    TensorType outTensor;
+
+    TensorMatrixType tmpMat; // matrix to hold values for rebasing
+
+    TensorType inTensorPhysical; // inTensor in physical space
+    TensorType inTensorReoriented; // inTensor reoriented by transform
+    TensorType outTensor; // reoriented tensor rebased to voxel space
 
     // valid values?
     bool hasNans = false;
@@ -341,7 +102,6 @@ PreservationOfPrincipalDirectionTensorReorientationImageFilter<TTensorImage, TVe
       if (std::isnan(inTensor[jj]) || std::isinf(inTensor[jj]))
       {
         hasNans = true;
-        ;
       }
     }
 
@@ -358,38 +118,37 @@ PreservationOfPrincipalDirectionTensorReorientationImageFilter<TTensorImage, TVe
     }
     else
     {
-      // outTensor = inTensor;
-      // InverseTransformPointer localDeformation;
+
+      // rebase tensor to physical space using directionTransformMatrix and directionTransformMatrixTranspose;
+      tmpMat = Vector2Matrix<TensorType, TensorMatrixType>(inTensor);
+      tmpMat = directionTransformMatrix * tmpMat * directionTransformMatrixTranspose;
+      inTensorPhysical = Matrix2Vector<TensorType, TensorMatrixType>(tmpMat);
+
       if (this->m_UseAffine)
       {
-        outTensor = this->m_AffineTransform->TransformDiffusionTensor3D(inTensor);
-        // localDeformation = this->m_InverseAffineTransform;
+        Vector2Matrix<TensorType, TensorMatrixType>(inTensor, tmpMat);
+        inTensorReoriented = this->m_AffineTransform->TransformDiffusionTensor3D(inTensorPhysical);
       }
       else
       {
         typename DisplacementFieldType::PointType pt;
         this->m_DisplacementField->TransformIndexToPhysicalPoint(outputIt.GetIndex(), pt);
-        outTensor = this->m_DisplacementTransform->TransformDiffusionTensor3D(inTensor, pt);
-        // AffineTransformPointer deformation = this->GetLocalDeformation( this->m_DeformationField, outputIt.GetIndex()
-        // );
-        // localDeformation = deformation->GetInverseTransform();
+        inTensorReoriented = this->m_DisplacementTransform->TransformDiffusionTensor3D(inTensorPhysical, pt);
       }
-
-      /*
-     std::cout << "apply";
-      outTensor = this->ApplyReorientation( localDeformation, inTensor );
-     std::cout << " ok" << std::endl;
-      */
     }
     // valid values?
     for (unsigned int jj = 0; jj < 6; jj++)
     {
-      if (std::isnan(outTensor[jj]) || std::isinf(outTensor[jj]))
+      if (std::isnan(inTensorReoriented[jj]) || std::isinf(inTensorReoriented[jj]))
       {
-        outTensor[jj] = 0;
+        inTensorReoriented[jj] = 0;
       }
     }
 
+    // rebase tensor to voxel space
+    tmpMat = Vector2Matrix<TensorType, TensorMatrixType>(inTensorReoriented);
+    tmpMat = directionTransformMatrixTranspose * tmpMat * directionTransformMatrix;
+    outTensor = Matrix2Vector<TensorType, TensorMatrixType>(tmpMat);
     outputIt.Set(outTensor);
   }
 }

--- a/Tensor/itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.cxx
+++ b/Tensor/itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.cxx
@@ -122,7 +122,6 @@ PreservationOfPrincipalDirectionTensorReorientationImageFilter<TTensorImage, TVe
 
       if (this->m_UseAffine)
       {
-        Vector2Matrix<TensorType, TensorMatrixType>(inTensor, tmpMat);
         inTensorReoriented = this->m_AffineTransform->TransformDiffusionTensor3D(inTensorPhysical);
       }
       else

--- a/Tensor/itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.cxx
+++ b/Tensor/itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.cxx
@@ -33,7 +33,6 @@ PreservationOfPrincipalDirectionTensorReorientationImageFilter<TTensorImage, TVe
   PreservationOfPrincipalDirectionTensorReorientationImageFilter()
 {
   m_DisplacementField = nullptr;
-  m_DirectionTransform = nullptr;
   m_AffineTransform = nullptr;
   m_UseAffine = false;
 }
@@ -47,9 +46,6 @@ PreservationOfPrincipalDirectionTensorReorientationImageFilter<TTensorImage, TVe
   // FIXME - use buffered region, etc
   InputImagePointer  input = this->GetInput();
   OutputImagePointer output = this->GetOutput();
-
-  this->m_DirectionTransform = AffineTransformType::New();
-  this->m_DirectionTransform->SetMatrix(input->GetDirection());
 
   if (this->m_UseAffine)
   {

--- a/Tensor/itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.h
+++ b/Tensor/itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.h
@@ -144,8 +144,6 @@ private:
 
   DisplacementFieldTransformPointer m_DisplacementTransform;
 
-  AffineTransformPointer m_DirectionTransform;
-
   AffineTransformPointer m_AffineTransform;
 
   bool m_UseAffine;

--- a/Tensor/itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.h
+++ b/Tensor/itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.h
@@ -15,12 +15,10 @@
 #define __itkPreservationOfPrincipalDirectionTensorReorientationImageFilter_h
 
 #include "itkImageToImageFilter.h"
-#include "itkVectorInterpolateImageFunction.h"
 #include "itkImage.h"
 #include "itkMatrix.h"
 #include "itkNumericTraits.h"
 #include "itkVector.h"
-#include "itkSymmetricSecondRankTensor.h"
 #include "itkDisplacementFieldTransform.h"
 
 namespace itk
@@ -69,20 +67,9 @@ public:
 
   typedef typename AffineTransformType::Pointer AffineTransformPointer;
 
-  typedef typename AffineTransformType::InputVectorType TransformInputVectorType;
-
-  typedef typename AffineTransformType::OutputVectorType TransformOutputVectorType;
-
   typedef typename AffineTransformType::InverseTransformBaseType InverseTransformType;
 
   typedef typename InverseTransformType::Pointer InverseTransformPointer;
-
-  //  typedef Vector<RealType, 6> TensorType;
-  // typedef itk::SymmetricSecondRankTensor< RealType, 3 >  TensorType;
-  // typedef Image<TensorType, ImageDimension> TensorImageType;
-  // typedef typename TensorImageType::Pointer TensorImagePointer;
-  typedef typename InputImageType::PixelType InputImagePixelType;
-  typedef InputImagePixelType                TensorType;
 
   typedef vnl_matrix<RealType> VnlMatrixType;
   typedef vnl_vector<RealType> VnlVectorType;
@@ -108,9 +95,6 @@ public:
   }
 
   itkGetMacro(AffineTransform, AffineTransformPointer);
-
-  itkSetMacro(UseImageDirection, bool);
-  itkGetMacro(UseImageDirection, bool);
 
   /** Run-time type information (and related methods). */
   itkOverrideGetNameOfClassMacro(PreservationOfPrincipalDirectionTensorReorientationImageFilter);
@@ -150,36 +134,11 @@ protected:
   void
   GenerateData() override;
 
-  typename DisplacementFieldType::PixelType
-  TransformVectorByDirection(typename DisplacementFieldType::PixelType cpix)
-  {
-    typedef itk::Vector<double, ImageDimension> locVectorType;
-    if (this->m_UseImageDirection)
-    {
-      locVectorType outpix;
-      for (unsigned int d = 0; d < ImageDimension; d++)
-      {
-        outpix[d] = cpix[d];
-      }
-      outpix = m_DirectionTransform->TransformVector(outpix);
-      for (unsigned int d = 0; d < ImageDimension; d++)
-      {
-        cpix[d] = outpix[d];
-      }
-    }
-    return cpix;
-  }
 
 private:
   PreservationOfPrincipalDirectionTensorReorientationImageFilter(const Self &) = delete;
   void
   operator=(const Self &) = delete;
-
-  AffineTransformPointer GetLocalDeformation(DisplacementFieldPointer, typename DisplacementFieldType::IndexType);
-
-  TensorType ApplyReorientation(InverseTransformPointer, TensorType);
-
-  void DirectionCorrectTransform(AffineTransformPointer, AffineTransformPointer);
 
   DisplacementFieldPointer m_DisplacementField;
 
@@ -189,11 +148,8 @@ private:
 
   AffineTransformPointer m_AffineTransform;
 
-  InverseTransformPointer m_InverseAffineTransform;
-
   bool m_UseAffine;
 
-  bool m_UseImageDirection;
 };
 } // end namespace itk
 

--- a/Tensor/itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.h
+++ b/Tensor/itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.h
@@ -43,52 +43,60 @@ class PreservationOfPrincipalDirectionTensorReorientationImageFilter final
   : public ImageToImageFilter<TTensorImage, TTensorImage>
 {
 public:
-  typedef TTensorImage InputImageType;
-  typedef TTensorImage OutputImageType;
-  typedef TVectorImage DisplacementFieldType;
-
-  typedef typename DisplacementFieldType::Pointer   DisplacementFieldPointer;
-  typedef typename DisplacementFieldType::PixelType VectorType;
-  typedef typename VectorType::RealValueType        RealType;
-
-  typedef itk::DisplacementFieldTransform<double, 3> DisplacementFieldTransformType;
-
-  typedef typename DisplacementFieldTransformType::Pointer DisplacementFieldTransformPointer;
-
-  typedef Matrix<RealType, 3, 3> MatrixType;
-  // typedef Vector<RealType, 3> VectorType;
-  typedef VariableSizeMatrix<RealType> VariableMatrixType;
-
-  static constexpr unsigned int ImageDimension = TTensorImage::ImageDimension;
-
-  typedef itk::Image<RealType, ImageDimension> RealTypeImageType;
-
-  typedef itk::MatrixOffsetTransformBase<RealType, ImageDimension, ImageDimension> AffineTransformType;
-
-  typedef typename AffineTransformType::Pointer AffineTransformPointer;
-
-  typedef typename AffineTransformType::InverseTransformBaseType InverseTransformType;
-
-  typedef typename InverseTransformType::Pointer InverseTransformPointer;
-
-  typedef vnl_matrix<RealType> VnlMatrixType;
-  typedef vnl_vector<RealType> VnlVectorType;
-  typedef vnl_vector<RealType> vvec;
-
-  /** Standard class typedefs. */
-  typedef PreservationOfPrincipalDirectionTensorReorientationImageFilter Self;
-  typedef ImageToImageFilter<InputImageType, OutputImageType>            Superclass;
-  typedef SmartPointer<Self>                                             Pointer;
-  typedef SmartPointer<const Self>                                       ConstPointer;
+  using Self = PreservationOfPrincipalDirectionTensorReorientationImageFilter;
+  using Superclass = ImageToImageFilter<TTensorImage, TTensorImage>;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
+  /** Run-time type information (and related methods). */
+  itkOverrideGetNameOfClassMacro(PreservationOfPrincipalDirectionTensorReorientationImageFilter);
+
+  using InputImageType = TTensorImage;
+  using OutputImageType = TTensorImage;
+  using DisplacementFieldType = TVectorImage;
+
+  using DisplacementFieldPointer = typename DisplacementFieldType::Pointer;
+  using VectorType = typename DisplacementFieldType::PixelType;
+  using RealType = typename VectorType::RealValueType;
+
+  using DisplacementFieldTransformType = DisplacementFieldTransform<double, 3>;
+  using DisplacementFieldTransformPointer = typename DisplacementFieldTransformType::Pointer;
+
+  using MatrixType = Matrix<RealType, 3, 3>;
+  using VariableMatrixType = VariableSizeMatrix<RealType>;
+
+  static constexpr unsigned int ImageDimension = TTensorImage::ImageDimension;
+
+  using RealTypeImageType = Image<RealType, ImageDimension>;
+  using AffineTransformType = MatrixOffsetTransformBase<RealType, ImageDimension, ImageDimension>;
+  using AffineTransformPointer = typename AffineTransformType::Pointer;
+  using InverseTransformType = typename AffineTransformType::InverseTransformBaseType;
+  using InverseTransformPointer = typename InverseTransformType::Pointer;
+
+  using VnlMatrixType = vnl_matrix<RealType>;
+  using VnlVectorType = vnl_vector<RealType>;
+
+  using InputImagePointer = typename InputImageType::ConstPointer;
+  using OutputImagePointer = typename OutputImageType::Pointer;
+  using InputPixelType = typename InputImageType::PixelType;
+  using OutputPixelType = typename OutputImageType::PixelType;
+  using InputRealType = typename InputPixelType::ValueType;
+
+  using InputImageRegionType = typename InputImageType::RegionType;
+  using OutputImageRegionType = typename OutputImageType::RegionType;
+
+  using InputSizeType = typename InputImageType::SizeType;
+  using OutputSizeType = typename OutputImageType::SizeType;
+  using InputIndexType = typename InputImageType::IndexType;
+  using OutputIndexType = typename OutputImageType::IndexType;
+
   itkSetMacro(DisplacementField, DisplacementFieldPointer);
   itkGetMacro(DisplacementField, DisplacementFieldPointer);
 
-  void
-  SetAffineTransform(AffineTransformPointer aff)
+  void SetAffineTransform(AffineTransformPointer aff)
   {
     this->m_AffineTransform = aff;
     this->m_UseAffine = true;
@@ -96,58 +104,21 @@ public:
 
   itkGetMacro(AffineTransform, AffineTransformPointer);
 
-  /** Run-time type information (and related methods). */
-  itkOverrideGetNameOfClassMacro(PreservationOfPrincipalDirectionTensorReorientationImageFilter);
-
-  /** Image typedef support. */
-  typedef typename InputImageType::ConstPointer InputImagePointer;
-  typedef typename OutputImageType::Pointer     OutputImagePointer;
-  typedef typename InputImageType::PixelType    InputPixelType;
-  typedef typename OutputImageType::PixelType   OutputPixelType;
-  typedef typename InputPixelType::ValueType    InputRealType;
-
-  typedef typename InputImageType::RegionType  InputImageRegionType;
-  typedef typename OutputImageType::RegionType OutputImageRegionType;
-
-  typedef typename InputImageType::SizeType   InputSizeType;
-  typedef typename OutputImageType::SizeType  OutputSizeType;
-  typedef typename InputImageType::IndexType  InputIndexType;
-  typedef typename OutputImageType::IndexType OutputIndexType;
-
 protected:
   PreservationOfPrincipalDirectionTensorReorientationImageFilter();
   ~PreservationOfPrincipalDirectionTensorReorientationImageFilter() override = default;
 
-  void
-  PrintSelf(std::ostream & os, Indent indent) const override;
-
-  /** PreservationOfPrincipalDirectionTensorReorientationImageFilter can be implemented as a multithreaded filter.
-   * Therefore, this implementation provides a ThreadedGenerateData()
-   * routine which is called for each processing thread. The output
-   * image data is allocated automatically by the superclass prior to
-   * calling ThreadedGenerateData().  ThreadedGenerateData can only
-   * write to the portion of the output image specified by the
-   * parameter "outputRegionForThread"
-   *
-   * \sa ImageToImageFilter::ThreadedGenerateData(),
-   *     ImageToImageFilter::GenerateData() */
-  void
-  GenerateData() override;
-
+  void PrintSelf(std::ostream & os, Indent indent) const override;
+  void GenerateData() override;
 
 private:
   PreservationOfPrincipalDirectionTensorReorientationImageFilter(const Self &) = delete;
-  void
-  operator=(const Self &) = delete;
+  void operator=(const Self &) = delete;
 
   DisplacementFieldPointer m_DisplacementField;
-
   DisplacementFieldTransformPointer m_DisplacementTransform;
-
   AffineTransformPointer m_AffineTransform;
-
-  bool m_UseAffine;
-
+  bool m_UseAffine = false;
 };
 } // end namespace itk
 


### PR DESCRIPTION
There was a lot of unused code in the PPD filter, and it was not consistent about how it expected the input tensors to be based - it seems it corrected for the header orientation with affine transforms, but not with displacement fields. A comment suggested this was intentional, but it produces wrong results if the resampled tensor image does not have an identity header transform. 

I've simplified the code in this PR.

Tensors should be stored in voxel orientation. In antsApplyTransforms, they are reoriented correctly into the voxel orientation of the reference space (#678).  In the new PPD filter, the tensors are rebased into physical orientation, the rotation from the transform is applied, then they are rebased onto the voxel orientation.

My motivation for getting back into this issue is the forthcoming BIDS extension proposal for dMRI derivatives. I plan to eventually do all the reorientation in `antsApplyTransforms`, but first I wanted to get the existing workflow correct. 

There remains the issue of how to import / export FSL tensors, these will require special handling, partly because of different NIFTI storage conventions, but also the tensor orientation in FSL has an x-axis flip compared to the ITK direction matrix, if the header transform has a positive determinant. This will require some special handling on input.