### PR TITLE
CI: Update macOS version in release workflow

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -40,8 +40,8 @@ jobs:
             generators: "Ninja"
         }
         - {
-            name: "Macos-13-clang",
-            os: macos-13,
+            name: "Macos-15-intel-clang",
+            os: macos-15-intel,
             cc: "clang",
             cxx: "clang++",
             build_type: "Release",


### PR DESCRIPTION
macos-13 runners are being shut down

<!--
Text in these brackets are comments, and won't be visible when you submit your
pull request.

We welcome contributions to ANTs. Pull requests will be reviewed by the
developers and if accepted, become part of ANTs, distributed under the license
terms in COPYING.txt.

Please title your PR according to what it does:
ENH: new or improved functionality
PERF: performance enhancements to existing functionality
BUG: fixing a run time bug
COMP: relating to compilation
DOC: documentation changes
WIP: work in progress, needs further commits to be ready
-->

# Description

MacOS 15 will be the last supported Intel runner


