### PR TITLE
STYLE: CoordRepType -> CoordinateType code readability

### DIFF
--- a/Examples/ANTSIntegrateVectorField.cxx
+++ b/Examples/ANTSIntegrateVectorField.cxx
@@ -183,7 +183,7 @@ IntegrateLength(typename TImage::Pointer gmsurf,
     ContinuousIndexType Y4;
     for (unsigned int jj = 0; jj < ImageDimension; jj++)
     {
-      pointIn2[jj] = static_cast<typename DPointType::CoordRepType>(disp[jj]) + pointIn1[jj];
+      pointIn2[jj] = static_cast<typename DPointType::CoordinateType>(disp[jj]) + pointIn1[jj];
       vcontind[jj] = pointIn2[jj] / lapgrad->GetSpacing()[jj];
       Y1[jj] = vcontind[jj];
       Y2[jj] = vcontind[jj];
@@ -198,7 +198,7 @@ IntegrateLength(typename TImage::Pointer gmsurf,
     f1 = vinterp->EvaluateAtContinuousIndex(Y1);
     for (unsigned int jj = 0; jj < ImageDimension; jj++)
     {
-      Y2[jj] += static_cast<typename ContinuousIndexType::CoordRepType>(static_cast<float>(f1[jj]) * deltaTime * 0.5f);
+      Y2[jj] += static_cast<typename ContinuousIndexType::CoordinateType>(static_cast<float>(f1[jj]) * deltaTime * 0.5f);
     }
     bool isinside = true;
     for (unsigned int jj = 0; jj < ImageDimension; jj++)
@@ -214,7 +214,7 @@ IntegrateLength(typename TImage::Pointer gmsurf,
     }
     for (unsigned int jj = 0; jj < ImageDimension; jj++)
     {
-      Y3[jj] += static_cast<typename ContinuousIndexType::CoordRepType>(static_cast<float>(f2[jj]) * deltaTime * 0.5f);
+      Y3[jj] += static_cast<typename ContinuousIndexType::CoordinateType>(static_cast<float>(f2[jj]) * deltaTime * 0.5f);
     }
     isinside = true;
     for (unsigned int jj = 0; jj < ImageDimension; jj++)
@@ -230,7 +230,7 @@ IntegrateLength(typename TImage::Pointer gmsurf,
     }
     for (unsigned int jj = 0; jj < ImageDimension; jj++)
     {
-      Y4[jj] += static_cast<typename ContinuousIndexType::CoordRepType>(static_cast<float>(f3[jj]) * deltaTime);
+      Y4[jj] += static_cast<typename ContinuousIndexType::CoordinateType>(static_cast<float>(f3[jj]) * deltaTime);
     }
     isinside = true;
     for (unsigned int jj = 0; jj < ImageDimension; jj++)
@@ -244,14 +244,14 @@ IntegrateLength(typename TImage::Pointer gmsurf,
     {
       f4 = vinterp->EvaluateAtContinuousIndex(Y4);
     }
-    using DPointCoordRepType = typename DPointType::CoordRepType;
-    auto twoValue = static_cast<DPointCoordRepType>(2.0);
+    using DPointCoordinateType = typename DPointType::CoordinateType;
+    auto twoValue = static_cast<DPointCoordinateType>(2.0);
     for (unsigned int jj = 0; jj < ImageDimension; jj++)
     {
       pointIn3[jj] =
-        pointIn2[jj] + static_cast<DPointCoordRepType>(gradsign * vecsign * deltaTime / 6.0f) *
-                         (static_cast<DPointCoordRepType>(f1[jj]) + twoValue * static_cast<DPointCoordRepType>(f2[jj]) +
-                          twoValue * static_cast<DPointCoordRepType>(f3[jj]) + static_cast<DPointCoordRepType>(f4[jj]));
+        pointIn2[jj] + static_cast<DPointCoordinateType>(gradsign * vecsign * deltaTime / 6.0f) *
+                         (static_cast<DPointCoordinateType>(f1[jj]) + twoValue * static_cast<DPointCoordinateType>(f2[jj]) +
+                          twoValue * static_cast<DPointCoordinateType>(f3[jj]) + static_cast<DPointCoordinateType>(f4[jj]));
     }
 
     VectorType out;

--- a/Examples/ANTSUseDeformationFieldToGetAffineTransform.cxx
+++ b/Examples/ANTSUseDeformationFieldToGetAffineTransform.cxx
@@ -295,7 +295,7 @@ FetchLandmarkMappingFromDisplacementField(const std::string &                   
       VectorType displacement = field->GetPixel(index);
       for (unsigned int j = 0; j < ImageDimension; j++)
       {
-        point2[j] = point1[j] + static_cast<typename PointType::CoordRepType>(displacement[j]);
+        point2[j] = point1[j] + static_cast<typename PointType::CoordinateType>(displacement[j]);
       }
 
       fixedLandmarks.push_back(point1);

--- a/Examples/ANTSUseLandmarkImagesToGetAffineTransform.cxx
+++ b/Examples/ANTSUseLandmarkImagesToGetAffineTransform.cxx
@@ -316,7 +316,7 @@ LandmarkBasedTransformInitializerBA(int, char * argv[])
     }
     for (unsigned int i = 0; i < spacing.Size(); i++)
     {
-      myCenterOfMass[i] /= static_cast<typename LandmarkPointType::CoordRepType>(totalct);
+      myCenterOfMass[i] /= static_cast<typename LandmarkPointType::CoordinateType>(totalct);
     }
     //    std::cout << " pushing-mov " <<  myCenterOfMass << std::endl;
     movingLandmarks.push_back(myCenterOfMass);

--- a/Examples/LaplacianThickness.cxx
+++ b/Examples/LaplacianThickness.cxx
@@ -505,7 +505,7 @@ IntegrateLength(typename TImage::Pointer /* gmsurf */,
       typename DefaultInterpolatorType::ContinuousIndexType Y4;
       for (unsigned int jj = 0; jj < ImageDimension; jj++)
       {
-        pointIn2[jj] = static_cast<typename DPointType::CoordRepType>(disp[jj]) + pointIn1[jj];
+        pointIn2[jj] = static_cast<typename DPointType::CoordinateType>(disp[jj]) + pointIn1[jj];
         vcontind[jj] = pointIn2[jj] / lapgrad->GetSpacing()[jj];
         Y1[jj] = vcontind[jj];
         Y2[jj] = vcontind[jj];
@@ -518,13 +518,13 @@ IntegrateLength(typename TImage::Pointer /* gmsurf */,
       //      Y4[ImageDimension]=itime;
 
       using ContinuousIndexType = typename DefaultInterpolatorType::ContinuousIndexType;
-      using CoordRepType = typename ContinuousIndexType::CoordRepType;
+      using CoordinateType = typename ContinuousIndexType::CoordinateType;
 
       f1 = vinterp->EvaluateAtContinuousIndex(Y1);
       for (unsigned int jj = 0; jj < ImageDimension; jj++)
       {
         Y2[jj] +=
-          static_cast<CoordRepType>(f1[jj]) * static_cast<CoordRepType>(deltaTime) * static_cast<CoordRepType>(0.5);
+          static_cast<CoordinateType>(f1[jj]) * static_cast<CoordinateType>(deltaTime) * static_cast<CoordinateType>(0.5);
       }
       bool isinside = true;
       for (unsigned int jj = 0; jj < ImageDimension; jj++)
@@ -541,7 +541,7 @@ IntegrateLength(typename TImage::Pointer /* gmsurf */,
       for (unsigned int jj = 0; jj < ImageDimension; jj++)
       {
         Y3[jj] +=
-          static_cast<CoordRepType>(f2[jj]) * static_cast<CoordRepType>(deltaTime) * static_cast<CoordRepType>(0.5);
+          static_cast<CoordinateType>(f2[jj]) * static_cast<CoordinateType>(deltaTime) * static_cast<CoordinateType>(0.5);
       }
       isinside = true;
       for (unsigned int jj = 0; jj < ImageDimension; jj++)
@@ -557,7 +557,7 @@ IntegrateLength(typename TImage::Pointer /* gmsurf */,
       }
       for (unsigned int jj = 0; jj < ImageDimension; jj++)
       {
-        Y4[jj] += static_cast<CoordRepType>(f3[jj]) * static_cast<CoordRepType>(deltaTime);
+        Y4[jj] += static_cast<CoordinateType>(f3[jj]) * static_cast<CoordinateType>(deltaTime);
       }
       isinside = true;
       for (unsigned int jj = 0; jj < ImageDimension; jj++)
@@ -571,14 +571,14 @@ IntegrateLength(typename TImage::Pointer /* gmsurf */,
       {
         f4 = vinterp->EvaluateAtContinuousIndex(Y4);
       }
-      using DPointCoordRepType = typename DPointType::CoordRepType;
-      auto twoValue = static_cast<DPointCoordRepType>(2.0);
+      using DPointCoordinateType = typename DPointType::CoordinateType;
+      auto twoValue = static_cast<DPointCoordinateType>(2.0);
       for (unsigned int jj = 0; jj < ImageDimension; jj++)
       {
         pointIn3[jj] = pointIn2[jj] +
-                       static_cast<DPointCoordRepType>(gradsign * vecsign * deltaTime / 6.0f) *
-                         (static_cast<DPointCoordRepType>(f1[jj]) + twoValue * static_cast<DPointCoordRepType>(f2[jj]) +
-                          twoValue * static_cast<DPointCoordRepType>(f3[jj]) + static_cast<DPointCoordRepType>(f4[jj]));
+                       static_cast<DPointCoordinateType>(gradsign * vecsign * deltaTime / 6.0f) *
+                         (static_cast<DPointCoordinateType>(f1[jj]) + twoValue * static_cast<DPointCoordinateType>(f2[jj]) +
+                          twoValue * static_cast<DPointCoordinateType>(f3[jj]) + static_cast<DPointCoordinateType>(f4[jj]));
       }
 
       VectorType out;

--- a/Examples/MeasureImageSimilarity.cxx
+++ b/Examples/MeasureImageSimilarity.cxx
@@ -356,8 +356,8 @@ MeasureImageSimilarity(itk::ants::CommandLineParser * parser)
               // randomly perturb the point within a voxel (approximately)
               for (unsigned int d = 0; d < ImageDimension; d++)
               {
-                point[d] += static_cast<typename SamplePointType::CoordRepType>(randomizer->GetNormalVariate()) *
-                            static_cast<typename SamplePointType::CoordRepType>(oneThirdVirtualSpacing[d]);
+                point[d] += static_cast<typename SamplePointType::CoordinateType>(randomizer->GetNormalVariate()) *
+                            static_cast<typename SamplePointType::CoordinateType>(oneThirdVirtualSpacing[d]);
               }
               if (!fixedImageMask || fixedImageMask->IsInsideInWorldSpace(point))
               {
@@ -384,8 +384,8 @@ MeasureImageSimilarity(itk::ants::CommandLineParser * parser)
             // randomly perturb the point within a voxel (approximately)
             for (unsigned int d = 0; d < ImageDimension; d++)
             {
-              point[d] += static_cast<typename SamplePointType::CoordRepType>(randomizer->GetNormalVariate()) *
-                          static_cast<typename SamplePointType::CoordRepType>(oneThirdVirtualSpacing[d]);
+              point[d] += static_cast<typename SamplePointType::CoordinateType>(randomizer->GetNormalVariate()) *
+                          static_cast<typename SamplePointType::CoordinateType>(oneThirdVirtualSpacing[d]);
             }
             if (!fixedImageMask || fixedImageMask->IsInsideInWorldSpace(point))
             {

--- a/Examples/WarpImageMultiTransform.cxx
+++ b/Examples/WarpImageMultiTransform.cxx
@@ -364,7 +364,7 @@ WarpImageMultiTransform(char *           moving_image_filename,
   if (misc_opt.use_NN_interpolator)
   {
     using NNInterpolateType =
-      typename itk::NearestNeighborInterpolateImageFunction<ImageType, typename WarperType::CoordRepType>;
+      typename itk::NearestNeighborInterpolateImageFunction<ImageType, typename WarperType::CoordinateType>;
     typename NNInterpolateType::Pointer interpolator_NN = NNInterpolateType::New();
     std::cout << "User nearest neighbor interpolation (was Haha) " << std::endl;
     warper->SetInterpolator(interpolator_NN);
@@ -374,7 +374,7 @@ WarpImageMultiTransform(char *           moving_image_filename,
     std::cout << " Need to fix in main itk repository " << std::endl;
     //      typedef VectorPixelCompare<RealType, NVectorComponents> CompareType;
     //      typedef typename itk::LabelImageGaussianInterpolateImageFunction<ImageType,
-    //                                                                       typename WarperType::CoordRepType,
+    //                                                                       typename WarperType::CoordinateType,
     //                                                                       CompareType> MLInterpolateType;
     //      typename MLInterpolateType::Pointer interpolator_ML = MLInterpolateType::New();
     //
@@ -400,7 +400,7 @@ WarpImageMultiTransform(char *           moving_image_filename,
   {
     std::cout << " Not currently supported because of a lack of vector support " << std::endl;
     /*
-      typedef typename itk::BSplineInterpolateImageFunction<ImageType, typename WarperType::CoordRepType>
+      typedef typename itk::BSplineInterpolateImageFunction<ImageType, typename WarperType::CoordinateType>
       BSInterpolateType; typename BSInterpolateType::Pointer interpolator_BS = BSInterpolateType::New();
       interpolator_BS->SetSplineOrder(3);
       std::cout << "User B-spline interpolation " << std::endl;
@@ -410,7 +410,7 @@ WarpImageMultiTransform(char *           moving_image_filename,
   else
   {
     using LinInterpolateType =
-      typename itk::LinearInterpolateImageFunction<ImageType, typename WarperType::CoordRepType>;
+      typename itk::LinearInterpolateImageFunction<ImageType, typename WarperType::CoordinateType>;
     typename LinInterpolateType::Pointer interpolator_LN = LinInterpolateType::New();
     std::cout << "User Linear interpolation " << std::endl;
     warper->SetInterpolator(interpolator_LN);

--- a/Examples/WarpTensorImageMultiTransform.cxx
+++ b/Examples/WarpTensorImageMultiTransform.cxx
@@ -337,7 +337,7 @@ WarpImageMultiTransform(char *           moving_image_filename,
     if (misc_opt.use_NN_interpolator)
     {
       using NNInterpolateType =
-        typename itk::NearestNeighborInterpolateImageFunction<ImageType, typename WarperType::CoordRepType>;
+        typename itk::NearestNeighborInterpolateImageFunction<ImageType, typename WarperType::CoordinateType>;
       typename NNInterpolateType::Pointer interpolator_NN = NNInterpolateType::New();
       std::cout << "Haha" << std::endl;
       warper->SetInterpolator(interpolator_NN);

--- a/Examples/WarpTimeSeriesImageMultiTransform.cxx
+++ b/Examples/WarpTimeSeriesImageMultiTransform.cxx
@@ -311,7 +311,7 @@ WarpImageMultiTransformFourD(char *           moving_image_filename,
     if (misc_opt.use_NN_interpolator)
     {
       using NNInterpolateType =
-        typename itk::NearestNeighborInterpolateImageFunction<ImageType, typename WarperType::CoordRepType>;
+        typename itk::NearestNeighborInterpolateImageFunction<ImageType, typename WarperType::CoordinateType>;
       typename NNInterpolateType::Pointer interpolator_NN = NNInterpolateType::New();
       std::cout << " Use Nearest Neighbor interpolation " << std::endl;
       warper->SetInterpolator(interpolator_NN);
@@ -528,7 +528,7 @@ WarpImageMultiTransform(char *           moving_image_filename,
     if (misc_opt.use_NN_interpolator)
     {
       using NNInterpolateType =
-        typename itk::NearestNeighborInterpolateImageFunction<ImageType, typename WarperType::CoordRepType>;
+        typename itk::NearestNeighborInterpolateImageFunction<ImageType, typename WarperType::CoordinateType>;
       typename NNInterpolateType::Pointer interpolator_NN = NNInterpolateType::New();
       std::cout << "Haha" << std::endl;
       warper->SetInterpolator(interpolator_NN);

--- a/Examples/antsAI.cxx
+++ b/Examples/antsAI.cxx
@@ -208,7 +208,7 @@ PatchCorrelation(itk::NeighborhoodIterator<TImage> fixedNeighborhood,
       movingGradientImage->TransformIndexToPhysicalPoint(movingIndex, movingPoint);
       for (unsigned int d = 0; d < ImageDimension; d++)
       {
-        movingPointCentroid[d] += movingPoint[d] * static_cast<typename PointType::CoordRepType>(weight);
+        movingPointCentroid[d] += movingPoint[d] * static_cast<typename PointType::CoordinateType>(weight);
       }
       movingImagePatchPoints.push_back(movingPoint);
     }
@@ -276,7 +276,7 @@ PatchCorrelation(itk::NeighborhoodIterator<TImage> fixedNeighborhood,
     for (unsigned int d = 0; d < ImageDimension; d++)
     {
       movingImagePoint[d] =
-        static_cast<typename PointType::CoordRepType>(movingImagePointRotated[d]) + movingPointCentroid[d];
+        static_cast<typename PointType::CoordinateType>(movingImagePointRotated[d]) + movingPointCentroid[d];
     }
     if (movingInterpolator->IsInsideBuffer(movingImagePoint))
     {
@@ -1287,8 +1287,8 @@ antsAI(itk::ants::CommandLineParser * parser)
             // randomly perturb the point within a voxel (approximately)
             for (unsigned int d = 0; d < ImageDimension; d++)
             {
-              point[d] += static_cast<typename SamplePointType::CoordRepType>(randomizer->GetNormalVariate()) *
-                          static_cast<typename SamplePointType::CoordRepType>(oneThirdVirtualSpacing[d]);
+              point[d] += static_cast<typename SamplePointType::CoordinateType>(randomizer->GetNormalVariate()) *
+                          static_cast<typename SamplePointType::CoordinateType>(oneThirdVirtualSpacing[d]);
             }
             if (!fixedMaskSpatialObject || fixedMaskSpatialObject->IsInsideInWorldSpace(point))
             {
@@ -1315,7 +1315,7 @@ antsAI(itk::ants::CommandLineParser * parser)
           // randomly perturb the point within a voxel (approximately)
           for (unsigned int d = 0; d < ImageDimension; d++)
           {
-            point[d] += static_cast<typename SamplePointType::CoordRepType>(randomizer->GetNormalVariate() *
+            point[d] += static_cast<typename SamplePointType::CoordinateType>(randomizer->GetNormalVariate() *
                                                                             oneThirdVirtualSpacing[d]);
           }
           if (!fixedMaskSpatialObject || fixedMaskSpatialObject->IsInsideInWorldSpace(point))

--- a/ImageRegistration/itkANTSImageRegistrationOptimizer.cxx
+++ b/ImageRegistration/itkANTSImageRegistrationOptimizer.cxx
@@ -505,8 +505,8 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>::ComposeDiffs(DisplacementFiel
       }
       for (unsigned int jj = 0; jj < ImageDimension; jj++)
       {
-        pointIn3[jj] = static_cast<typename VPointType::CoordRepType>(disp2[jj]) *
-                         static_cast<typename VPointType::CoordRepType>(timesign) +
+        pointIn3[jj] = static_cast<typename VPointType::CoordinateType>(disp2[jj]) *
+                         static_cast<typename VPointType::CoordinateType>(timesign) +
                        pointIn2[jj];
       }
 
@@ -2758,14 +2758,14 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>::IntegratePointVelocity(TReal 
     {
       f4 = this->m_VelocityFieldInterpolator->Evaluate(Y4x);
     }
-    using xPointCoordRepType = typename xPointType::CoordRepType;
-    xPointCoordRepType twoValue = static_cast<xPointCoordRepType>(2.0);
+    using xPointCoordinateType = typename xPointType::CoordinateType;
+    xPointCoordinateType twoValue = static_cast<xPointCoordinateType>(2.0);
     for (unsigned int jj = 0; jj < TDimension; jj++)
     {
       pointIn3[jj] =
-        pointIn2[jj] + static_cast<xPointCoordRepType>(vecsign * deltaTime / 6.0f) *
-                         (static_cast<xPointCoordRepType>(f1[jj]) + twoValue * static_cast<xPointCoordRepType>(f2[jj]) +
-                          twoValue * static_cast<xPointCoordRepType>(f3[jj]) + static_cast<xPointCoordRepType>(f4[jj]));
+        pointIn2[jj] + static_cast<xPointCoordinateType>(vecsign * deltaTime / 6.0f) *
+                         (static_cast<xPointCoordinateType>(f1[jj]) + twoValue * static_cast<xPointCoordinateType>(f2[jj]) +
+                          twoValue * static_cast<xPointCoordinateType>(f3[jj]) + static_cast<xPointCoordinateType>(f4[jj]));
     }
     pointIn3[TDimension] = itime * static_cast<TReal>(m_NumberOfTimePoints - 1);
 
@@ -2908,14 +2908,14 @@ ANTSImageRegistrationOptimizer<TDimension, TReal>::IntegratePointVelocity(TReal 
       {
         f4 = this->m_VelocityFieldInterpolator->Evaluate(Y4x);
       }
-      using xPointCoordRepType = typename xPointType::CoordRepType;
-      xPointCoordRepType twoValue = static_cast<xPointCoordRepType>(2.0);
+      using xPointCoordinateType = typename xPointType::CoordinateType;
+      xPointCoordinateType twoValue = static_cast<xPointCoordinateType>(2.0);
       for (unsigned int jj = 0; jj < TDimension; jj++)
       {
         pointIn3[jj] = pointIn2[jj] +
-                       static_cast<xPointCoordRepType>(vecsign * deltaTime / 6.0f) *
-                         (static_cast<xPointCoordRepType>(f1[jj]) + twoValue * static_cast<xPointCoordRepType>(f2[jj]) +
-                          twoValue * static_cast<xPointCoordRepType>(f3[jj]) + static_cast<xPointCoordRepType>(f4[jj]));
+                       static_cast<xPointCoordinateType>(vecsign * deltaTime / 6.0f) *
+                         (static_cast<xPointCoordinateType>(f1[jj]) + twoValue * static_cast<xPointCoordinateType>(f2[jj]) +
+                          twoValue * static_cast<xPointCoordinateType>(f3[jj]) + static_cast<xPointCoordinateType>(f4[jj]));
       }
       pointIn3[TDimension] = itime * static_cast<TReal>(m_NumberOfTimePoints - 1);
 

--- a/ImageRegistration/itkAvantsMutualInformationRegistrationFunction.h
+++ b/ImageRegistration/itkAvantsMutualInformationRegistrationFunction.h
@@ -161,14 +161,14 @@ public:
   typedef typename Superclass::TimeStepType     TimeStepType;
 
   /** Interpolator type. */
-  typedef double CoordRepType;
-  typedef //       //    LinearInterpolateImageFunction<MovingImageType,CoordRepType>
-    BSplineInterpolateImageFunction<MovingImageType, CoordRepType>
+  typedef double CoordinateType;
+  typedef //       //    LinearInterpolateImageFunction<MovingImageType,CoordinateType>
+    BSplineInterpolateImageFunction<MovingImageType, CoordinateType>
                                                InterpolatorType;
   typedef typename InterpolatorType::Pointer   InterpolatorPointer;
   typedef typename InterpolatorType::PointType PointType;
   typedef InterpolatorType                     DefaultInterpolatorType;
-  //  typedef LinearInterpolateImageFunction<MovingImageType,CoordRepType>
+  //  typedef LinearInterpolateImageFunction<MovingImageType,CoordinateType>
   // DefaultInterpolatorType;
 
   /** Covariant vector type. */

--- a/ImageRegistration/itkCrossCorrelationRegistrationFunction.h
+++ b/ImageRegistration/itkCrossCorrelationRegistrationFunction.h
@@ -104,11 +104,11 @@ public:
   typedef typename Superclass::TimeStepType    TimeStepType;
 
   /** Interpolator type. */
-  typedef double                                                        CoordRepType;
-  typedef InterpolateImageFunction<MovingImageType, CoordRepType>       InterpolatorType;
+  typedef double                                                        CoordinateType;
+  typedef InterpolateImageFunction<MovingImageType, CoordinateType>       InterpolatorType;
   typedef typename InterpolatorType::Pointer                            InterpolatorPointer;
   typedef typename InterpolatorType::PointType                          PointType;
-  typedef LinearInterpolateImageFunction<MovingImageType, CoordRepType> DefaultInterpolatorType;
+  typedef LinearInterpolateImageFunction<MovingImageType, CoordinateType> DefaultInterpolatorType;
 
   /** Covariant vector type. */
   typedef CovariantVector<double, Self::ImageDimension> CovariantVectorType;

--- a/ImageRegistration/itkExpectationBasedPointSetRegistrationFunction.h
+++ b/ImageRegistration/itkExpectationBasedPointSetRegistrationFunction.h
@@ -111,7 +111,7 @@ public:
   using PointDataType = typename PointSetType::PixelType;
   using LabelSetType = std::vector<PointDataType>;
   //  typedef long PointDataType;
-  using MeasurementVectorType = Vector<typename PointSetType::CoordRepType, MeasurementDimension>;
+  using MeasurementVectorType = Vector<typename PointSetType::CoordinateType, MeasurementDimension>;
   using SampleType = typename Statistics::ListSample<MeasurementVectorType>;
   using TreeGeneratorType = typename Statistics::WeightedCentroidKdTreeGenerator<SampleType>;
   using NeighborhoodIdentifierType = typename TreeGeneratorType::KdTreeType::InstanceIdentifierVectorType;

--- a/ImageRegistration/itkExpectationBasedPointSetRegistrationFunction.hxx
+++ b/ImageRegistration/itkExpectationBasedPointSetRegistrationFunction.hxx
@@ -724,8 +724,8 @@ ExpectationBasedPointSetRegistrationFunction<TFixedImage, TMovingImage, TDisplac
           {
             for (unsigned int j = 0; j < ImageDimension; j++)
             {
-              mpt[j] += static_cast<typename ImagePointType::CoordRepType>(pp) *
-                        static_cast<typename ImagePointType::CoordRepType>(npt[j]);
+              mpt[j] += static_cast<typename ImagePointType::CoordinateType>(pp) *
+                        static_cast<typename ImagePointType::CoordinateType>(npt[j]);
             }
           }
           //

--- a/ImageRegistration/itkProbabilisticRegistrationFunction.h
+++ b/ImageRegistration/itkProbabilisticRegistrationFunction.h
@@ -104,11 +104,11 @@ public:
   typedef typename Superclass::TimeStepType    TimeStepType;
 
   /** Interpolator type. */
-  typedef double                                                        CoordRepType;
-  typedef InterpolateImageFunction<MovingImageType, CoordRepType>       InterpolatorType;
+  typedef double                                                        CoordinateType;
+  typedef InterpolateImageFunction<MovingImageType, CoordinateType>       InterpolatorType;
   typedef typename InterpolatorType::Pointer                            InterpolatorPointer;
   typedef typename InterpolatorType::PointType                          PointType;
-  typedef LinearInterpolateImageFunction<MovingImageType, CoordRepType> DefaultInterpolatorType;
+  typedef LinearInterpolateImageFunction<MovingImageType, CoordinateType> DefaultInterpolatorType;
 
   /** Covariant vector type. */
   typedef CovariantVector<double, Self::ImageDimension> CovariantVectorType;

--- a/ImageRegistration/itkSpatialMutualInformationRegistrationFunction.h
+++ b/ImageRegistration/itkSpatialMutualInformationRegistrationFunction.h
@@ -158,14 +158,14 @@ public:
   typedef typename Superclass::TimeStepType     TimeStepType;
 
   /** Interpolator type. */
-  typedef double CoordRepType;
-  typedef //       //    LinearInterpolateImageFunction<MovingImageType,CoordRepType>
-    BSplineInterpolateImageFunction<MovingImageType, CoordRepType>
+  typedef double CoordinateType;
+  typedef //       //    LinearInterpolateImageFunction<MovingImageType,CoordinateType>
+    BSplineInterpolateImageFunction<MovingImageType, CoordinateType>
                                                InterpolatorType;
   typedef typename InterpolatorType::Pointer   InterpolatorPointer;
   typedef typename InterpolatorType::PointType PointType;
   typedef InterpolatorType                     DefaultInterpolatorType;
-  //  typedef LinearInterpolateImageFunction<MovingImageType,CoordRepType>
+  //  typedef LinearInterpolateImageFunction<MovingImageType,CoordinateType>
   // DefaultInterpolatorType;
 
   /** Covariant vector type. */

--- a/ImageRegistration/itkSyNDemonsRegistrationFunction.h
+++ b/ImageRegistration/itkSyNDemonsRegistrationFunction.h
@@ -89,11 +89,11 @@ public:
   typedef typename Superclass::TimeStepType     TimeStepType;
 
   /** Interpolator type. */
-  typedef double                                                        CoordRepType;
-  typedef InterpolateImageFunction<MovingImageType, CoordRepType>       InterpolatorType;
+  typedef double                                                        CoordinateType;
+  typedef InterpolateImageFunction<MovingImageType, CoordinateType>       InterpolatorType;
   typedef typename InterpolatorType::Pointer                            InterpolatorPointer;
   typedef typename InterpolatorType::PointType                          PointType;
-  typedef LinearInterpolateImageFunction<MovingImageType, CoordRepType> DefaultInterpolatorType;
+  typedef LinearInterpolateImageFunction<MovingImageType, CoordinateType> DefaultInterpolatorType;
 
   /** Covariant vector type. */
   typedef CovariantVector<double, Self::ImageDimension> CovariantVectorType;
@@ -103,7 +103,7 @@ public:
   typedef typename GradientCalculatorType::Pointer       GradientCalculatorPointer;
 
   /** Moving image gradient calculator type. */
-  typedef CentralDifferenceImageFunction<MovingImageType, CoordRepType> MovingImageGradientCalculatorType;
+  typedef CentralDifferenceImageFunction<MovingImageType, CoordinateType> MovingImageGradientCalculatorType;
   typedef typename MovingImageGradientCalculatorType::Pointer           MovingImageGradientCalculatorPointer;
 
   /** Set the moving image interpolator. */

--- a/ImageSegmentation/antsAtroposSegmentationImageFilter.hxx
+++ b/ImageSegmentation/antsAtroposSegmentationImageFilter.hxx
@@ -102,7 +102,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>::Atrop
 
   this->m_RandomizerInitializationSeed = std::numeric_limits<RandomizerSeedType>::quiet_NaN();
   this->m_Randomizer = RandomizerType::New();
-  this->m_Randomizer->Initialize();
+  this->m_Randomizer->SetSeed();
 
   this->m_MaximumICMCode = 0;
   this->m_InitialAnnealingTemperature = 1.0;
@@ -124,7 +124,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>::SetRa
   if (seed != this->m_RandomizerInitializationSeed)
   {
     this->m_RandomizerInitializationSeed = seed;
-    this->m_Randomizer->Initialize(this->m_RandomizerInitializationSeed);
+    this->m_Randomizer->SetSeed(this->m_RandomizerInitializationSeed);
     this->Modified();
   }
 }

--- a/ImageSegmentation/antsHistogramParzenWindowsListSampleFunction.hxx
+++ b/ImageSegmentation/antsHistogramParzenWindowsListSampleFunction.hxx
@@ -98,10 +98,10 @@ HistogramParzenWindowsListSampleFunction<TListSample, TOutput, TCoordRep>::SetIn
 
     using HistogramPointType = typename HistogramImageType::PointType;
     HistogramPointType origin;
-    origin[0] = static_cast<typename HistogramPointType::CoordRepType>(minValues[d]) -
-                static_cast<typename HistogramPointType::CoordRepType>(3.0) *
-                  (static_cast<typename HistogramPointType::CoordRepType>(this->m_Sigma) *
-                   static_cast<typename HistogramPointType::CoordRepType>(spacing[0]));
+    origin[0] = static_cast<typename HistogramPointType::CoordinateType>(minValues[d]) -
+                static_cast<typename HistogramPointType::CoordinateType>(3.0) *
+                  (static_cast<typename HistogramPointType::CoordinateType>(this->m_Sigma) *
+                   static_cast<typename HistogramPointType::CoordinateType>(spacing[0]));
 
     typename HistogramImageType::SizeType size;
     size[0] = static_cast<unsigned int>(

--- a/ImageSegmentation/antsJointHistogramParzenShapeAndOrientationListSampleFunction.hxx
+++ b/ImageSegmentation/antsJointHistogramParzenShapeAndOrientationListSampleFunction.hxx
@@ -265,10 +265,10 @@ JointHistogramParzenShapeAndOrientationListSampleFunction<TListSample, TOutput, 
 
   // note, if a point maps to 0 or 2*pi then it should contribute to both bins -- pretty much only difference between
   // this function and matlab code is the next 15 or so lines, as far as we see
-  orientPoint[0] = static_cast<typename JointHistogramImagePointType::CoordRepType>(
+  orientPoint[0] = static_cast<typename JointHistogramImagePointType::CoordinateType>(
     psi / static_cast<RealType>(Math::pi) * static_cast<RealType>(this->m_NumberOfOrientationJointHistogramBins - 1) +
     NumericTraits<RealType>::OneValue());
-  orientPoint[1] = static_cast<typename JointHistogramImagePointType::CoordRepType>(
+  orientPoint[1] = static_cast<typename JointHistogramImagePointType::CoordinateType>(
     (theta + static_cast<RealType>(Math::pi_over_2)) / static_cast<RealType>(Math::pi) *
     static_cast<RealType>(this->m_NumberOfOrientationJointHistogramBins - 1));
 

--- a/ImageSegmentation/antsListSampleFunction.h
+++ b/ImageSegmentation/antsListSampleFunction.h
@@ -65,8 +65,8 @@ public:
   /** OutputType typedef support. */
   typedef TOutput OutputType;
 
-  /** CoordRepType typedef support. */
-  typedef TCoordRep CoordRepType;
+  /** CoordinateType typedef support. */
+  typedef TCoordRep CoordinateType;
 
   /** Set the input point set.
    * \warning this method caches BufferedRegion information.

--- a/Tensor/itkWarpTensorImageMultiTransformFilter.h
+++ b/Tensor/itkWarpTensorImageMultiTransformFilter.h
@@ -132,15 +132,15 @@ public:
   typedef typename TransformType::Pointer TransformTypePointer;
 
   /** Interpolator typedef support. */
-  typedef double                                                                    CoordRepType;
-  typedef VectorInterpolateImageFunction<InputImageType, CoordRepType>              InterpolatorType;
+  typedef double                                                                    CoordinateType;
+  typedef VectorInterpolateImageFunction<InputImageType, CoordinateType>              InterpolatorType;
   typedef typename InterpolatorType::Pointer                                        InterpolatorPointer;
-  typedef VectorLinearInterpolateImageFunction<InputImageType, CoordRepType>        DefaultInterpolatorType;
-  typedef VectorLinearInterpolateImageFunction<DisplacementFieldType, CoordRepType> DefaultVectorInterpolatorType;
+  typedef VectorLinearInterpolateImageFunction<InputImageType, CoordinateType>        DefaultInterpolatorType;
+  typedef VectorLinearInterpolateImageFunction<DisplacementFieldType, CoordinateType> DefaultVectorInterpolatorType;
   typedef typename DefaultVectorInterpolatorType::Pointer                           VectorInterpolatorPointer;
 
   /** Point type */
-  typedef Point<CoordRepType, Self::ImageDimension> PointType;
+  typedef Point<CoordinateType, Self::ImageDimension> PointType;
 
   typedef struct _DeformationTypeEx
   {

--- a/Utilities/itkLabeledPointSetFileWriter.hxx
+++ b/Utilities/itkLabeledPointSetFileWriter.hxx
@@ -86,7 +86,7 @@ LabeledPointSetFileWriter<TInputMesh>::GenerateData()
   {
     typedef BoundingBox<unsigned long,
                         Dimension,
-                        typename TInputMesh::CoordRepType,
+                        typename TInputMesh::CoordinateType,
                         typename TInputMesh::PointsContainer>
                                       BoundingBoxType;
     typename BoundingBoxType::Pointer bbox = BoundingBoxType::New();

--- a/Utilities/itkManifoldParzenWindowsPointSetFunction.h
+++ b/Utilities/itkManifoldParzenWindowsPointSetFunction.h
@@ -57,7 +57,7 @@ public:
   typedef typename PointSetType::PointType                     PointType;
   typedef typename PointSetType ::PointsContainerConstIterator PointsContainerConstIterator;
 
-  typedef Vector<typename PointSetType::CoordRepType, Self::Dimension> MeasurementVectorType;
+  typedef Vector<typename PointSetType::CoordinateType, Self::Dimension> MeasurementVectorType;
   typedef typename Statistics::ListSample<MeasurementVectorType>                         SampleType;
   typedef typename Statistics ::WeightedCentroidKdTreeGenerator<SampleType>              TreeGeneratorType;
   typedef typename TreeGeneratorType::KdTreeType                                         KdTreeType;

--- a/Utilities/itkPointSetFunction.h
+++ b/Utilities/itkPointSetFunction.h
@@ -76,8 +76,8 @@ public:
   /** OutputType typedef support. */
   typedef TOutput OutputType;
 
-  /** CoordRepType typedef support. */
-  typedef TCoordRep CoordRepType;
+  /** CoordinateType typedef support. */
+  typedef TCoordRep CoordinateType;
 
   /** Set the input point set.
    * \warning this method caches BufferedRegion information.

--- a/Utilities/itkWarpImageMultiTransformFilter.h
+++ b/Utilities/itkWarpImageMultiTransformFilter.h
@@ -135,16 +135,16 @@ public:
   typedef typename TransformType::Pointer TransformTypePointer;
 
   /** Interpolator typedef support. */
-  typedef double                                                                      CoordRepType;
-  typedef InterpolateImageFunction<InputImageType, CoordRepType>                      InterpolatorType;
+  typedef double                                                                      CoordinateType;
+  typedef InterpolateImageFunction<InputImageType, CoordinateType>                      InterpolatorType;
   typedef typename InterpolatorType::Pointer                                          InterpolatorPointer;
-  typedef LinearInterpolateImageFunction<InputImageType, CoordRepType>                DefaultInterpolatorType;
-  typedef VectorLinearInterpolateImageFunction<DisplacementFieldType, CoordRepType>   DefaultVectorInterpolatorType;
-  typedef VectorGaussianInterpolateImageFunction<DisplacementFieldType, CoordRepType> DefaultVectorInterpolatorType2;
+  typedef LinearInterpolateImageFunction<InputImageType, CoordinateType>                DefaultInterpolatorType;
+  typedef VectorLinearInterpolateImageFunction<DisplacementFieldType, CoordinateType>   DefaultVectorInterpolatorType;
+  typedef VectorGaussianInterpolateImageFunction<DisplacementFieldType, CoordinateType> DefaultVectorInterpolatorType2;
   typedef typename DefaultVectorInterpolatorType::Pointer                             VectorInterpolatorPointer;
 
   /** Point type */
-  typedef Point<CoordRepType, Self::ImageDimension> PointType;
+  typedef Point<CoordinateType, Self::ImageDimension> PointType;
 
   typedef struct _DeformationTypeEx
   {

--- a/Utilities/itkWarpImageWAffineFilter.h
+++ b/Utilities/itkWarpImageWAffineFilter.h
@@ -125,13 +125,13 @@ public:
   typedef typename TransformType::Pointer TransformTypePointer;
 
   /** Interpolator typedef support. */
-  typedef double                                                       CoordRepType;
-  typedef InterpolateImageFunction<InputImageType, CoordRepType>       InterpolatorType;
+  typedef double                                                       CoordinateType;
+  typedef InterpolateImageFunction<InputImageType, CoordinateType>       InterpolatorType;
   typedef typename InterpolatorType::Pointer                           InterpolatorPointer;
-  typedef LinearInterpolateImageFunction<InputImageType, CoordRepType> DefaultInterpolatorType;
+  typedef LinearInterpolateImageFunction<InputImageType, CoordinateType> DefaultInterpolatorType;
 
   /** Point type */
-  typedef Point<CoordRepType, Self::ImageDimension> PointType;
+  typedef Point<CoordinateType, Self::ImageDimension> PointType;
 
   /** Set the deformation field. */
   void

--- a/Utilities/itkWarpTensorImageMultiTransformFilter.h
+++ b/Utilities/itkWarpTensorImageMultiTransformFilter.h
@@ -131,15 +131,15 @@ public:
   typedef typename TransformType::Pointer TransformTypePointer;
 
   /** Interpolator typedef support. */
-  typedef double                                                                    CoordRepType;
-  typedef VectorInterpolateImageFunction<InputImageType, CoordRepType>              InterpolatorType;
+  typedef double                                                                    CoordinateType;
+  typedef VectorInterpolateImageFunction<InputImageType, CoordinateType>              InterpolatorType;
   typedef typename InterpolatorType::Pointer                                        InterpolatorPointer;
-  typedef VectorLinearInterpolateImageFunction<InputImageType, CoordRepType>        DefaultInterpolatorType;
-  typedef VectorLinearInterpolateImageFunction<DisplacementFieldType, CoordRepType> DefaultVectorInterpolatorType;
+  typedef VectorLinearInterpolateImageFunction<InputImageType, CoordinateType>        DefaultInterpolatorType;
+  typedef VectorLinearInterpolateImageFunction<DisplacementFieldType, CoordinateType> DefaultVectorInterpolatorType;
   typedef typename DefaultVectorInterpolatorType::Pointer                           VectorInterpolatorPointer;
 
   /** Point type */
-  typedef Point<CoordRepType, Self::ImageDimension> PointType;
+  typedef Point<CoordinateType, Self::ImageDimension> PointType;
 
   typedef struct _DeformationTypeEx
   {


### PR DESCRIPTION
# Description

For the sake of code readability, a new 'CoordinateType' alias is added for
each nested 'CoordRepType' alias. The old 'CoordRepType' aliases will still be
available with ITK 6.0, but it is recommended to use 'CoordinateType' instead.
The 'CoordRepType' aliases will be removed when 'ITK_FUTURE_LEGACY_REMOVE' is
enabled. Similarly, 'InputCoordinateType', 'OutputCoordinateType', and
'ImagePointCoordinateType' replace 'InputCoordRepType', 'OutputCoordRepType',
and 'ImagePointCoordRepType', respectively.

Used ITK/Utilities/Maintenance/migrate-itk6-code-recommendations.sh to apply updates.

<!--
Text in these brackets are comments, and won't be visible when you submit your
pull request.

We welcome contributions to ANTs. Pull requests will be reviewed by the
developers and if accepted, become part of ANTs, distributed under the license
terms in COPYING.txt.

Please title your PR according to what it does:
ENH: new or improved functionality
PERF: performance enhancements to existing functionality
BUG: fixing a run time bug
COMP: relating to compilation
DOC: documentation changes
WIP: work in progress, needs further commits to be ready
-->


<!--
Extended description of your PR.

If the PR can close an existing issue, you can say "Fixes #1234" or "Resolves
#1234". Otherwise you can say something like "Related to #1234".
-->


