### PR TITLE
ENH: ANTsPy needs specific image cast for vectors

### DIFF
--- a/Examples/antsApplyTransforms.cxx
+++ b/Examples/antsApplyTransforms.cxx
@@ -819,7 +819,7 @@ antsApplyTransforms(itk::ants::CommandLineParser::Pointer & parser, unsigned int
         caster->SetInput(reorienter->GetOutput());
         caster->Update();
 
-        ANTs::WriteImage<OutputDisplacementFieldType>(caster->GetOutput(), (outputFileName).c_str());
+        WriteVectorImage<OutputDisplacementFieldType>(caster->GetOutput(), (outputFileName).c_str());
       }
       else if (inputImageType == 2)
       {


### PR DESCRIPTION
As with tensors, the pointer has to be cast to the right kind of vector image
