### PR TITLE
Dt background value

### DIFF
--- a/Examples/LabelGeometryMeasures.cxx
+++ b/Examples/LabelGeometryMeasures.cxx
@@ -82,10 +82,6 @@ LabelGeometryMeasures(int argc, char * argv[])
 {
   using LabelType = unsigned int;
   using LabelImageType = itk::Image<LabelType, ImageDimension>;
-  // mask image is used to binarize the labels, used to mask the intensity image
-  // to better initialize the histogram for stats
-  using MaskType = unsigned char;
-  using MaskImageType = itk::Image<MaskType, ImageDimension>;
   using RealType = float;
   using RealImageType = itk::Image<RealType, ImageDimension>;
 

--- a/Examples/antsApplyTransforms.cxx
+++ b/Examples/antsApplyTransforms.cxx
@@ -215,6 +215,25 @@ antsApplyTransforms(itk::ants::CommandLineParser::Pointer & parser, unsigned int
   // Time-index to extract from time-series image
   unsigned long extractTimeIndex = 0;
 
+  /**
+   * Default voxel value or default MD for tensor images. This is used in pixels outside the domain of the
+   * input image. The default value is also used for tensor images that are all-zero, because otherwise the
+   * zero tensors cause huge interpolation artifacts in the log domain.
+   */
+  PixelType                                                  defaultValue = 0;
+  typename itk::ants::CommandLineParser::OptionType::Pointer defaultOption = parser->GetOption("default-value");
+  if (defaultOption && defaultOption->GetNumberOfFunctions())
+  {
+    defaultValue = parser->Convert<PixelType>(defaultOption->GetFunction(0)->GetName());
+  }
+  if (verbose)
+  {
+    if (inputImageType == 2)
+      std::cout << "Default pixel mean diffusivity: " << defaultValue << std::endl;
+    else
+      std::cout << "Default pixel value: " << defaultValue << std::endl;
+  }
+
   bool extractTimeIndexSet = false;
 
   typename itk::ants::CommandLineParser::OptionType::Pointer timeIndexOption = parser->GetOption("time-index");
@@ -298,7 +317,7 @@ antsApplyTransforms(itk::ants::CommandLineParser::Pointer & parser, unsigned int
     {
       std::cout << "Input tensor image: " << inputOption->GetFunction(0)->GetName() << std::endl;
     }
-    ReadTensorImage<TensorImageType>(tensorImage, (inputOption->GetFunction(0)->GetName()).c_str(), true);
+    ReadTensorImage<TensorImageType>(tensorImage, (inputOption->GetFunction(0)->GetName()).c_str(), true, defaultValue);
   }
   else if (inputImageType == 0 && inputOption && inputOption->GetNumberOfFunctions())
   {
@@ -560,22 +579,6 @@ antsApplyTransforms(itk::ants::CommandLineParser::Pointer & parser, unsigned int
 
 #include "make_interpolator_snip.tmpl"
 
-  /**
-   * Default voxel value
-   */
-  PixelType                                                  defaultValue = 0;
-  typename itk::ants::CommandLineParser::OptionType::Pointer defaultOption = parser->GetOption("default-value");
-  if (defaultOption && defaultOption->GetNumberOfFunctions())
-  {
-    defaultValue = parser->Convert<PixelType>(defaultOption->GetFunction(0)->GetName());
-  }
-  if (verbose)
-  {
-    if (inputImageType == 2)
-      std::cout << "Default pixel mean diffusivity: " << defaultValue << std::endl;
-    else
-      std::cout << "Default pixel value: " << defaultValue << std::endl;
-  }
   for (unsigned int n = 0; n < inputImages.size(); n++)
   {
     using ResamplerType = itk::ResampleImageFilter<ImageType, ImageType, RealType>;

--- a/Examples/antsApplyTransforms.cxx
+++ b/Examples/antsApplyTransforms.cxx
@@ -1145,7 +1145,7 @@ antsApplyTransformsInitializeCommandLineOptions(itk::ants::CommandLineParser * p
                               std::string("Specifies the voxel value when the input point maps outside ") +
                               std::string("the output domain. With tensor input images, specifies the ") +
                               std::string("default voxel eigenvalues. Default tensor eigenvalues are ") +
-                              std::string("also are used in voxels where the tensor data is all zero.") +
+                              std::string("also are used in voxels where the tensor data is all zero.");
 
     OptionType::Pointer option = OptionType::New();
     option->SetLongName("default-value");

--- a/Examples/antsApplyTransforms.cxx
+++ b/Examples/antsApplyTransforms.cxx
@@ -1144,7 +1144,8 @@ antsApplyTransformsInitializeCommandLineOptions(itk::ants::CommandLineParser * p
     std::string description = std::string("Default voxel value to be used with input images only. ") +
                               std::string("Specifies the voxel value when the input point maps outside ") +
                               std::string("the output domain. With tensor input images, specifies the ") +
-                              std::string("default voxel eigenvalues. ");
+                              std::string("default voxel eigenvalues. Default tensor eigenvalues are ") +
+                              std::string("also are used in voxels where the tensor data is all zero.") +
 
     OptionType::Pointer option = OptionType::New();
     option->SetLongName("default-value");


### PR DESCRIPTION
We've had a default tensor pixel value for some time, but it's only used when the fixed and moving domains don't overlap. 

A bigger problem is that when the tensor volume is brain masked, the interpolation with zeros in the log space causes huge tensors at the edge of the brain, which hinders visualization of tensor glyphs or mean diffusivity images.

Currently, this can be avoided with the `TensorMask` option in `ImageMath`.

This PR allows the use of a default isotropic tensor in background voxels. In antsApplyTransforms, the default mean diffusivity specified with `-f` is now used in background voxels of the moving image, so that resampling is more sensible along the edge of the brain.

The default value of -f remains zero, so the user has to opt-in to using the new functionality.