### PR TITLE
BUG: Fix segfault when mask file does not exist (NOMASK)

### DIFF
--- a/Examples/antsRegistrationTemplateHeader.h
+++ b/Examples/antsRegistrationTemplateHeader.h
@@ -352,7 +352,10 @@ DoRegistration(typename ParserType::Pointer & parser)
     if (cached.IsNull())
     {
       ReadImage<MaskImageType>(cached, filename.c_str());
-      cached->DisconnectPipeline();
+      if (cached.IsNotNull())
+      {
+        cached->DisconnectPipeline();
+      }
     }
     return cached;
   };


### PR DESCRIPTION
## Problem

`antsRegistration` segfaults when `--masks '[ NOMASK,NOMASK ]'` or any non-existent mask filename is passed.

## Root Cause

In `getCachedMask` (`Examples/antsRegistrationTemplateHeader.h:354`), `ReadImage` sets the smart pointer to `nullptr` when the file doesn't exist. The subsequent `cached->DisconnectPipeline()` unconditionally dereferences this null pointer.

## Fix

Add a null check before calling `DisconnectPipeline()`. The downstream code (`AddFixedImageMask`/`AddMovingImageMask`) already handles null masks correctly — this was the only missing guard.

## Verification

The command from the issue now fails gracefully instead of segfaulting:
```
antsRegistration --masks '[ NOMASK,NOMASK ]' ...
```