### PR TITLE
ENH: Deduplicate image reads in antsRegistration multi-stage registration.

### DIFF
--- a/Examples/antsRegistrationTemplateHeader.h
+++ b/Examples/antsRegistrationTemplateHeader.h
@@ -21,6 +21,8 @@
 #include "itkLabelImageGenericInterpolateImageFunction.h"
 #include "include/antsRegistration.h"
 #include "ReadWriteData.h"
+#include <filesystem>
+#include <map>
 
 namespace ants
 {
@@ -945,6 +947,21 @@ DoRegistration(typename ParserType::Pointer & parser)
   // ID to the added metric.  Multiple metrics for a single stage are specified
   // on the command line by being specified adjacently.
 
+  std::map<std::string, typename ImageType::Pointer> imageCache;
+
+  auto getCachedImage = [&imageCache](const std::string & filename) -> typename ImageType::Pointer {
+    std::error_code                   ec;
+    std::filesystem::path             canonicalPath = std::filesystem::canonical(filename, ec);
+    std::string                       key = ec ? filename : canonicalPath.string();
+    typename ImageType::Pointer &     cached = imageCache[key];
+    if (cached.IsNull())
+    {
+      ReadImage<ImageType>(cached, filename.c_str());
+      cached->DisconnectPipeline();
+    }
+    return cached;
+  };
+
   unsigned int numberOfMetrics = metricOption->GetNumberOfFunctions();
   for (int currentMetricNumber = numberOfMetrics - 1; currentMetricNumber >= 0; currentMetricNumber--)
   {
@@ -1028,10 +1045,8 @@ DoRegistration(typename ParserType::Pointer & parser)
         std::cout << "  moving image: " << movingFileName << std::endl;
       }
 
-      ReadImage<ImageType>(fixedImage, fixedFileName.c_str());
-      ReadImage<ImageType>(movingImage, movingFileName.c_str());
-      fixedImage->DisconnectPipeline();
-      movingImage->DisconnectPipeline();
+      fixedImage = getCachedImage(fixedFileName);
+      movingImage = getCachedImage(movingFileName);
 
       std::string strategy = "none";
       if (metricOption->GetFunction(currentMetricNumber)->GetNumberOfParameters() > 4)
@@ -1252,18 +1267,8 @@ DoRegistration(typename ParserType::Pointer & parser)
     itk::NumericTraits<typename ImageType::SpacingType::ValueType>::ZeroValue());
   if (!std::strcmp(whichInterpolator.c_str(), "gaussian") || !std::strcmp(whichInterpolator.c_str(), "multilabel"))
   {
-#if 1
-    // HACK:: This can just be cached when reading the fixedImage from above!!
-    //
     std::string fixedImageFileName = metricOption->GetFunction(numberOfTransforms - 1)->GetParameter(0);
-
-    typedef itk::ImageFileReader<ImageType> ImageReaderType;
-    typename ImageReaderType::Pointer       fixedImageReader = ImageReaderType::New();
-
-    fixedImageReader->SetFileName(fixedImageFileName.c_str());
-    fixedImageReader->Update();
-    typename ImageType::Pointer fixedImage = fixedImageReader->GetOutput();
-#endif
+    typename ImageType::Pointer fixedImage = getCachedImage(fixedImageFileName);
     cache_spacing_for_smoothing_sigmas = fixedImage->GetSpacing();
   }
 


### PR DESCRIPTION
## Disclosure

Generated using OpenCode with karpathy-guidelines and GLM-5.1.

## Summary

Addresses #758 

- Each `--metric` stage in `antsRegistration` independently called `ReadImage()` from disk, creating separate pixel buffers even when the same file was specified across stages
- For N transform stages (e.g., Rigid + Similarity + Affine), this produced N copies of each image in memory (N fixed + N moving = 2N total), when only 2 shared copies are needed
- Adds an image cache with `std::filesystem::canonical()` path deduplication that reuses ITK `SmartPointer` references (zero-copy pixel buffer sharing)
- Also eliminates the long-standing HACK that re-read the fixed image from disk just to get spacing for gaussian/multilabel interpolation

## Memory impact

For a typical 3-stage registration (Rigid + Similarity + Affine) on identical images:

| | Before | After |
|---|---|---|
| Persistent image copies | 6 (3 fixed + 3 moving) | 2 (1 shared fixed + 1 shared moving) |

## Safety

Images stored in metrics are used read-only after loading — `PreprocessImage()` creates new copies via `IntensityWindowingImageFilter`, and images are accessed as `ConstPointer` during registration. Shared pixel buffers are never mutated.

## Changes

- `Examples/antsRegistrationTemplateHeader.h`: Added `imageCache` map and `getCachedImage` lambda with canonical path resolution; replaced direct `ReadImage()` calls with cache lookups; removed HACK re-read for spacing lookup.
