### PR TITLE
ENH: Support composite transforms in ReorientTensorImage

### DIFF
--- a/Examples/RebaseTensorImage.cxx
+++ b/Examples/RebaseTensorImage.cxx
@@ -15,7 +15,6 @@
 #include <algorithm>
 
 #include "ReadWriteData.h"
-#include "itkPreservationOfPrincipalDirectionTensorReorientationImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkWarpTensorImageMultiTransformFilter.h"
 #include "itkTransformFileReader.h"

--- a/Utilities/itkantsReadWriteTransform.h
+++ b/Utilities/itkantsReadWriteTransform.h
@@ -38,7 +38,7 @@ ReadTransform(const std::string & filename,
   typedef typename itk::CompositeTransform<T, VImageDimension> CompositeTransformType;
 
   // There are known transform type extentions that should not be considered as imaging files
-  // That would be used as deformatino feilds
+  // That would be used as deformation fields
   // If file is an hdf5 file, assume it is a transform instead of an image.
   bool recognizedExtension = false;
   recognizedExtension |= (itksys::SystemTools::GetFilenameLastExtension(filename) == ".h5");
@@ -176,7 +176,7 @@ WriteTransform(typename itk::Transform<T, VImageDimension, VImageDimension>::Poi
 
       CompositeTransformType * comp_xfm = dynamic_cast<CompositeTransformType *>(xfrm.GetPointer());
       if (comp_xfm != nullptr)
-      { // this is a composite transform, make sure it doesn't contain wiered stuff
+      { // this is a composite transform, make sure it doesn't contain weird stuff
         CompositeTransformPointer tmp_comp_xfm = CompositeTransformType::New();
 
         size_t numTransforms = comp_xfm->GetNumberOfTransforms();


### PR DESCRIPTION
Reorienting with a composite transform removes the requirement to collapse all transforms into a single displacement field.