### PR TITLE
STYLE/COMP: Silence 611 -Wunnecessary-virtual-specifier warnings via itkNonVirtual* macros

### DIFF
--- a/ImageRegistration/itkANTSAffine3DTransform.h
+++ b/ImageRegistration/itkANTSAffine3DTransform.h
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include "itkRigid3DTransform.h"
+#include "ITKGetterSetterMacroShims.h"
 #include "vnl/vnl_quaternion.h"
 
 namespace itk

--- a/ImageRegistration/itkANTSAffine3DTransform.h
+++ b/ImageRegistration/itkANTSAffine3DTransform.h
@@ -97,12 +97,12 @@ public:
   MatrixType
   ComputeMyRotationMatrix();
 
-  itkGetConstReferenceMacro(S1, TScalarType);
-  itkGetConstReferenceMacro(S2, TScalarType);
-  itkGetConstReferenceMacro(S3, TScalarType);
-  itkGetConstReferenceMacro(K1, TScalarType);
-  itkGetConstReferenceMacro(K2, TScalarType);
-  itkGetConstReferenceMacro(K3, TScalarType);
+  itkNonVirtualGetConstReferenceMacro(S1, TScalarType);
+  itkNonVirtualGetConstReferenceMacro(S2, TScalarType);
+  itkNonVirtualGetConstReferenceMacro(S3, TScalarType);
+  itkNonVirtualGetConstReferenceMacro(K1, TScalarType);
+  itkNonVirtualGetConstReferenceMacro(K2, TScalarType);
+  itkNonVirtualGetConstReferenceMacro(K3, TScalarType);
 
   /** Set the parameters to the IdentityTransform */
   void

--- a/Temporary/antsFastMarchingImageFilter.h
+++ b/Temporary/antsFastMarchingImageFilter.h
@@ -15,6 +15,7 @@ Program:   Advanced Normalization Tools
 #define __antsFMarchingImageFilter_h
 
 #include "itkArray.h"
+#include "ITKGetterSetterMacroShims.h"
 #include "itkImageToImageFilter.h"
 #include "itkIndex.h"
 #include "itkLevelSet.h"

--- a/Temporary/antsFastMarchingImageFilter.h
+++ b/Temporary/antsFastMarchingImageFilter.h
@@ -255,38 +255,38 @@ public:
   }
 
   /** Get the Speed Constant. */
-  itkGetConstReferenceMacro(SpeedConstant, double);
+  itkNonVirtualGetConstReferenceMacro(SpeedConstant, double);
 
   /** Set/Get the Normalization Factor for the Speed Image.
       The values in the Speed Image is divided by this
       factor. This allows the use of images with
       integer pixel types to represent the speed. */
-  itkSetMacro(NormalizationFactor, double);
-  itkGetConstMacro(NormalizationFactor, double);
+  itkNonVirtualSetMacro(NormalizationFactor, double);
+  itkNonVirtualGetConstMacro(NormalizationFactor, double);
 
   /** Set the Fast Marching algorithm Stopping Value. The Fast Marching
    * algorithm is terminated when the value of the smallest trial point
    * is greater than the stopping value. */
-  itkSetMacro(StoppingValue, double);
+  itkNonVirtualSetMacro(StoppingValue, double);
 
   /** Get the Fast Marching algorithm Stopping Value. */
-  itkGetConstReferenceMacro(StoppingValue, double);
+  itkNonVirtualGetConstReferenceMacro(StoppingValue, double);
 
   /** Set the Collect Points flag. Instrument the algorithm to collect
    * a container of all nodes which it has visited. Useful for
    * creating Narrowbands for level set algorithms that supports
    * narrow banding. */
-  itkSetMacro(CollectPoints, bool);
+  itkNonVirtualSetMacro(CollectPoints, bool);
 
   /** Get thConste Collect Points flag. */
-  itkGetConstReferenceMacro(CollectPoints, bool);
-  itkBooleanMacro(CollectPoints);
+  itkNonVirtualGetConstReferenceMacro(CollectPoints, bool);
+  itkNonVirtualBooleanMacro(CollectPoints);
 
   using TopologyCheckType = itk::FastMarchingTraitsEnums::TopologyCheck;
 
   /** Set/Get boolean macro indicating whether the user wants to check topology. */
-  itkSetMacro(TopologyCheck, TopologyCheckType);
-  itkGetConstReferenceMacro(TopologyCheck, TopologyCheckType);
+  itkNonVirtualSetMacro(TopologyCheck, TopologyCheckType);
+  itkNonVirtualGetConstReferenceMacro(TopologyCheck, TopologyCheckType);
 
   /** Get the container of Processed Points. If the CollectPoints flag
    * is set, the algorithm collects a container of all processed nodes.
@@ -316,17 +316,17 @@ public:
     return m_OutputRegion.GetSize();
   }
 
-  itkSetMacro(OutputRegion, OutputRegionType);
-  itkGetConstReferenceMacro(OutputRegion, OutputRegionType);
-  itkSetMacro(OutputSpacing, OutputSpacingType);
-  itkGetConstReferenceMacro(OutputSpacing, OutputSpacingType);
-  itkSetMacro(OutputDirection, OutputDirectionType);
-  itkGetConstReferenceMacro(OutputDirection, OutputDirectionType);
-  itkSetMacro(OutputOrigin, OutputPointType);
-  itkGetConstReferenceMacro(OutputOrigin, OutputPointType);
-  itkSetMacro(OverrideOutputInformation, bool);
-  itkGetConstReferenceMacro(OverrideOutputInformation, bool);
-  itkBooleanMacro(OverrideOutputInformation);
+  itkNonVirtualSetMacro(OutputRegion, OutputRegionType);
+  itkNonVirtualGetConstReferenceMacro(OutputRegion, OutputRegionType);
+  itkNonVirtualSetMacro(OutputSpacing, OutputSpacingType);
+  itkNonVirtualGetConstReferenceMacro(OutputSpacing, OutputSpacingType);
+  itkNonVirtualSetMacro(OutputDirection, OutputDirectionType);
+  itkNonVirtualGetConstReferenceMacro(OutputDirection, OutputDirectionType);
+  itkNonVirtualSetMacro(OutputOrigin, OutputPointType);
+  itkNonVirtualGetConstReferenceMacro(OutputOrigin, OutputPointType);
+  itkNonVirtualSetMacro(OverrideOutputInformation, bool);
+  itkNonVirtualGetConstReferenceMacro(OverrideOutputInformation, bool);
+  itkNonVirtualBooleanMacro(OverrideOutputInformation);
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */
@@ -371,15 +371,15 @@ protected:
       represent the concept of infinity for the time assigned to pixels that
       have not been visited. This value is set by default to half the
       max() of the pixel type used to represent the time-crossing map. */
-  itkGetConstReferenceMacro(LargeValue, PixelType);
+  itkNonVirtualGetConstReferenceMacro(LargeValue, PixelType);
 
   OutputRegionType                              m_BufferedRegion;
   typedef typename LevelSetImageType::IndexType LevelSetIndexType;
   LevelSetIndexType                             m_StartIndex;
   LevelSetIndexType                             m_LastIndex;
 
-  itkGetConstReferenceMacro(StartIndex, LevelSetIndexType);
-  itkGetConstReferenceMacro(LastIndex, LevelSetIndexType);
+  itkNonVirtualGetConstReferenceMacro(StartIndex, LevelSetIndexType);
+  itkNonVirtualGetConstReferenceMacro(LastIndex, LevelSetIndexType);
 
 private:
   FMarchingImageFilter(const Self &); // purposely not implemented

--- a/Utilities/ITKGetterSetterMacroShims.h
+++ b/Utilities/ITKGetterSetterMacroShims.h
@@ -1,0 +1,538 @@
+/*=========================================================================
+ *
+ *  ITKGetterSetterMacroShims.h
+ *
+ *  Backward-compatibility shim providing the itkVirtual* / itkFinal* /
+ *  itkNonVirtual* Set/Get macro family from
+ *  InsightSoftwareConsortium/ITK PR #6253.
+ *
+ *  Once ANTs's minimum ITK version contains PR #6253, the
+ *  upstream itkMacro.h itself defines itkSetMacroImpl (and the rest of
+ *  the *Impl helpers plus their public variants). The sentinel guard
+ *  below collapses this file to an empty translation unit in that
+ *  configuration so it can be retired without source churn.
+ *
+ *  Usage: include AFTER itkMacro.h.
+ *
+ *=========================================================================*/
+#ifndef ITKGetterSetterMacroShims_h
+#define ITKGetterSetterMacroShims_h
+
+#include "itkMacro.h"
+
+// Sentinel: itkSetMacroImpl is the first internal helper introduced by
+// ITK PR #6253. When ITK provides it, the entire shim is a no-op.
+#if !defined(itkSetMacroImpl)
+
+// ---------------------------------------------------------------------------
+// itkSetInputMacro family
+// ---------------------------------------------------------------------------
+#define itkSetInputMacroImpl(virtualKeyword, finalKeyword, name, type)                   \
+  virtualKeyword void Set##name(const type * _arg) finalKeyword                          \
+  {                                                                                      \
+    itkDebugMacro("setting input " #name " to " << _arg);                                \
+    if (_arg != itkDynamicCastInDebugMode<type *>(this->ProcessObject::GetInput(#name))) \
+    {                                                                                    \
+      this->ProcessObject::SetInput(#name, const_cast<type *>(_arg));                    \
+      this->Modified();                                                                  \
+    }                                                                                    \
+  }                                                                                      \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define itkVirtualSetInputMacro(name, type)    itkSetInputMacroImpl(virtual, , name, type)
+#define itkFinalSetInputMacro(name, type)      itkSetInputMacroImpl(, final, name, type)
+#define itkNonVirtualSetInputMacro(name, type) itkSetInputMacroImpl(, , name, type)
+
+// ---------------------------------------------------------------------------
+// itkGetInputMacro family
+// ---------------------------------------------------------------------------
+#define itkGetInputMacroImpl(virtualKeyword, finalKeyword, name, type)                         \
+  virtualKeyword const type * Get##name() const finalKeyword                                   \
+  {                                                                                            \
+    itkDebugMacro("returning input " << #name " of " << this->ProcessObject::GetInput(#name)); \
+    return itkDynamicCastInDebugMode<const type *>(this->ProcessObject::GetInput(#name));      \
+  }                                                                                            \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define itkVirtualGetInputMacro(name, type)    itkGetInputMacroImpl(virtual, , name, type)
+#define itkFinalGetInputMacro(name, type)      itkGetInputMacroImpl(, final, name, type)
+#define itkNonVirtualGetInputMacro(name, type) itkGetInputMacroImpl(, , name, type)
+
+// ---------------------------------------------------------------------------
+// itkSetDecoratedInputMacro family
+// ---------------------------------------------------------------------------
+// clang-format off
+#define itkSetDecoratedInputMacroImpl(virtualKeyword, finalKeyword, name, type)                                     \
+  virtualKeyword void Set##name##Input(const SimpleDataObjectDecorator<type> * _arg) finalKeyword                   \
+  {                                                                                                                 \
+    itkDebugMacro("setting input " #name " to " << _arg);                                                           \
+    if (_arg != itkDynamicCastInDebugMode<SimpleDataObjectDecorator<type> *>(this->ProcessObject::GetInput(#name))) \
+    {                                                                                                               \
+      this->ProcessObject::SetInput(#name, const_cast<SimpleDataObjectDecorator<type> *>(_arg));                    \
+      this->Modified();                                                                                             \
+    }                                                                                                               \
+  }                                                                                                                 \
+  virtualKeyword void Set##name(const SimpleDataObjectDecorator<type> * _arg) finalKeyword                          \
+  {                                                                                                                 \
+    this->Set##name##Input(_arg);                                                                                   \
+  }                                                                                                                 \
+  virtualKeyword void Set##name(const type & _arg) finalKeyword                                                     \
+  {                                                                                                                 \
+    using DecoratorType = SimpleDataObjectDecorator<type>;                                                          \
+    itkDebugMacro("setting input " #name " to " << _arg);                                                           \
+    const DecoratorType * oldInput =                                                                                \
+      itkDynamicCastInDebugMode<const DecoratorType *>(this->ProcessObject::GetInput(#name));                       \
+    ITK_GCC_PRAGMA_PUSH                                                                                             \
+    ITK_GCC_SUPPRESS_Wfloat_equal                                                                                   \
+    if (oldInput && oldInput->Get() == _arg)                                                                        \
+    {                                                                                                               \
+      return;                                                                                                       \
+    }                                                                                                               \
+    ITK_GCC_PRAGMA_POP                                                                                              \
+    auto newInput = DecoratorType::New();                                                                           \
+    newInput->Set(_arg);                                                                                            \
+    this->Set##name##Input(newInput);                                                                               \
+  }                                                                                                                 \
+  ITK_MACROEND_NOOP_STATEMENT
+// clang-format on
+
+#define itkVirtualSetDecoratedInputMacro(name, type)    itkSetDecoratedInputMacroImpl(virtual, , name, type)
+#define itkFinalSetDecoratedInputMacro(name, type)      itkSetDecoratedInputMacroImpl(, final, name, type)
+#define itkNonVirtualSetDecoratedInputMacro(name, type) itkSetDecoratedInputMacroImpl(, , name, type)
+
+// ---------------------------------------------------------------------------
+// itkGetDecoratedInputMacro family
+// ---------------------------------------------------------------------------
+#define itkGetDecoratedInputMacroImpl(virtualKeyword, finalKeyword, name, type)                                      \
+  virtualKeyword const SimpleDataObjectDecorator<type> * Get##name##Input() const finalKeyword                       \
+  {                                                                                                                  \
+    itkDebugMacro("returning input " << #name " of " << this->ProcessObject::GetInput(#name));                       \
+    return itkDynamicCastInDebugMode<const SimpleDataObjectDecorator<type> *>(this->ProcessObject::GetInput(#name)); \
+  }                                                                                                                  \
+  virtualKeyword const type & Get##name() const finalKeyword                                                         \
+  {                                                                                                                  \
+    itkDebugMacro("Getting input " #name);                                                                           \
+    using DecoratorType = SimpleDataObjectDecorator<type>;                                                           \
+    const DecoratorType * input =                                                                                    \
+      itkDynamicCastInDebugMode<const DecoratorType *>(this->ProcessObject::GetInput(#name));                        \
+    if (input == nullptr)                                                                                            \
+    {                                                                                                                \
+      itkExceptionMacro("input" #name " is not set");                                                                \
+    }                                                                                                                \
+    return input->Get();                                                                                             \
+  }                                                                                                                  \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define itkVirtualGetDecoratedInputMacro(name, type)    itkGetDecoratedInputMacroImpl(virtual, , name, type)
+#define itkFinalGetDecoratedInputMacro(name, type)      itkGetDecoratedInputMacroImpl(, final, name, type)
+#define itkNonVirtualGetDecoratedInputMacro(name, type) itkGetDecoratedInputMacroImpl(, , name, type)
+
+// Combined Set/Get for a decorated input.
+#define itkVirtualSetGetDecoratedInputMacro(name, type) \
+  itkVirtualSetDecoratedInputMacro(name, type);         \
+  itkVirtualGetDecoratedInputMacro(name, type)
+#define itkFinalSetGetDecoratedInputMacro(name, type) \
+  itkFinalSetDecoratedInputMacro(name, type);         \
+  itkFinalGetDecoratedInputMacro(name, type)
+#define itkNonVirtualSetGetDecoratedInputMacro(name, type) \
+  itkNonVirtualSetDecoratedInputMacro(name, type);         \
+  itkNonVirtualGetDecoratedInputMacro(name, type)
+
+// ---------------------------------------------------------------------------
+// itkSetDecoratedObjectInputMacro family
+// ---------------------------------------------------------------------------
+#define itkSetDecoratedObjectInputMacroImpl(virtualKeyword, finalKeyword, name, type)                         \
+  virtualKeyword void Set##name##Input(const DataObjectDecorator<type> * _arg) finalKeyword                   \
+  {                                                                                                           \
+    itkDebugMacro("setting input " #name " to " << _arg);                                                     \
+    if (_arg != itkDynamicCastInDebugMode<DataObjectDecorator<type> *>(this->ProcessObject::GetInput(#name))) \
+    {                                                                                                         \
+      this->ProcessObject::SetInput(#name, const_cast<DataObjectDecorator<type> *>(_arg));                    \
+      this->Modified();                                                                                       \
+    }                                                                                                         \
+  }                                                                                                           \
+  virtualKeyword void Set##name(const type * _arg) finalKeyword                                               \
+  {                                                                                                           \
+    using DecoratorType = DataObjectDecorator<type>;                                                          \
+    itkDebugMacro("setting input " #name " to " << _arg);                                                     \
+    const DecoratorType * oldInput =                                                                          \
+      itkDynamicCastInDebugMode<const DecoratorType *>(this->ProcessObject::GetInput(#name));                 \
+    if (oldInput && oldInput->Get() == _arg)                                                                  \
+    {                                                                                                         \
+      return;                                                                                                 \
+    }                                                                                                         \
+    auto newInput = DecoratorType::New();                                                                     \
+    newInput->Set(_arg);                                                                                      \
+    this->Set##name##Input(newInput);                                                                         \
+  }                                                                                                           \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define itkVirtualSetDecoratedObjectInputMacro(name, type)    itkSetDecoratedObjectInputMacroImpl(virtual, , name, type)
+#define itkFinalSetDecoratedObjectInputMacro(name, type)      itkSetDecoratedObjectInputMacroImpl(, final, name, type)
+#define itkNonVirtualSetDecoratedObjectInputMacro(name, type) itkSetDecoratedObjectInputMacroImpl(, , name, type)
+
+// ---------------------------------------------------------------------------
+// itkGetDecoratedObjectInputMacro family
+// ---------------------------------------------------------------------------
+#define itkGetDecoratedObjectInputMacroImpl(virtualKeyword, finalKeyword, name, type)                          \
+  virtualKeyword const DataObjectDecorator<type> * Get##name##Input() const finalKeyword                       \
+  {                                                                                                            \
+    itkDebugMacro("returning input " << #name " of " << this->ProcessObject::GetInput(#name));                 \
+    return itkDynamicCastInDebugMode<const DataObjectDecorator<type> *>(this->ProcessObject::GetInput(#name)); \
+  }                                                                                                            \
+  virtualKeyword const type * Get##name() const finalKeyword                                                   \
+  {                                                                                                            \
+    itkDebugMacro("Getting input " #name);                                                                     \
+    using DecoratorType = DataObjectDecorator<type>;                                                           \
+    const DecoratorType * input =                                                                              \
+      itkDynamicCastInDebugMode<const DecoratorType *>(this->ProcessObject::GetInput(#name));                  \
+    if (input == nullptr)                                                                                      \
+    {                                                                                                          \
+      return nullptr;                                                                                          \
+    }                                                                                                          \
+    return input->Get();                                                                                       \
+  }                                                                                                            \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define itkVirtualGetDecoratedObjectInputMacro(name, type)    itkGetDecoratedObjectInputMacroImpl(virtual, , name, type)
+#define itkFinalGetDecoratedObjectInputMacro(name, type)      itkGetDecoratedObjectInputMacroImpl(, final, name, type)
+#define itkNonVirtualGetDecoratedObjectInputMacro(name, type) itkGetDecoratedObjectInputMacroImpl(, , name, type)
+
+#define itkVirtualSetGetDecoratedObjectInputMacro(name, type) \
+  itkVirtualSetDecoratedObjectInputMacro(name, type);         \
+  itkVirtualGetDecoratedObjectInputMacro(name, type)
+#define itkFinalSetGetDecoratedObjectInputMacro(name, type) \
+  itkFinalSetDecoratedObjectInputMacro(name, type);         \
+  itkFinalGetDecoratedObjectInputMacro(name, type)
+#define itkNonVirtualSetGetDecoratedObjectInputMacro(name, type) \
+  itkNonVirtualSetDecoratedObjectInputMacro(name, type);         \
+  itkNonVirtualGetDecoratedObjectInputMacro(name, type)
+
+// ---------------------------------------------------------------------------
+// itkSetMacro family
+// ---------------------------------------------------------------------------
+// clang-format off
+#define itkSetMacroImpl(virtualKeyword, finalKeyword, name, type) \
+  virtualKeyword void Set##name(type _arg) finalKeyword           \
+  {                                                               \
+    itkDebugMacro("setting " #name " to " << _arg);               \
+    ITK_GCC_PRAGMA_PUSH                                           \
+    ITK_GCC_SUPPRESS_Wfloat_equal                                 \
+    if (this->m_##name != _arg)                                   \
+    {                                                             \
+      this->m_##name = std::move(_arg);                           \
+      this->Modified();                                           \
+    }                                                             \
+    ITK_GCC_PRAGMA_POP                                            \
+  }                                                               \
+  ITK_MACROEND_NOOP_STATEMENT
+// clang-format on
+
+#define itkVirtualSetMacro(name, type)    itkSetMacroImpl(virtual, , name, type)
+#define itkFinalSetMacro(name, type)      itkSetMacroImpl(, final, name, type)
+#define itkNonVirtualSetMacro(name, type) itkSetMacroImpl(, , name, type)
+
+// ---------------------------------------------------------------------------
+// itkGetMacro / itkGetConstMacro / itkGetConstReferenceMacro families
+// ---------------------------------------------------------------------------
+#define itkGetMacroImpl(virtualKeyword, finalKeyword, name, type)         \
+  virtualKeyword type Get##name() finalKeyword { return this->m_##name; } \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define itkGetConstMacroImpl(virtualKeyword, finalKeyword, name, type)          \
+  virtualKeyword type Get##name() const finalKeyword { return this->m_##name; } \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define itkGetConstReferenceMacroImpl(virtualKeyword, finalKeyword, name, type)         \
+  virtualKeyword const type & Get##name() const finalKeyword { return this->m_##name; } \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define itkVirtualGetMacro(name, type)    itkGetMacroImpl(virtual, , name, type)
+#define itkFinalGetMacro(name, type)      itkGetMacroImpl(, final, name, type)
+#define itkNonVirtualGetMacro(name, type) itkGetMacroImpl(, , name, type)
+
+#define itkVirtualGetConstMacro(name, type)    itkGetConstMacroImpl(virtual, , name, type)
+#define itkFinalGetConstMacro(name, type)      itkGetConstMacroImpl(, final, name, type)
+#define itkNonVirtualGetConstMacro(name, type) itkGetConstMacroImpl(, , name, type)
+
+#define itkVirtualGetConstReferenceMacro(name, type)    itkGetConstReferenceMacroImpl(virtual, , name, type)
+#define itkFinalGetConstReferenceMacro(name, type)      itkGetConstReferenceMacroImpl(, final, name, type)
+#define itkNonVirtualGetConstReferenceMacro(name, type) itkGetConstReferenceMacroImpl(, , name, type)
+
+// ---------------------------------------------------------------------------
+// itkSetEnumMacro / itkGetEnumMacro families
+// ---------------------------------------------------------------------------
+#define itkSetEnumMacroImpl(virtualKeyword, finalKeyword, name, type)  \
+  virtualKeyword void Set##name(const type _arg) finalKeyword          \
+  {                                                                    \
+    itkDebugMacro("setting " #name " to " << static_cast<long>(_arg)); \
+    if (this->m_##name != _arg)                                        \
+    {                                                                  \
+      this->m_##name = _arg;                                           \
+      this->Modified();                                                \
+    }                                                                  \
+  }                                                                    \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define itkVirtualSetEnumMacro(name, type)    itkSetEnumMacroImpl(virtual, , name, type)
+#define itkFinalSetEnumMacro(name, type)      itkSetEnumMacroImpl(, final, name, type)
+#define itkNonVirtualSetEnumMacro(name, type) itkSetEnumMacroImpl(, , name, type)
+
+#define itkGetEnumMacroImpl(virtualKeyword, finalKeyword, name, type)           \
+  virtualKeyword type Get##name() const finalKeyword { return this->m_##name; } \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define itkVirtualGetEnumMacro(name, type)    itkGetEnumMacroImpl(virtual, , name, type)
+#define itkFinalGetEnumMacro(name, type)      itkGetEnumMacroImpl(, final, name, type)
+#define itkNonVirtualGetEnumMacro(name, type) itkGetEnumMacroImpl(, , name, type)
+
+// ---------------------------------------------------------------------------
+// itkSetStringMacro / itkGetStringMacro families
+// ---------------------------------------------------------------------------
+#define itkSetStringMacroImpl(virtualKeyword, finalKeyword, name)                                         \
+  virtualKeyword void Set##name(const char * _arg) finalKeyword                                           \
+  {                                                                                                       \
+    if (_arg && (_arg == this->m_##name))                                                                 \
+    {                                                                                                     \
+      return;                                                                                             \
+    }                                                                                                     \
+    if (_arg)                                                                                             \
+    {                                                                                                     \
+      this->m_##name = _arg;                                                                              \
+    }                                                                                                     \
+    else                                                                                                  \
+    {                                                                                                     \
+      this->m_##name = "";                                                                                \
+    }                                                                                                     \
+    this->Modified();                                                                                     \
+  }                                                                                                       \
+  virtualKeyword void Set##name(const std::string & _arg) finalKeyword { this->Set##name(_arg.c_str()); } \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define itkVirtualSetStringMacro(name)    itkSetStringMacroImpl(virtual, , name)
+#define itkFinalSetStringMacro(name)      itkSetStringMacroImpl(, final, name)
+#define itkNonVirtualSetStringMacro(name) itkSetStringMacroImpl(, , name)
+
+#define itkGetStringMacroImpl(virtualKeyword, finalKeyword, name)                               \
+  virtualKeyword const char * Get##name() const finalKeyword { return this->m_##name.c_str(); } \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define itkVirtualGetStringMacro(name)    itkGetStringMacroImpl(virtual, , name)
+#define itkFinalGetStringMacro(name)      itkGetStringMacroImpl(, final, name)
+#define itkNonVirtualGetStringMacro(name) itkGetStringMacroImpl(, , name)
+
+// ---------------------------------------------------------------------------
+// itkSetClampMacro family
+// ---------------------------------------------------------------------------
+// clang-format off
+#define itkSetClampMacroImpl(virtualKeyword, finalKeyword, name, type, min, max) \
+  virtualKeyword void Set##name(type _arg) finalKeyword                          \
+  {                                                                              \
+    const type temp_extrema = (_arg <= min ? min : (_arg >= max ? max : _arg));  \
+    itkDebugMacro("setting " << #name " to " << _arg);                           \
+    ITK_GCC_PRAGMA_PUSH                                                          \
+    ITK_GCC_SUPPRESS_Wfloat_equal                                                \
+    if (this->m_##name != temp_extrema)                                          \
+    {                                                                            \
+      this->m_##name = temp_extrema;                                             \
+      this->Modified();                                                          \
+    }                                                                            \
+    ITK_GCC_PRAGMA_POP                                                           \
+  }                                                                              \
+  ITK_MACROEND_NOOP_STATEMENT
+// clang-format on
+
+#define itkVirtualSetClampMacro(name, type, min, max)    itkSetClampMacroImpl(virtual, , name, type, min, max)
+#define itkFinalSetClampMacro(name, type, min, max)      itkSetClampMacroImpl(, final, name, type, min, max)
+#define itkNonVirtualSetClampMacro(name, type, min, max) itkSetClampMacroImpl(, , name, type, min, max)
+
+// ---------------------------------------------------------------------------
+// itkSetObjectMacro / itkGetObjectMacro / itkGetConstObjectMacro /
+// itkGetModifiableObjectMacro / itkGetConstReferenceObjectMacro /
+// itkSetConstObjectMacro families
+// ---------------------------------------------------------------------------
+#define itkSetObjectMacroImpl(virtualKeyword, finalKeyword, name, type) \
+  virtualKeyword void Set##name(type * _arg) finalKeyword               \
+  {                                                                     \
+    itkDebugMacro("setting " << #name " to " << _arg);                  \
+    if (this->m_##name != _arg)                                         \
+    {                                                                   \
+      this->m_##name = _arg;                                            \
+      this->Modified();                                                 \
+    }                                                                   \
+  }                                                                     \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define itkVirtualSetObjectMacro(name, type)    itkSetObjectMacroImpl(virtual, , name, type)
+#define itkFinalSetObjectMacro(name, type)      itkSetObjectMacroImpl(, final, name, type)
+#define itkNonVirtualSetObjectMacro(name, type) itkSetObjectMacroImpl(, , name, type)
+
+#define itkGetConstObjectMacroImpl(virtualKeyword, finalKeyword, name, type)                         \
+  virtualKeyword const type * Get##name() const finalKeyword { return this->m_##name.GetPointer(); } \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define itkVirtualGetConstObjectMacro(name, type)    itkGetConstObjectMacroImpl(virtual, , name, type)
+#define itkFinalGetConstObjectMacro(name, type)      itkGetConstObjectMacroImpl(, final, name, type)
+#define itkNonVirtualGetConstObjectMacro(name, type) itkGetConstObjectMacroImpl(, , name, type)
+
+#if defined(ITK_FUTURE_LEGACY_REMOVE)
+#  define itkGetObjectMacroImpl(virtualKeyword, finalKeyword, name, type)                         \
+    virtualKeyword type * Get##name() finalKeyword                                                \
+    {                                                                                             \
+      purposeful_error("itkGetObjectMacro should be replaced with itkGetModifiableObjectMacro."); \
+    }                                                                                             \
+    ITK_MACROEND_NOOP_STATEMENT
+
+#  define itkGetModifiableObjectMacroImpl(virtualKeyword, finalKeyword, name, type)                  \
+    virtualKeyword type * GetModifiable##name() finalKeyword { return this->m_##name.GetPointer(); } \
+    itkGetConstObjectMacroImpl(virtualKeyword, finalKeyword, name, type)
+#else
+#  define itkGetObjectMacroImpl(virtualKeyword, finalKeyword, name, type)                  \
+    virtualKeyword type * Get##name() finalKeyword { return this->m_##name.GetPointer(); } \
+    ITK_MACROEND_NOOP_STATEMENT
+
+#  define itkGetModifiableObjectMacroImpl(virtualKeyword, finalKeyword, name, type)                  \
+    virtualKeyword type * GetModifiable##name() finalKeyword { return this->m_##name.GetPointer(); } \
+    itkGetConstObjectMacroImpl(virtualKeyword, finalKeyword, name, type);                            \
+    itkGetObjectMacroImpl(virtualKeyword, finalKeyword, name, type)
+#endif
+
+#define itkVirtualGetObjectMacro(name, type)    itkGetObjectMacroImpl(virtual, , name, type)
+#define itkFinalGetObjectMacro(name, type)      itkGetObjectMacroImpl(, final, name, type)
+#define itkNonVirtualGetObjectMacro(name, type) itkGetObjectMacroImpl(, , name, type)
+
+#define itkVirtualGetModifiableObjectMacro(name, type)    itkGetModifiableObjectMacroImpl(virtual, , name, type)
+#define itkFinalGetModifiableObjectMacro(name, type)      itkGetModifiableObjectMacroImpl(, final, name, type)
+#define itkNonVirtualGetModifiableObjectMacro(name, type) itkGetModifiableObjectMacroImpl(, , name, type)
+
+#define itkGetConstReferenceObjectMacroImpl(virtualKeyword, finalKeyword, name, type)                     \
+  virtualKeyword const typename type::Pointer & Get##name() const finalKeyword { return this->m_##name; } \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define itkVirtualGetConstReferenceObjectMacro(name, type)    itkGetConstReferenceObjectMacroImpl(virtual, , name, type)
+#define itkFinalGetConstReferenceObjectMacro(name, type)      itkGetConstReferenceObjectMacroImpl(, final, name, type)
+#define itkNonVirtualGetConstReferenceObjectMacro(name, type) itkGetConstReferenceObjectMacroImpl(, , name, type)
+
+#define itkSetConstObjectMacroImpl(virtualKeyword, finalKeyword, name, type) \
+  virtualKeyword void Set##name(const type * _arg) finalKeyword              \
+  {                                                                          \
+    itkDebugMacro("setting " << #name " to " << _arg);                       \
+    if (this->m_##name != _arg)                                              \
+    {                                                                        \
+      this->m_##name = _arg;                                                 \
+      this->Modified();                                                      \
+    }                                                                        \
+  }                                                                          \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define itkVirtualSetConstObjectMacro(name, type)    itkSetConstObjectMacroImpl(virtual, , name, type)
+#define itkFinalSetConstObjectMacro(name, type)      itkSetConstObjectMacroImpl(, final, name, type)
+#define itkNonVirtualSetConstObjectMacro(name, type) itkSetConstObjectMacroImpl(, , name, type)
+
+// ---------------------------------------------------------------------------
+// itkBooleanMacro family
+// ---------------------------------------------------------------------------
+#define itkBooleanMacroImpl(virtualKeyword, finalKeyword, name)            \
+  virtualKeyword void name##On() finalKeyword { this->Set##name(true); }   \
+  virtualKeyword void name##Off() finalKeyword { this->Set##name(false); } \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define itkVirtualBooleanMacro(name)    itkBooleanMacroImpl(virtual, , name)
+#define itkFinalBooleanMacro(name)      itkBooleanMacroImpl(, final, name)
+#define itkNonVirtualBooleanMacro(name) itkBooleanMacroImpl(, , name)
+
+// ---------------------------------------------------------------------------
+// itkSetVectorMacro / itkGetVectorMacro families
+// ---------------------------------------------------------------------------
+#define itkSetVectorMacroImpl(virtualKeyword, finalKeyword, name, type, count) \
+  virtualKeyword void Set##name(type data[]) finalKeyword                      \
+  {                                                                            \
+    if (ContainerCopyWithCheck(this->m_##name, data, count))                   \
+    {                                                                          \
+      this->Modified();                                                        \
+    }                                                                          \
+  }                                                                            \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define itkVirtualSetVectorMacro(name, type, count)    itkSetVectorMacroImpl(virtual, , name, type, count)
+#define itkFinalSetVectorMacro(name, type, count)      itkSetVectorMacroImpl(, final, name, type, count)
+#define itkNonVirtualSetVectorMacro(name, type, count) itkSetVectorMacroImpl(, , name, type, count)
+
+#define itkGetVectorMacroImpl(virtualKeyword, finalKeyword, name, type, count)    \
+  virtualKeyword type * Get##name() const finalKeyword { return this->m_##name; } \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define itkVirtualGetVectorMacro(name, type, count)    itkGetVectorMacroImpl(virtual, , name, type, count)
+#define itkFinalGetVectorMacro(name, type, count)      itkGetVectorMacroImpl(, final, name, type, count)
+#define itkNonVirtualGetVectorMacro(name, type, count) itkGetVectorMacroImpl(, , name, type, count)
+
+// ---------------------------------------------------------------------------
+// itkSetDecoratedOutputMacro / itkGetDecoratedOutputMacro families
+// ---------------------------------------------------------------------------
+#define itkSetDecoratedOutputMacroImpl(virtualKeyword, finalKeyword, name, type)                                     \
+  virtualKeyword void Set##name##Output(const SimpleDataObjectDecorator<type> * _arg) finalKeyword                   \
+  {                                                                                                                  \
+    itkDebugMacro("setting output " #name " to " << _arg);                                                           \
+    if (_arg != itkDynamicCastInDebugMode<SimpleDataObjectDecorator<type> *>(this->ProcessObject::GetOutput(#name))) \
+    {                                                                                                                \
+      this->ProcessObject::SetOutput(#name, const_cast<SimpleDataObjectDecorator<type> *>(_arg));                    \
+      this->Modified();                                                                                              \
+    }                                                                                                                \
+  }                                                                                                                  \
+  virtualKeyword void Set##name(const type & _arg) finalKeyword                                                      \
+  {                                                                                                                  \
+    using DecoratorType = SimpleDataObjectDecorator<type>;                                                           \
+    itkDebugMacro("setting output " #name " to " << _arg);                                                           \
+    DecoratorType * output =                                                                                         \
+      itkDynamicCastInDebugMode<DecoratorType *>(this->ProcessObject::GetOutput(#name));                             \
+    if (output)                                                                                                      \
+    {                                                                                                                \
+      if (output->Get() == _arg)                                                                                     \
+      {                                                                                                              \
+        return;                                                                                                      \
+      }                                                                                                              \
+      else                                                                                                           \
+      {                                                                                                              \
+        output->Set(_arg);                                                                                           \
+      }                                                                                                              \
+    }                                                                                                                \
+    else                                                                                                             \
+    {                                                                                                                \
+      auto newOutput = DecoratorType::New();                                                                         \
+      newOutput->Set(_arg);                                                                                          \
+      this->Set##name##Output(newOutput);                                                                            \
+    }                                                                                                                \
+  }                                                                                                                  \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define itkVirtualSetDecoratedOutputMacro(name, type)    itkSetDecoratedOutputMacroImpl(virtual, , name, type)
+#define itkFinalSetDecoratedOutputMacro(name, type)      itkSetDecoratedOutputMacroImpl(, final, name, type)
+#define itkNonVirtualSetDecoratedOutputMacro(name, type) itkSetDecoratedOutputMacroImpl(, , name, type)
+
+#define itkGetDecoratedOutputMacroImpl(virtualKeyword, finalKeyword, name, type)                                      \
+  virtualKeyword const SimpleDataObjectDecorator<type> * Get##name##Output() const finalKeyword                       \
+  {                                                                                                                   \
+    itkDebugMacro("returning output " << #name " of " << this->ProcessObject::GetOutput(#name));                      \
+    return itkDynamicCastInDebugMode<const SimpleDataObjectDecorator<type> *>(this->ProcessObject::GetOutput(#name)); \
+  }                                                                                                                   \
+  virtualKeyword const type & Get##name() const finalKeyword                                                          \
+  {                                                                                                                   \
+    itkDebugMacro("Getting output " #name);                                                                           \
+    using DecoratorType = SimpleDataObjectDecorator<type>;                                                            \
+    const DecoratorType * output =                                                                                    \
+      itkDynamicCastInDebugMode<const DecoratorType *>(this->ProcessObject::GetOutput(#name));                        \
+    if (output == nullptr)                                                                                            \
+    {                                                                                                                 \
+      itkExceptionMacro("output" #name " is not set");                                                                \
+    }                                                                                                                 \
+    return output->Get();                                                                                             \
+  }                                                                                                                   \
+  ITK_MACROEND_NOOP_STATEMENT
+
+#define itkVirtualGetDecoratedOutputMacro(name, type)    itkGetDecoratedOutputMacroImpl(virtual, , name, type)
+#define itkFinalGetDecoratedOutputMacro(name, type)      itkGetDecoratedOutputMacroImpl(, final, name, type)
+#define itkNonVirtualGetDecoratedOutputMacro(name, type) itkGetDecoratedOutputMacroImpl(, , name, type)
+
+#endif // !defined(itkSetMacroImpl)
+
+#endif // ITKGetterSetterMacroShims_h

--- a/Utilities/antsCommandLineOption.h
+++ b/Utilities/antsCommandLineOption.h
@@ -63,15 +63,15 @@ public:
 
   typedef std::deque<std::string> ParameterStackType;
 
-  itkSetStringMacro(Name);
-  itkGetStringMacro(Name);
-  itkGetMacro(Name, std::string);
+  itkNonVirtualSetStringMacro(Name);
+  itkNonVirtualGetStringMacro(Name);
+  itkNonVirtualGetMacro(Name, std::string);
 
-  itkSetMacro(ArgOrder, unsigned int);
-  itkGetConstMacro(ArgOrder, unsigned int);
+  itkNonVirtualSetMacro(ArgOrder, unsigned int);
+  itkNonVirtualGetConstMacro(ArgOrder, unsigned int);
 
-  itkSetMacro(StageID, unsigned int);
-  itkGetConstMacro(StageID, unsigned int);
+  itkNonVirtualSetMacro(StageID, unsigned int);
+  itkNonVirtualGetConstMacro(StageID, unsigned int);
 
   ParameterStackType
   GetParameters()
@@ -179,14 +179,14 @@ public:
     }
   }
 
-  itkSetMacro(ShortName, char);
-  itkGetConstMacro(ShortName, char);
+  itkNonVirtualSetMacro(ShortName, char);
+  itkNonVirtualGetConstMacro(ShortName, char);
 
-  itkSetStringMacro(LongName);
-  itkGetConstMacro(LongName, std::string);
+  itkNonVirtualSetStringMacro(LongName);
+  itkNonVirtualGetConstMacro(LongName, std::string);
 
-  itkSetStringMacro(Description);
-  itkGetMacro(Description, std::string);
+  itkNonVirtualSetStringMacro(Description);
+  itkNonVirtualGetMacro(Description, std::string);
 
   void
   AddFunction(std::string, char, char, unsigned int order = 0);

--- a/Utilities/antsCommandLineOption.h
+++ b/Utilities/antsCommandLineOption.h
@@ -15,6 +15,7 @@
 #define antsCommandLineOption_h
 
 #include "itkDataObject.h"
+#include "ITKGetterSetterMacroShims.h"
 #include "itkObjectFactory.h"
 #include "itkMacro.h"
 #include "itkNumericTraits.h"

--- a/Utilities/antsCommandLineParser.h
+++ b/Utilities/antsCommandLineParser.h
@@ -16,6 +16,7 @@
 #include "antsCommandLineOption.h"
 
 #include "itkDataObject.h"
+#include "ITKGetterSetterMacroShims.h"
 #include "itkObjectFactory.h"
 #include "itkMacro.h"
 #include "itkNumericTraits.h"

--- a/Utilities/antsCommandLineParser.h
+++ b/Utilities/antsCommandLineParser.h
@@ -89,11 +89,11 @@ public:
   void
   PrintMenu(std::ostream & os, Indent indent, bool printShortVersion = false) const;
 
-  itkSetStringMacro(Command);
-  itkGetStringMacro(Command);
+  itkNonVirtualSetStringMacro(Command);
+  itkNonVirtualGetStringMacro(Command);
 
-  itkSetStringMacro(CommandDescription);
-  itkGetStringMacro(CommandDescription);
+  itkNonVirtualSetStringMacro(CommandDescription);
+  itkNonVirtualGetStringMacro(CommandDescription);
 
   OptionListType
   GetOptions() const

--- a/Utilities/antsMatrixUtilities.h
+++ b/Utilities/antsMatrixUtilities.h
@@ -134,8 +134,8 @@ public:
     this->m_MatrixP.update(matrix);
   }
 
-  itkSetMacro(FractionNonZeroQ, RealType);
-  itkSetMacro(KeepPositiveQ, bool);
+  itkNonVirtualSetMacro(FractionNonZeroQ, RealType);
+  itkNonVirtualSetMacro(KeepPositiveQ, bool);
   void
   SetMaskImageQ(ImagePointer mask)
   {
@@ -151,8 +151,8 @@ public:
     this->m_MatrixQ.update(matrix);
   }
 
-  itkSetMacro(FractionNonZeroR, RealType);
-  itkSetMacro(KeepPositiveR, bool);
+  itkNonVirtualSetMacro(FractionNonZeroR, RealType);
+  itkNonVirtualSetMacro(KeepPositiveR, bool);
   void
   SetMaskImageR(ImagePointer mask)
   {

--- a/Utilities/antsMatrixUtilities.h
+++ b/Utilities/antsMatrixUtilities.h
@@ -17,6 +17,7 @@
 #include <vnl/algo/vnl_matrix_inverse.h>
 #include <vnl/algo/vnl_cholesky.h>
 #include "itkImageToImageFilter.h"
+#include "ITKGetterSetterMacroShims.h"
 namespace itk
 {
 namespace ants

--- a/Utilities/antsSCCANObject.h
+++ b/Utilities/antsSCCANObject.h
@@ -25,6 +25,7 @@
 #  include "itkImageToImageFilter.h"
 
 #  include "itkMath.h"
+#  include "ITKGetterSetterMacroShims.h"
 
 /** Custom SCCA implemented with vnl and ITK: Flexible positivity constraints, image ops, permutation testing, etc. */
 namespace itk

--- a/Utilities/antsSCCANObject.h
+++ b/Utilities/antsSCCANObject.h
@@ -86,32 +86,32 @@ public:
   };
 
   /** ivars Set/Get functionality */
-  itkSetMacro(MaximumNumberOfIterations, unsigned int);
-  itkGetConstMacro(MaximumNumberOfIterations, unsigned int);
-  itkSetMacro(MinClusterSizeP, unsigned int);
-  itkGetConstMacro(MinClusterSizeP, unsigned int);
-  itkSetMacro(MinClusterSizeQ, unsigned int);
-  itkGetConstMacro(MinClusterSizeQ, unsigned int);
-  itkSetMacro(KeptClusterSize, unsigned int);
-  itkGetConstMacro(KeptClusterSize, unsigned int);
-  itkSetMacro(AlreadyWhitened, bool);
-  itkGetConstMacro(AlreadyWhitened, bool);
-  itkSetMacro(PriorWeight, RealType);
-  itkGetConstMacro(PriorWeight, RealType);
-  itkSetMacro(ConvergenceThreshold, RealType);
-  itkGetConstMacro(ConvergenceThreshold, RealType);
-  itkGetConstMacro(CurrentConvergenceMeasurement, RealType);
-  itkGetConstMacro(ElapsedIterations, unsigned int);
-  itkSetMacro(SCCANFormulation, SCCANFormulationType);
-  itkGetConstMacro(SCCANFormulation, SCCANFormulationType);
-  itkSetMacro(Silent, bool);
-  itkGetMacro(Silent, bool);
-  itkSetMacro(RowSparseness, RealType);
-  itkGetMacro(RowSparseness, RealType);
-  itkSetMacro(UseLongitudinalFormulation, RealType);
-  itkGetMacro(UseLongitudinalFormulation, RealType);
-  itkSetMacro(Smoother, RealType);
-  itkGetMacro(Smoother, RealType);
+  itkNonVirtualSetMacro(MaximumNumberOfIterations, unsigned int);
+  itkNonVirtualGetConstMacro(MaximumNumberOfIterations, unsigned int);
+  itkNonVirtualSetMacro(MinClusterSizeP, unsigned int);
+  itkNonVirtualGetConstMacro(MinClusterSizeP, unsigned int);
+  itkNonVirtualSetMacro(MinClusterSizeQ, unsigned int);
+  itkNonVirtualGetConstMacro(MinClusterSizeQ, unsigned int);
+  itkNonVirtualSetMacro(KeptClusterSize, unsigned int);
+  itkNonVirtualGetConstMacro(KeptClusterSize, unsigned int);
+  itkNonVirtualSetMacro(AlreadyWhitened, bool);
+  itkNonVirtualGetConstMacro(AlreadyWhitened, bool);
+  itkNonVirtualSetMacro(PriorWeight, RealType);
+  itkNonVirtualGetConstMacro(PriorWeight, RealType);
+  itkNonVirtualSetMacro(ConvergenceThreshold, RealType);
+  itkNonVirtualGetConstMacro(ConvergenceThreshold, RealType);
+  itkNonVirtualGetConstMacro(CurrentConvergenceMeasurement, RealType);
+  itkNonVirtualGetConstMacro(ElapsedIterations, unsigned int);
+  itkNonVirtualSetMacro(SCCANFormulation, SCCANFormulationType);
+  itkNonVirtualGetConstMacro(SCCANFormulation, SCCANFormulationType);
+  itkNonVirtualSetMacro(Silent, bool);
+  itkNonVirtualGetMacro(Silent, bool);
+  itkNonVirtualSetMacro(RowSparseness, RealType);
+  itkNonVirtualGetMacro(RowSparseness, RealType);
+  itkNonVirtualSetMacro(UseLongitudinalFormulation, RealType);
+  itkNonVirtualGetMacro(UseLongitudinalFormulation, RealType);
+  itkNonVirtualSetMacro(Smoother, RealType);
+  itkNonVirtualGetMacro(Smoother, RealType);
 
   void
   NormalizeWeights(const unsigned int k);
@@ -258,9 +258,9 @@ public:
     return M;
   }
 
-  itkSetMacro(FractionNonZeroP, RealType);
-  itkSetMacro(KeepPositiveP, bool);
-  itkGetMacro(KeepPositiveP, bool);
+  itkNonVirtualSetMacro(FractionNonZeroP, RealType);
+  itkNonVirtualSetMacro(KeepPositiveP, bool);
+  itkNonVirtualGetMacro(KeepPositiveP, bool);
   void
   SetMaskImageP(ImagePointer mask)
   {
@@ -276,9 +276,9 @@ public:
     this->m_MatrixP.update(matrix);
   }
 
-  itkSetMacro(FractionNonZeroQ, RealType);
-  itkSetMacro(KeepPositiveQ, bool);
-  itkGetMacro(KeepPositiveQ, bool);
+  itkNonVirtualSetMacro(FractionNonZeroQ, RealType);
+  itkNonVirtualSetMacro(KeepPositiveQ, bool);
+  itkNonVirtualGetMacro(KeepPositiveQ, bool);
 
   void
   SetMaskImageQ(ImagePointer mask)
@@ -295,14 +295,14 @@ public:
     this->m_MatrixQ.update(matrix);
   }
 
-  itkSetMacro(Covering, unsigned int);
-  itkSetMacro(GetSmall, bool);
-  itkSetMacro(UseL1, bool);
-  itkSetMacro(MaxBasedThresholding, bool);
-  itkGetMacro(MaxBasedThresholding, bool);
-  itkSetMacro(GradStep, RealType);
-  itkSetMacro(FractionNonZeroR, RealType);
-  itkSetMacro(KeepPositiveR, bool);
+  itkNonVirtualSetMacro(Covering, unsigned int);
+  itkNonVirtualSetMacro(GetSmall, bool);
+  itkNonVirtualSetMacro(UseL1, bool);
+  itkNonVirtualSetMacro(MaxBasedThresholding, bool);
+  itkNonVirtualGetMacro(MaxBasedThresholding, bool);
+  itkNonVirtualSetMacro(GradStep, RealType);
+  itkNonVirtualSetMacro(FractionNonZeroR, RealType);
+  itkNonVirtualSetMacro(KeepPositiveR, bool);
   void
   SetMaskImageR(ImagePointer mask)
   {
@@ -649,8 +649,8 @@ for ( unsigned int j = 0 ; j < b.rows(); j++ ) mat( i , j ) = invamat( i , j );
     this->m_MatrixPriorROI2.update(matrix);
   }
 
-  // itkSetMacro( priorScale, RealType );
-  // itkGetMacro( priorScale, RealType );
+  // itkNonVirtualSetMacro( priorScale, RealType );
+  // itkNonVirtualGetMacro( priorScale, RealType );
   RealType
   GetPriorScaleMat()
   {

--- a/Utilities/itkAlternatingValueDifferenceImageFilter.h
+++ b/Utilities/itkAlternatingValueDifferenceImageFilter.h
@@ -74,11 +74,11 @@ public:
   static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
-  itkGetMacro(SubtractionDimension, unsigned int);
-  itkSetMacro(SubtractionDimension, unsigned int);
+  itkNonVirtualGetMacro(SubtractionDimension, unsigned int);
+  itkNonVirtualSetMacro(SubtractionDimension, unsigned int);
 
-  itkGetMacro(IndexPadding, unsigned int);
-  itkSetMacro(IndexPadding, unsigned int);
+  itkNonVirtualGetMacro(IndexPadding, unsigned int);
+  itkNonVirtualSetMacro(IndexPadding, unsigned int);
 
   /** Set the interpolator function.  The default is
    * LinearInterpolateImageFunction<InputImageType,
@@ -87,18 +87,18 @@ public:
    * (useful for binary masks and other images with a small number of
    * possible pixel values), and BSplineInterpolateImageFunction
    * (which provides a higher order of interpolation).  */
-  itkSetObjectMacro(ControlInterpolator, InterpolatorType);
-  itkSetObjectMacro(LabelInterpolator, InterpolatorType);
+  itkNonVirtualSetObjectMacro(ControlInterpolator, InterpolatorType);
+  itkNonVirtualSetObjectMacro(LabelInterpolator, InterpolatorType);
 
   /** Get a pointer to the interpolator function. */
-  itkGetConstObjectMacro(ControlInterpolator, InterpolatorType);
-  itkGetConstObjectMacro(LabelInterpolator, InterpolatorType);
+  itkNonVirtualGetConstObjectMacro(ControlInterpolator, InterpolatorType);
+  itkNonVirtualGetConstObjectMacro(LabelInterpolator, InterpolatorType);
 
-  itkGetModifiableObjectMacro(ControlImage, InputImageType);
-  itkGetModifiableObjectMacro(LabelImage, InputImageType);
+  itkNonVirtualGetModifiableObjectMacro(ControlImage, InputImageType);
+  itkNonVirtualGetModifiableObjectMacro(LabelImage, InputImageType);
 
-  itkGetModifiableObjectMacro(ControlOutputImage, InputImageType);
-  itkGetModifiableObjectMacro(LabelOutputImage, InputImageType);
+  itkNonVirtualGetModifiableObjectMacro(ControlOutputImage, InputImageType);
+  itkNonVirtualGetModifiableObjectMacro(LabelOutputImage, InputImageType);
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */

--- a/Utilities/itkAlternatingValueDifferenceImageFilter.h
+++ b/Utilities/itkAlternatingValueDifferenceImageFilter.h
@@ -19,6 +19,7 @@
 #define __itkAlternatingValueDifferenceImageFilter_h
 
 #include "itkImageToImageFilter.h"
+#include "ITKGetterSetterMacroShims.h"
 #include "itkExtrapolateImageFunction.h"
 #include "itkInterpolateImageFunction.h"
 #include "itkLinearInterpolateImageFunction.h"

--- a/Utilities/itkAlternatingValueSimpleSubtractionImageFilter.h
+++ b/Utilities/itkAlternatingValueSimpleSubtractionImageFilter.h
@@ -19,6 +19,7 @@
 #define __itkAlternatingValueSimpleSubtractionImageFilter_h
 
 #include "itkImageToImageFilter.h"
+#include "ITKGetterSetterMacroShims.h"
 
 namespace itk
 {

--- a/Utilities/itkAlternatingValueSimpleSubtractionImageFilter.h
+++ b/Utilities/itkAlternatingValueSimpleSubtractionImageFilter.h
@@ -65,8 +65,8 @@ public:
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
   /** Set/Get dimension to subtract over */
-  itkGetMacro(SubtractionDimension, unsigned int);
-  itkSetMacro(SubtractionDimension, unsigned int);
+  itkNonVirtualGetMacro(SubtractionDimension, unsigned int);
+  itkNonVirtualSetMacro(SubtractionDimension, unsigned int);
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */

--- a/Utilities/itkAverageOverDimensionImageFilter.h
+++ b/Utilities/itkAverageOverDimensionImageFilter.h
@@ -19,6 +19,7 @@
 #define __itkAverageOverDimensionImageFilter_h
 
 #include "itkInPlaceImageFilter.h"
+#include "ITKGetterSetterMacroShims.h"
 #include "itkSmartPointer.h"
 #include "itkExtractImageFilterRegionCopier.h"
 

--- a/Utilities/itkAverageOverDimensionImageFilter.h
+++ b/Utilities/itkAverageOverDimensionImageFilter.h
@@ -222,7 +222,7 @@ public:
    *  ExtractionRegion.Size = 0. */
   void
   SetAveragingDimension(unsigned int averagingDimension);
-  itkGetMacro(AveragingDimension, unsigned int);
+  itkNonVirtualGetMacro(AveragingDimension, unsigned int);
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */

--- a/Utilities/itkLabeledPointSetFileReader.h
+++ b/Utilities/itkLabeledPointSetFileReader.h
@@ -15,6 +15,7 @@
 #define itkLabeledPointSetFileReader_h
 
 #include "itkMesh.h"
+#include "ITKGetterSetterMacroShims.h"
 #include "itkMeshSource.h"
 
 #include "itkArray.h"

--- a/Utilities/itkLabeledPointSetFileReader.h
+++ b/Utilities/itkLabeledPointSetFileReader.h
@@ -65,18 +65,18 @@ public:
   typedef std::vector<PixelType> LabelSetType;
 
   /** Set/Get the name of the file to be read. */
-  itkSetStringMacro(FileName);
-  itkGetStringMacro(FileName);
+  itkNonVirtualSetStringMacro(FileName);
+  itkNonVirtualGetStringMacro(FileName);
 
-  itkSetMacro(ExtractBoundaryPoints, bool);
-  itkGetMacro(ExtractBoundaryPoints, bool);
-  itkBooleanMacro(ExtractBoundaryPoints);
+  itkNonVirtualSetMacro(ExtractBoundaryPoints, bool);
+  itkNonVirtualGetMacro(ExtractBoundaryPoints, bool);
+  itkNonVirtualBooleanMacro(ExtractBoundaryPoints);
 
   /**
    * Percentage of points selected randomnly
    */
-  itkSetClampMacro(RandomPercentage, double, 0.0, 1.0);
-  itkGetConstMacro(RandomPercentage, double);
+  itkNonVirtualSetClampMacro(RandomPercentage, double, 0.0, 1.0);
+  itkNonVirtualGetConstMacro(RandomPercentage, double);
 
   LabelSetType *
   GetLabelSet()

--- a/Utilities/itkLabeledPointSetFileWriter.h
+++ b/Utilities/itkLabeledPointSetFileWriter.h
@@ -15,6 +15,7 @@
 #define itkLabeledPointSetFileWriter_h
 
 #include "itkMesh.h"
+#include "ITKGetterSetterMacroShims.h"
 
 #include "itkArray.h"
 #include "itkImage.h"

--- a/Utilities/itkLabeledPointSetFileWriter.h
+++ b/Utilities/itkLabeledPointSetFileWriter.h
@@ -76,26 +76,26 @@ public:
   SetInput(InputMeshType * input);
 
   /** Set/Get the name of the file where data are written. */
-  itkSetStringMacro(FileName);
-  itkGetStringMacro(FileName);
+  itkNonVirtualSetStringMacro(FileName);
+  itkNonVirtualGetStringMacro(FileName);
 
   /** Specify other attributes */
-  itkSetMacro(Lines, typename LineSetType::Pointer);
+  itkNonVirtualSetMacro(Lines, typename LineSetType::Pointer);
 
-  itkSetMacro(MultiComponentScalars, typename MultiComponentScalarSetType::Pointer);
+  itkNonVirtualSetMacro(MultiComponentScalars, typename MultiComponentScalarSetType::Pointer);
 
   /** Specify image attributes if output is an image. */
-  itkSetMacro(ImageSize, ImageSizeType);
-  itkGetConstMacro(ImageSize, ImageSizeType);
+  itkNonVirtualSetMacro(ImageSize, ImageSizeType);
+  itkNonVirtualGetConstMacro(ImageSize, ImageSizeType);
 
-  itkSetMacro(ImageOrigin, ImageOriginType);
-  itkGetConstMacro(ImageOrigin, ImageOriginType);
+  itkNonVirtualSetMacro(ImageOrigin, ImageOriginType);
+  itkNonVirtualGetConstMacro(ImageOrigin, ImageOriginType);
 
-  itkSetMacro(ImageSpacing, ImageSpacingType);
-  itkGetConstMacro(ImageSpacing, ImageSpacingType);
+  itkNonVirtualSetMacro(ImageSpacing, ImageSpacingType);
+  itkNonVirtualGetConstMacro(ImageSpacing, ImageSpacingType);
 
-  itkSetMacro(ImageDirection, ImageDirectionType);
-  itkGetConstMacro(ImageDirection, ImageDirectionType);
+  itkNonVirtualSetMacro(ImageDirection, ImageDirectionType);
+  itkNonVirtualGetConstMacro(ImageDirection, ImageDirectionType);
 
 protected:
   LabeledPointSetFileWriter();

--- a/Utilities/itkMultiScaleLaplacianBlobDetectorImageFilter.h
+++ b/Utilities/itkMultiScaleLaplacianBlobDetectorImageFilter.h
@@ -59,8 +59,8 @@ public:
   itkOverrideGetNameOfClassMacro(ScaleSpaceBlobSpatialObject);
 
   /** Set/Get the normalized laplacian value of the extrema */
-  itkGetMacro(ScaleSpaceValue, double);
-  itkSetMacro(ScaleSpaceValue, double);
+  itkNonVirtualGetMacro(ScaleSpaceValue, double);
+  itkNonVirtualSetMacro(ScaleSpaceValue, double);
 
   /** The radius of the object if it is a solid hyper-sphere */
   double
@@ -77,8 +77,8 @@ public:
   }
 
   /** The location where the extrema occoured */
-  itkGetMacro(Center, CenterType);
-  itkSetMacro(Center, CenterType);
+  itkNonVirtualGetMacro(Center, CenterType);
+  itkNonVirtualSetMacro(Center, CenterType);
 
 private:
   double     m_ScaleSpaceValue;
@@ -142,28 +142,28 @@ public:
    *
    * T is equivalent to varinace or sigma squared.
    **/
-  itkSetMacro(StartT, double);
-  itkGetMacro(StartT, double);
+  itkNonVirtualSetMacro(StartT, double);
+  itkNonVirtualGetMacro(StartT, double);
 
   /** Set/Get the ending value to search scale-space.
    */
-  itkSetMacro(EndT, double);
-  itkGetMacro(EndT, double);
+  itkNonVirtualSetMacro(EndT, double);
+  itkNonVirtualGetMacro(EndT, double);
 
   /** Set/Get the number of steps per doubling of sigma sampled.
    */
-  itkSetMacro(StepsPerOctave, double);
-  itkGetMacro(StepsPerOctave, double);
+  itkNonVirtualSetMacro(StepsPerOctave, double);
+  itkNonVirtualGetMacro(StepsPerOctave, double);
 
   /** Set/Get the number of blobs to find
    */
-  itkSetMacro(NumberOfBlobs, size_t);
-  itkGetMacro(NumberOfBlobs, size_t);
+  itkNonVirtualSetMacro(NumberOfBlobs, size_t);
+  itkNonVirtualGetMacro(NumberOfBlobs, size_t);
 
   /** Set/Get the label image
    */
-  itkSetMacro(BlobRadiusImage, BlobRadiusImagePointer);
-  itkGetMacro(BlobRadiusImage, BlobRadiusImagePointer);
+  itkNonVirtualSetMacro(BlobRadiusImage, BlobRadiusImagePointer);
+  itkNonVirtualGetMacro(BlobRadiusImage, BlobRadiusImagePointer);
 
   /** Pseudo-output
    * Get the list of circles. This recomputes the circles

--- a/Utilities/itkMultiScaleLaplacianBlobDetectorImageFilter.h
+++ b/Utilities/itkMultiScaleLaplacianBlobDetectorImageFilter.h
@@ -27,6 +27,7 @@
 #define __itkMultiScaleLaplacianBlobDetectorImageFilter_h
 
 #include "itkImageToImageFilter.h"
+#include "ITKGetterSetterMacroShims.h"
 #include "itkGaussianSpatialObject.h"
 
 namespace itk

--- a/Utilities/itkPulsedArterialSpinLabeledCerebralBloodFlowImageFilter.h
+++ b/Utilities/itkPulsedArterialSpinLabeledCerebralBloodFlowImageFilter.h
@@ -19,6 +19,7 @@
 #define __itkPulsedArterialSpinLabeledCerebralBloodFlowImageFilter_h
 
 #include "itkImageToImageFilter.h"
+#include "ITKGetterSetterMacroShims.h"
 
 namespace itk
 {

--- a/Utilities/itkPulsedArterialSpinLabeledCerebralBloodFlowImageFilter.h
+++ b/Utilities/itkPulsedArterialSpinLabeledCerebralBloodFlowImageFilter.h
@@ -78,23 +78,23 @@ public:
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
   static constexpr unsigned int ReferenceImageDimension = TReferenceImage::ImageDimension;
 
-  itkGetMacro(TI1, float);
-  itkSetMacro(TI1, float);
+  itkNonVirtualGetMacro(TI1, float);
+  itkNonVirtualSetMacro(TI1, float);
 
-  itkGetMacro(TI2, float);
-  itkSetMacro(TI2, float);
+  itkNonVirtualGetMacro(TI2, float);
+  itkNonVirtualSetMacro(TI2, float);
 
-  itkGetMacro(T1blood, float);
-  itkSetMacro(T1blood, float);
+  itkNonVirtualGetMacro(T1blood, float);
+  itkNonVirtualSetMacro(T1blood, float);
 
-  itkGetMacro(Alpha, float);
-  itkSetMacro(Alpha, float);
+  itkNonVirtualGetMacro(Alpha, float);
+  itkNonVirtualSetMacro(Alpha, float);
 
-  itkGetMacro(Lambda, float);
-  itkSetMacro(Lambda, float);
+  itkNonVirtualGetMacro(Lambda, float);
+  itkNonVirtualSetMacro(Lambda, float);
 
-  itkGetMacro(SliceDelay, float);
-  itkSetMacro(SliceDelay, float);
+  itkNonVirtualGetMacro(SliceDelay, float);
+  itkNonVirtualSetMacro(SliceDelay, float);
 
   void
   SetDifferenceImage(const InputImageType * image);

--- a/Utilities/itkSliceTimingCorrectionImageFilter.h
+++ b/Utilities/itkSliceTimingCorrectionImageFilter.h
@@ -19,6 +19,7 @@
 #define __itkSliceTimingCorrectionImageFilter_h
 
 #include "itkImageToImageFilter.h"
+#include "ITKGetterSetterMacroShims.h"
 #include "itkExtrapolateImageFunction.h"
 #include "itkInterpolateImageFunction.h"
 #include "itkLinearInterpolateImageFunction.h"

--- a/Utilities/itkSliceTimingCorrectionImageFilter.h
+++ b/Utilities/itkSliceTimingCorrectionImageFilter.h
@@ -77,20 +77,20 @@ public:
   static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
   static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
-  itkGetMacro(TimeDimension, unsigned int);
-  itkSetMacro(TimeDimension, unsigned int);
+  itkNonVirtualGetMacro(TimeDimension, unsigned int);
+  itkNonVirtualSetMacro(TimeDimension, unsigned int);
 
-  itkSetMacro(SliceDimension, unsigned int);
-  itkGetMacro(SliceDimension, unsigned int);
+  itkNonVirtualSetMacro(SliceDimension, unsigned int);
+  itkNonVirtualGetMacro(SliceDimension, unsigned int);
 
-  itkGetMacro(IndexPadding, unsigned int);
-  itkSetMacro(IndexPadding, unsigned int);
+  itkNonVirtualGetMacro(IndexPadding, unsigned int);
+  itkNonVirtualSetMacro(IndexPadding, unsigned int);
 
-  itkSetMacro(SliceTiming, TimingType);
-  itkGetMacro(SliceTiming, TimingType);
+  itkNonVirtualSetMacro(SliceTiming, TimingType);
+  itkNonVirtualGetMacro(SliceTiming, TimingType);
 
-  itkSetMacro(ExtrapolateEdges, bool);
-  itkGetMacro(ExtrapolateEdges, bool);
+  itkNonVirtualSetMacro(ExtrapolateEdges, bool);
+  itkNonVirtualGetMacro(ExtrapolateEdges, bool);
 
   /** Set the interpolator function.  The default is
    * LinearInterpolateImageFunction<InputImageType,
@@ -100,10 +100,10 @@ public:
    * (useful for binary masks and other images with a small number of
    * possible pixel values), and BSplineInterpolateImageFunction
    * (which provides a higher order of interpolation).  */
-  itkSetObjectMacro(Interpolator, InterpolatorType);
+  itkNonVirtualSetObjectMacro(Interpolator, InterpolatorType);
 
   /** Get a pointer to the interpolator function. */
-  itkGetConstObjectMacro(Interpolator, InterpolatorType);
+  itkNonVirtualGetConstObjectMacro(Interpolator, InterpolatorType);
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */

--- a/Utilities/itkSurfaceImageCurvature.h
+++ b/Utilities/itkSurfaceImageCurvature.h
@@ -15,6 +15,7 @@
 #define _SurfaceImageCurvature_h
 
 #include "itkNeighborhoodIterator.h"
+#include "ITKGetterSetterMacroShims.h"
 #include "itkImageRegionIteratorWithIndex.h"
 
 #include "itkSurfaceCurvatureBase.h"

--- a/Utilities/itkSurfaceImageCurvature.h
+++ b/Utilities/itkSurfaceImageCurvature.h
@@ -155,18 +155,18 @@ public:
   void
   PostProcessGeometry();
 
-  itkSetMacro(NeighborhoodRadius, RealType);
-  itkGetMacro(NeighborhoodRadius, RealType);
+  itkNonVirtualSetMacro(NeighborhoodRadius, RealType);
+  itkNonVirtualGetMacro(NeighborhoodRadius, RealType);
 
-  itkSetMacro(UseLabel, bool);
-  itkGetMacro(UseLabel, bool);
+  itkNonVirtualSetMacro(UseLabel, bool);
+  itkNonVirtualGetMacro(UseLabel, bool);
 
-  itkSetMacro(kSign, float);
+  itkNonVirtualSetMacro(kSign, float);
 
-  itkSetMacro(Threshold, float);
+  itkNonVirtualSetMacro(Threshold, float);
 
-  itkGetMacro(FunctionImage, OutputImagePointer);
-  itkSetMacro(FunctionImage, OutputImagePointer);
+  itkNonVirtualGetMacro(FunctionImage, OutputImagePointer);
+  itkNonVirtualSetMacro(FunctionImage, OutputImagePointer);
 
   void
   ProcessLabelImage();


### PR DESCRIPTION
Silence 611 of 626 `-Wunnecessary-virtual-specifier` warnings reported by Clang on a clean ANTs build, by migrating 14 `final` classes from `itk{Set,Get,Boolean}Macro` to their new `itkNonVirtual*` equivalents (from upcoming ITK PR [InsightSoftwareConsortium/ITK#6253](https://github.com/InsightSoftwareConsortium/ITK/pull/6253)). A backward-compatibility shim header makes the work usable against current ITK 5.x and ITK 6.x master *today*, without waiting for #6253 to merge.

<details>
<summary>Why the warning fires (Clang's <code>-Wunnecessary-virtual-specifier</code>)</summary>

The legacy `itkSetMacro` / `itkGetMacro` / `itkBooleanMacro` families emit `virtual` on every generated member function. When the enclosing class is marked `final`, that `virtual` is meaningless — C++ only permits `final` on functions that override a base virtual, so a `virtual` function declared inside a `final` class with no matching base method cannot be further overridden. Clang flags every such occurrence.

The new `itkNonVirtual*` family emits the same function body without `virtual`, which is the correct spelling for a freshly-introduced member function inside a `final` class.

</details>

<details>
<summary>Scope of the cleanup</summary>

14 headers migrated (15 files touched once the shim include is added to each):

| File | Class |
|---|---|
| `ImageRegistration/itkANTSAffine3DTransform.h` | `ANTSAffine3DTransform` |
| `Temporary/antsFastMarchingImageFilter.h` | `FastMarchingImageFilter` |
| `Utilities/antsCommandLineOption.h` | `CommandLineOption` |
| `Utilities/antsCommandLineParser.h` | `CommandLineParser` |
| `Utilities/antsMatrixUtilities.h` | `antsMatrixUtilities` |
| `Utilities/antsSCCANObject.h` | `antsSCCANObject` |
| `Utilities/itkAlternatingValueDifferenceImageFilter.h` | `AlternatingValueDifferenceImageFilter` |
| `Utilities/itkAlternatingValueSimpleSubtractionImageFilter.h` | `AlternatingValueSimpleSubtractionImageFilter` |
| `Utilities/itkAverageOverDimensionImageFilter.h` | `AverageOverDimensionImageFilter` |
| `Utilities/itkLabeledPointSetFileReader.h` | `LabeledPointSetFileReader` |
| `Utilities/itkLabeledPointSetFileWriter.h` | `LabeledPointSetFileWriter` |
| `Utilities/itkMultiScaleLaplacianBlobDetectorImageFilter.h` | `MultiScaleLaplacianBlobDetectorImageFilter` |
| `Utilities/itkPulsedArterialSpinLabeledCerebralBloodFlowImageFilter.h` | `PulsedArterialSpinLabeledCerebralBloodFlowImageFilter` |
| `Utilities/itkSliceTimingCorrectionImageFilter.h` | `SliceTimingCorrectionImageFilter` |
| `Utilities/itkSurfaceImageCurvature.h` | `SurfaceImageCurvature` |

Also fixed: a latent typo `itkNotVirtualGetConstReferenceMacro` → `itkNonVirtualGetConstReferenceMacro`.

</details>

<details>
<summary>Backward compatibility: <code>Utilities/ITKGetterSetterMacroShims.h</code></summary>

`itkNonVirtual*` and its `itkVirtual*` / `itkFinal*` cousins are introduced by [ITK PR #6253](https://github.com/InsightSoftwareConsortium/ITK/pull/6253) and are absent from every released ITK to date — both the 5.x series and current 6.x `master`.

To keep ANTs buildable while that PR matures upstream, this PR adds a shim header that supplies the new macro family. The sentinel:

```cpp
#if !defined(itkSetMacroImpl)
// ... 27 macro families, parametrized by (virtualKeyword, finalKeyword) ...
#endif
```

uses `itkSetMacroImpl` — a brand-new identifier introduced by #6253 — as the trip-wire. Once ITK ships with #6253, the entire shim collapses to an empty translation unit and the file can be deleted in a one-line follow-up commit. No source churn at the migrated call sites.

Design notes:
- The shim only provides the **new** public variants (`itkVirtual*`, `itkFinal*`, `itkNonVirtual*`) plus the internal `*Impl(virtualKeyword, finalKeyword, ...)` helpers.
- The legacy `itkSetMacro`/`itkGetMacro`/etc. names are **not** redefined — pre-6253 ITK already provides them as `virtual`-emitting forms, and redefinition would trigger `-Wmacro-redefined`.
- Macro families covered: `Set/GetInput`, `Set/GetDecoratedInput`, `SetGetDecoratedInput`, `Set/GetDecoratedObjectInput`, `SetGetDecoratedObjectInput`, `Set`, `Get`, `GetConst`, `GetConstReference`, `SetEnum`, `GetEnum`, `SetString`, `GetString`, `SetClamp`, `SetObject`, `GetObject`, `GetConstObject`, `GetModifiableObject` (honoring `ITK_FUTURE_LEGACY_REMOVE`), `GetConstReferenceObject`, `SetConstObject`, `Boolean`, `SetVector`, `GetVector`, `Set/GetDecoratedOutput`.

</details>

<details>
<summary>Local validation</summary>

Two clean SuperBuilds from scratch, both against the SuperBuild's pinned pre-6253 ITK `GIT_TAG=18d89fd6` (2026-03-18):

| Build | Inner targets | SuperBuild steps | Errors |
|---|---|---|---|
| `build-ITKv5/` | 424/424 | 17/17 | 0 |
| `build-ITKv6/` | 424/424 | 17/17 | 0 |

(The "ITKv5" name is documentary — the ANTs SuperBuild only supports `ITK_VERSION_MAJOR=6`. Both builds exercise the shim's sentinel-false branch since the pinned ITK predates #6253.)

ccache was used to share dependency objects between the two builds. ANTs has no `.pre-commit-config.yaml`, so the per-PR pre-commit gate does not apply.

</details>

<!--
provenance: claude-code session 2026-05-12
related_upstream: InsightSoftwareConsortium/ITK#6253 (itkVirtual*/itkFinal*/itkNonVirtual* macro family)
followup: once #6253 ships in an ITK release ANTs supports, delete Utilities/ITKGetterSetterMacroShims.h and remove the corresponding #include lines (15 files).
key_facts:
  warnings_silenced: 611 of 626 -Wunnecessary-virtual-specifier
  classes_migrated: 14 (15 files touched)
  shim_sentinel: itkSetMacroImpl (introduced by ITK PR 6253)
  validation_builds: build-ITKv5/ and build-ITKv6/ both 0 errors, 424/424 inner + 17/17 superbuild
-->
