### PR TITLE
Apply PPD reorientation for tensor data in antsApplyTransforms

### DIFF
--- a/Examples/ImageMath.cxx
+++ b/Examples/ImageMath.cxx
@@ -322,7 +322,8 @@ ImageMath(std::vector<std::string> args, std::ostream * itkNotUsed(out_stream))
               << std::endl;
 
     std::cout << "\nTensor Operations:" << std::endl;
-    std::cout << "  4DTensorTo3DTensor    : Outputs a 3D_DT_Image with the same information. " << std::endl;
+    std::cout << "  4DTensorTo3DTensor    : Outputs a 3D tensor image from a 4D image containing upper-triangular components "
+              << "(dxx, dxy, dxz, dyy, dyz, dzz)" << std::endl;
     std::cout << "    Usage        : 4DTensorTo3DTensor 4D_DTImage.ext" << std::endl;
     std::cout << "  ComponentTo3DTensor    : Outputs a 3D_DT_Image with the same information as component images. "
               << std::endl;

--- a/Examples/ReorientTensorImage.cxx
+++ b/Examples/ReorientTensorImage.cxx
@@ -145,7 +145,10 @@ ReorientTensorImage(std::vector<std::string> args, std::ostream * /*out_stream =
   if (argc != 5)
   {
     std::cout << "Usage: " << argv[0] << " Dimension infile.nii outfile.nii <composite.h5/warp.nii.gz/affine.mat/affine.txt> "
-        << std::endl;
+              << std::endl
+              << "antsApplyTransforms now applies reorientation automatically. If resampled your tensors into fixed space "
+              << "with antsApplyTransforms -e 2, the reorientation is already done."
+              << std::endl;
     if (argc >= 2 && (std::string(argv[1]) == std::string("--help") || std::string(argv[1]) == std::string("-h")))
     {
       return EXIT_SUCCESS;

--- a/Examples/antsApplyTransforms.cxx
+++ b/Examples/antsApplyTransforms.cxx
@@ -1269,8 +1269,13 @@ antsApplyTransforms(std::vector<std::string> args, std::ostream * /*out_stream =
   parser->SetCommand(argv[0]);
 
   std::string commandDescription = std::string("antsApplyTransforms, applied to an input image, transforms it ") +
-                                   std::string("according to a reference image and a transform ") +
-                                   std::string("(or a set of transforms).");
+                                   std::string("according to a reference image and a transform (or a set of transforms). ") +
+                                   std::string("The output image is resliced into the space of the reference image. Tensor ") +
+                                   std::string("images are reoriented to preserve the principal directions. Vector input ") +
+                                   std::string("is not currently reoriented (this may be added later). ") +
+                                   std::string("As well as applying warps to images, antsApplyTransforms can also compose ") +
+                                   std::string("multiple transforms into a composite transform file, or collapse them into ") +
+                                   std::string("a single affine transform or displacement field.");
 
   parser->SetCommandDescription(commandDescription);
   antsApplyTransformsInitializeCommandLineOptions(parser);

--- a/Examples/antsApplyTransforms.cxx
+++ b/Examples/antsApplyTransforms.cxx
@@ -1000,9 +1000,9 @@ antsApplyTransformsInitializeCommandLineOptions(itk::ants::CommandLineParser * p
 
   {
     std::string description = std::string("Option specifying the input image type of scalar (default), ") +
-                              std::string("vector, tensor, time series, or multi-channel.  A time series ") +
-                              std::string("image is a scalar image defined by an additional dimension ") +
-                              std::string("for the time component whereas a multi-channel image is a ") +
+                              std::string("vector, tensor (3D diffusion tensor), time series, or multi-channel.  ") +
+                              std::string("A time series image is a scalar image defined by an additional ") +
+                              std::string("dimension for the time component whereas a multi-channel image is a ") +
                               std::string("vector image with only spatial dimensions.  Five-dimensional") +
                               std::string("images are e.g., AFNI stats image.");
 


### PR DESCRIPTION
Now that the PPD filter supports composite transforms, it is feasible to add it directly to antsApplyTransforms. This avoids the need to use a separate program and keep track of the transforms to use.

This simplifies things for users, and reduces potential for mistakes in transform composition.

To make this happen, I had to change the tensor type in AAT from a general itk::SymmetricSecondRankTensor to a DiffusionTensor3D. Typing this, I realize I should document this in the usage.

I think DiffusionTensor3D is the vast majority of use cases, so I'm thinking it would not be worth complicating usage by separately supporting generic tensors. Non-diffusion tensors might not also work with the log transformation that we apply automatically.

