### PR TITLE
ENH: Deduplicate all image reads in antsRegistration

### DIFF
--- a/Examples/antsRegistrationTemplateHeader.h
+++ b/Examples/antsRegistrationTemplateHeader.h
@@ -342,6 +342,20 @@ DoRegistration(typename ParserType::Pointer & parser)
     return cached;
   };
 
+  std::map<std::string, typename MaskImageType::Pointer> maskCache;
+
+  auto getCachedMask = [&maskCache](const std::string & filename) -> typename MaskImageType::Pointer {
+    std::error_code                        ec;
+    std::filesystem::path                  canonicalPath = std::filesystem::canonical(filename, ec);
+    std::string                            key = ec ? filename : canonicalPath.string();
+    typename MaskImageType::Pointer &      cached = maskCache[key];
+    if (cached.IsNull())
+    {
+      ReadImage<MaskImageType>(cached, filename.c_str());
+    }
+    return cached;
+  };
+
   if (maskOption && maskOption->GetNumberOfFunctions())
   {
     if (verbose)
@@ -359,8 +373,7 @@ DoRegistration(typename ParserType::Pointer & parser)
         for (unsigned m = 0; m < maskOption->GetFunction(l)->GetNumberOfParameters(); m++)
         {
           std::string                     fname = maskOption->GetFunction(l)->GetParameter(m);
-          typename MaskImageType::Pointer maskImage;
-          ReadImage<MaskImageType>(maskImage, fname.c_str());
+          typename MaskImageType::Pointer maskImage = getCachedMask(fname);
           if (m == 0)
           {
             regHelper->AddFixedImageMask(maskImage);
@@ -396,8 +409,7 @@ DoRegistration(typename ParserType::Pointer & parser)
       else
       {
         std::string                     fname = maskOption->GetFunction(l)->GetName();
-        typename MaskImageType::Pointer maskImage;
-        ReadImage<MaskImageType>(maskImage, fname.c_str());
+        typename MaskImageType::Pointer maskImage = getCachedMask(fname);
         regHelper->AddFixedImageMask(maskImage);
         if (verbose)
         {

--- a/Examples/antsRegistrationTemplateHeader.h
+++ b/Examples/antsRegistrationTemplateHeader.h
@@ -327,6 +327,21 @@ DoRegistration(typename ParserType::Pointer & parser)
     }
   }
 
+  std::map<std::string, typename ImageType::Pointer> imageCache;
+
+  auto getCachedImage = [&imageCache](const std::string & filename) -> typename ImageType::Pointer {
+    std::error_code                   ec;
+    std::filesystem::path             canonicalPath = std::filesystem::canonical(filename, ec);
+    std::string                       key = ec ? filename : canonicalPath.string();
+    typename ImageType::Pointer &     cached = imageCache[key];
+    if (cached.IsNull())
+    {
+      ReadImage<ImageType>(cached, filename.c_str());
+      cached->DisconnectPipeline();
+    }
+    return cached;
+  };
+
   if (maskOption && maskOption->GetNumberOfFunctions())
   {
     if (verbose)
@@ -946,21 +961,6 @@ DoRegistration(typename ParserType::Pointer & parser)
   // line and add it the registration helper.  We also need to assign the stage
   // ID to the added metric.  Multiple metrics for a single stage are specified
   // on the command line by being specified adjacently.
-
-  std::map<std::string, typename ImageType::Pointer> imageCache;
-
-  auto getCachedImage = [&imageCache](const std::string & filename) -> typename ImageType::Pointer {
-    std::error_code                   ec;
-    std::filesystem::path             canonicalPath = std::filesystem::canonical(filename, ec);
-    std::string                       key = ec ? filename : canonicalPath.string();
-    typename ImageType::Pointer &     cached = imageCache[key];
-    if (cached.IsNull())
-    {
-      ReadImage<ImageType>(cached, filename.c_str());
-      cached->DisconnectPipeline();
-    }
-    return cached;
-  };
 
   unsigned int numberOfMetrics = metricOption->GetNumberOfFunctions();
   for (int currentMetricNumber = numberOfMetrics - 1; currentMetricNumber >= 0; currentMetricNumber--)

--- a/Examples/antsRegistrationTemplateHeader.h
+++ b/Examples/antsRegistrationTemplateHeader.h
@@ -352,6 +352,7 @@ DoRegistration(typename ParserType::Pointer & parser)
     if (cached.IsNull())
     {
       ReadImage<MaskImageType>(cached, filename.c_str());
+      cached->DisconnectPipeline();
     }
     return cached;
   };

--- a/Examples/antsRegistrationTemplateHeader.h
+++ b/Examples/antsRegistrationTemplateHeader.h
@@ -707,9 +707,7 @@ DoRegistration(typename ParserType::Pointer & parser)
 
         if (meshSizeForTheUpdateField.size() == 1)
         {
-          typename ImageType::Pointer fixedImage;
-          ReadImage<ImageType>(fixedImage, fixedImageFileName.c_str());
-          fixedImage->DisconnectPipeline();
+          typename ImageType::Pointer fixedImage = getCachedImage(fixedImageFileName);
 
           meshSizeForTheUpdateField =
             regHelper->CalculateMeshSizeForSpecifiedKnotSpacing(fixedImage, meshSizeForTheUpdateField[0], splineOrder);
@@ -722,9 +720,7 @@ DoRegistration(typename ParserType::Pointer & parser)
             parser->ConvertVector<unsigned int>(transformOption->GetFunction(currentStage)->GetParameter(2));
           if (meshSizeForTheTotalField.size() == 1)
           {
-            typename ImageType::Pointer fixedImage;
-            ReadImage<ImageType>(fixedImage, fixedImageFileName.c_str());
-            fixedImage->DisconnectPipeline();
+            typename ImageType::Pointer fixedImage = getCachedImage(fixedImageFileName);
 
             meshSizeForTheTotalField =
               regHelper->CalculateMeshSizeForSpecifiedKnotSpacing(fixedImage, meshSizeForTheTotalField[0], splineOrder);
@@ -748,9 +744,7 @@ DoRegistration(typename ParserType::Pointer & parser)
           parser->ConvertVector<unsigned int>(transformOption->GetFunction(currentStage)->GetParameter(1));
         if (meshSizeAtBaseLevel.size() == 1)
         {
-          typename ImageType::Pointer fixedImage;
-          ReadImage<ImageType>(fixedImage, fixedImageFileName.c_str());
-          fixedImage->DisconnectPipeline();
+          typename ImageType::Pointer fixedImage = getCachedImage(fixedImageFileName);
 
           meshSizeAtBaseLevel =
             regHelper->CalculateMeshSizeForSpecifiedKnotSpacing(fixedImage, meshSizeAtBaseLevel[0], 3);
@@ -829,9 +823,7 @@ DoRegistration(typename ParserType::Pointer & parser)
           parser->ConvertVector<float>(transformOption->GetFunction(currentStage)->GetParameter(1));
         if (meshSizeForTheUpdateFieldFloat.size() == 1)
         {
-          typename ImageType::Pointer fixedImage;
-          ReadImage<ImageType>(fixedImage, fixedImageFileName.c_str());
-          fixedImage->DisconnectPipeline();
+          typename ImageType::Pointer fixedImage = getCachedImage(fixedImageFileName);
 
           meshSizeForTheUpdateField = regHelper->CalculateMeshSizeForSpecifiedKnotSpacing(
             fixedImage, meshSizeForTheUpdateFieldFloat[0], splineOrder);
@@ -849,9 +841,7 @@ DoRegistration(typename ParserType::Pointer & parser)
             parser->ConvertVector<float>(transformOption->GetFunction(currentStage)->GetParameter(2));
           if (meshSizeForTheTotalFieldFloat.size() == 1)
           {
-            typename ImageType::Pointer fixedImage;
-            ReadImage<ImageType>(fixedImage, fixedImageFileName.c_str());
-            fixedImage->DisconnectPipeline();
+            typename ImageType::Pointer fixedImage = getCachedImage(fixedImageFileName);
 
             meshSizeForTheTotalField = regHelper->CalculateMeshSizeForSpecifiedKnotSpacing(
               fixedImage, meshSizeForTheTotalFieldFloat[0], splineOrder);
@@ -903,9 +893,7 @@ DoRegistration(typename ParserType::Pointer & parser)
           parser->ConvertVector<unsigned int>(transformOption->GetFunction(currentStage)->GetParameter(1));
         if (meshSizeForTheUpdateField.size() == 1)
         {
-          typename ImageType::Pointer fixedImage;
-          ReadImage<ImageType>(fixedImage, fixedImageFileName.c_str());
-          fixedImage->DisconnectPipeline();
+          typename ImageType::Pointer fixedImage = getCachedImage(fixedImageFileName);
 
           meshSizeForTheUpdateField =
             regHelper->CalculateMeshSizeForSpecifiedKnotSpacing(fixedImage, meshSizeForTheUpdateField[0], splineOrder);
@@ -918,9 +906,7 @@ DoRegistration(typename ParserType::Pointer & parser)
             parser->ConvertVector<unsigned int>(transformOption->GetFunction(currentStage)->GetParameter(2));
           if (meshSizeForTheVelocityField.size() == 1)
           {
-            typename ImageType::Pointer fixedImage;
-            ReadImage<ImageType>(fixedImage, fixedImageFileName.c_str());
-            fixedImage->DisconnectPipeline();
+            typename ImageType::Pointer fixedImage = getCachedImage(fixedImageFileName);
 
             meshSizeForTheVelocityField = regHelper->CalculateMeshSizeForSpecifiedKnotSpacing(
               fixedImage, meshSizeForTheVelocityField[0], splineOrder);

--- a/Examples/antsRegistrationTemplateHeader.h
+++ b/Examples/antsRegistrationTemplateHeader.h
@@ -21,6 +21,8 @@
 #include "itkLabelImageGenericInterpolateImageFunction.h"
 #include "include/antsRegistration.h"
 #include "ReadWriteData.h"
+#include <filesystem>
+#include <map>
 
 namespace ants
 {
@@ -945,6 +947,21 @@ DoRegistration(typename ParserType::Pointer & parser)
   // ID to the added metric.  Multiple metrics for a single stage are specified
   // on the command line by being specified adjacently.
 
+  std::map<std::string, typename ImageType::Pointer> imageCache;
+
+  auto getCachedImage = [&imageCache](const std::string & filename) -> typename ImageType::Pointer {
+    std::error_code                   ec;
+    std::filesystem::path             canonicalPath = std::filesystem::canonical(filename, ec);
+    std::string                       key = ec ? filename : canonicalPath.string();
+    typename ImageType::Pointer &     cached = imageCache[key];
+    if (cached.IsNull())
+    {
+      ReadImage<ImageType>(cached, filename.c_str());
+      cached->DisconnectPipeline();
+    }
+    return cached;
+  };
+
   unsigned int numberOfMetrics = metricOption->GetNumberOfFunctions();
   for (int currentMetricNumber = numberOfMetrics - 1; currentMetricNumber >= 0; currentMetricNumber--)
   {
@@ -1028,10 +1045,8 @@ DoRegistration(typename ParserType::Pointer & parser)
         std::cout << "  moving image: " << movingFileName << std::endl;
       }
 
-      ReadImage<ImageType>(fixedImage, fixedFileName.c_str());
-      ReadImage<ImageType>(movingImage, movingFileName.c_str());
-      fixedImage->DisconnectPipeline();
-      movingImage->DisconnectPipeline();
+      fixedImage = getCachedImage(fixedFileName);
+      movingImage = getCachedImage(movingFileName);
 
       std::string strategy = "none";
       if (metricOption->GetFunction(currentMetricNumber)->GetNumberOfParameters() > 4)
@@ -1252,18 +1267,8 @@ DoRegistration(typename ParserType::Pointer & parser)
     itk::NumericTraits<typename ImageType::SpacingType::ValueType>::ZeroValue());
   if (!std::strcmp(whichInterpolator.c_str(), "gaussian") || !std::strcmp(whichInterpolator.c_str(), "multilabel"))
   {
-#if 1
-    // HACK:: This can just be cached when reading the fixedImage from above!!
-    //
     std::string fixedImageFileName = metricOption->GetFunction(numberOfTransforms - 1)->GetParameter(0);
-
-    typedef itk::ImageFileReader<ImageType> ImageReaderType;
-    typename ImageReaderType::Pointer       fixedImageReader = ImageReaderType::New();
-
-    fixedImageReader->SetFileName(fixedImageFileName.c_str());
-    fixedImageReader->Update();
-    typename ImageType::Pointer fixedImage = fixedImageReader->GetOutput();
-#endif
+    typename ImageType::Pointer fixedImage = getCachedImage(fixedImageFileName);
     cache_spacing_for_smoothing_sigmas = fixedImage->GetSpacing();
   }
 


### PR DESCRIPTION
# AI Disclosure

Generated using OpenCode with karpathy-guidelines and GLM-5.1.

## Summary

Followup to PR #1969, includes that commit here.

- **Mask images** (commit 3): Same duplication pattern — each `--masks` specification read the mask file independently. Now cached via `maskCache`.
- **B-spline mesh size** (commit 4): Seven `ReadImage` calls across BSplineDisplacementField, BSpline, BSplineSyN, and BSplineExponential each read the fixed image independently for mesh size calculation. All now use the shared `imageCache`.

## Memory impact

For a typical 3-stage registration (Rigid + Similarity + Affine) on identical images with masks and B-spline transforms:

| | Before | After |
|---|---|---|
| Metric image copies | 6 (3 fixed + 3 moving) | 2 (1 shared each) |
| Mask image copies | 6 (3 fixed + 3 moving) | 2 (1 shared each) |
| B-spline reads per stage | up to 2 full image reads | 0 (reuses cache) |
| HACK spacing re-read | 1 full image read | 0 (reuses cache) |

## Commits

1. `9e0ee91` ENH: Deduplicate image reads in antsRegistration multi-stage registrations
2. `6243ce0` STYLE: Move image cache declaration before mask/transform parsing loops
3. `d34f2ea` ENH: Deduplicate mask image reads across registration stages
4. `66794b6` ENH: Deduplicate B-spline mesh size fixed image reads

## Safety

Images are used read-only after loading — `PreprocessImage()` creates new copies via `IntensityWindowingImageFilter`, and images are accessed as `ConstPointer` during registration. Mask images are wrapped in per-stage `ImageMaskSpatialObject` instances but share the underlying pixel buffer. Shared pixel buffers are never mutated.
