### PR TITLE
BUG: Jacobian determinants incorrect for non-identity direction matrices

### DIFF
--- a/Examples/CreateJacobianDeterminantImage.cxx
+++ b/Examples/CreateJacobianDeterminantImage.cxx
@@ -70,8 +70,6 @@ CreateJacobianDeterminantImage(int argc, char * argv[])
     jacobianFilter->SetInput(reader->GetOutput());
     jacobianFilter->SetCalculateJacobian(true);
     jacobianFilter->SetUseImageSpacing(true);
-    jacobianFilter->SetOrder(2);
-    jacobianFilter->SetUseCenteredDifference(true);
 
     if ( returnDeformationGradient )
     {

--- a/Utilities/itkDeformationFieldGradientTensorImageFilter.h
+++ b/Utilities/itkDeformationFieldGradientTensorImageFilter.h
@@ -87,13 +87,6 @@ public:
   void
   GenerateInputRequestedRegion() override;
 
-  itkSetClampMacro(Order, unsigned int, 1, 2);
-  itkGetConstReferenceMacro(Order, unsigned int);
-
-  itkSetMacro(UseCenteredDifference, bool);
-  itkGetConstReferenceMacro(UseCenteredDifference, bool);
-  itkBooleanMacro(UseCenteredDifference);
-
   itkSetMacro(UseImageSpacing, bool);
   itkGetConstReferenceMacro(UseImageSpacing, bool);
   itkBooleanMacro(UseImageSpacing);
@@ -135,7 +128,6 @@ protected:
 
 private:
   bool                                       m_UseImageSpacing;
-  bool                                       m_UseCenteredDifference;
   bool                                       m_CalculateJacobian;
   unsigned int                               m_Order;
   RadiusType                                 m_NeighborhoodRadius;

--- a/Utilities/itkDeformationFieldGradientTensorImageFilter.hxx
+++ b/Utilities/itkDeformationFieldGradientTensorImageFilter.hxx
@@ -175,19 +175,14 @@ DeformationFieldGradientTensorImageFilter<TInputImage, TRealType, TOutputImage>:
   unsigned       i, j;
   RealMatrixType F;
 
-  RealVectorType physicalVectorCenter;
-  this->m_RealValuedInputImage->TransformLocalVectorToPhysicalVector(it.GetCenterPixel(), physicalVectorCenter);
+  RealVectorType physicalVectorCenter = it.GetCenterPixel();
 
   for (i = 0; i < ImageDimension; ++i)
   {
-    RealVectorType physicalVectorNext1;
-    this->m_RealValuedInputImage->TransformLocalVectorToPhysicalVector(it.GetNext(i, 1), physicalVectorNext1);
-    RealVectorType physicalVectorNext2;
-    this->m_RealValuedInputImage->TransformLocalVectorToPhysicalVector(it.GetNext(i, 2), physicalVectorNext2);
-    RealVectorType physicalVectorPrevious1;
-    this->m_RealValuedInputImage->TransformLocalVectorToPhysicalVector(it.GetPrevious(i, 1), physicalVectorPrevious1);
-    RealVectorType physicalVectorPrevious2;
-    this->m_RealValuedInputImage->TransformLocalVectorToPhysicalVector(it.GetPrevious(i, 2), physicalVectorPrevious2);
+    RealVectorType physicalVectorNext1 = it.GetNext(i, 1);
+    RealVectorType physicalVectorNext2 = it.GetNext(i, 2);
+    RealVectorType physicalVectorPrevious1 = it.GetPrevious(i, 1);
+    RealVectorType physicalVectorPrevious2 = it.GetPrevious(i, 2);
 
     RealType weight = this->m_DerivativeWeights[i];
     for (j = 0; j < VectorDimension; ++j)

--- a/Utilities/itkDeformationFieldGradientTensorImageFilter.hxx
+++ b/Utilities/itkDeformationFieldGradientTensorImageFilter.hxx
@@ -29,10 +29,9 @@ template <typename TInputImage, typename TRealType, typename TOutputImage>
 DeformationFieldGradientTensorImageFilter<TInputImage, TRealType, TOutputImage>::
   DeformationFieldGradientTensorImageFilter()
 {
-  this->m_UseImageSpacing = true;
-  this->m_UseCenteredDifference = true;
   this->m_CalculateJacobian = false;
-  this->m_Order = 1;
+  this->m_UseImageSpacing = true;
+  this->m_Order = 2;
   this->m_DerivativeWeights.Fill(1.0);
   this->DynamicMultiThreadingOff();
 }
@@ -201,8 +200,6 @@ DeformationFieldGradientTensorImageFilter<TInputImage, TRealType, TOutputImage>:
   unsigned       i, j;
   RealMatrixType F;
 
-  RealVectorType physicalVectorCenter = it.GetCenterPixel();
-
   for (j = 0; j < ImageDimension; ++j)
   {
     RealVectorType physicalVectorNext1 = it.GetNext(j, 1);
@@ -213,35 +210,12 @@ DeformationFieldGradientTensorImageFilter<TInputImage, TRealType, TOutputImage>:
     RealType weight = this->m_DerivativeWeights[j];
     for (i = 0; i < ImageDimension; ++i)
     {
-      if (this->m_UseCenteredDifference)
-      {
-        switch (this->m_Order)
-        {
-          case 1:
-          default:
-            F[i][j] = weight * 0.5 * (physicalVectorNext1[j] - physicalVectorPrevious1[j]);
-            break;
-          case 2:
-            F[i][j] = weight *
+       F[i][j] = weight *
                       (-physicalVectorNext2[i] + 8.0 * physicalVectorNext1[i] - 8.0 * physicalVectorPrevious1[i] +
                        physicalVectorPrevious2[i]) /
                       12.0;
-            break;
-        }
-      }
-      else // Forward difference schema
-      {
-        switch (this->m_Order)
-        {
-          case 1:
-          default:
-            F[i][j] = weight * (physicalVectorNext1[j] - physicalVectorCenter[j]);
-            break;
-        }
-      }
     }
   }
-
   return F;
 }
 
@@ -254,7 +228,6 @@ DeformationFieldGradientTensorImageFilter<TInputImage, TRealType, TOutputImage>:
 
   os << indent << "m_CalculateJacobian = " << this->m_CalculateJacobian << std::endl;
   os << indent << "m_UseImageSpacing = " << this->m_UseImageSpacing << std::endl;
-  os << indent << "m_UseCenteredDifference = " << this->m_UseCenteredDifference << std::endl;
   os << indent << "m_Order = " << this->m_Order << std::endl;
   os << indent << "m_NeighborhoodRadius = " << this->m_NeighborhoodRadius << std::endl;
   os << indent << "m_RealValuedInputImage = " << m_RealValuedInputImage.GetPointer() << std::endl;


### PR DESCRIPTION
Discussed in #1884 

I added more examples with synthetic data at

https://github.com/cookpa/antsJacobianExample

I think the Jacobian matrix as well as the determinant were not properly computed in physical space. For some cases, these errors could cancel out leading to results that appear correct.

I've simplified the ANTs Jacobian filter to behave more like the itkDisplacementFieldTransform method, which works consistently well across different image orientations.

I would really like some validation on external real data, but don't have time to pursue that for a couple of weeks at least. Opening a draft PR for feedback

