### PR TITLE
ENH: Add shrink factors, smoothing sigmas, and max iterations to diagnostic log headers

### DIFF
--- a/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
+++ b/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
@@ -120,18 +120,24 @@ public:
       const unsigned int lCurrentIteration = filter->GetCurrentIteration();
       if (lCurrentIteration == 1)
       {
+        this->Logger() << "XXDIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST";
+        if (currentLevel < this->m_ShrinkFactors.size())
+        {
+          this->Logger() << ",ShrinkFactor=" << this->m_ShrinkFactors[currentLevel];
+        }
+        if (currentLevel < this->m_SmoothingSigmas.size())
+        {
+          this->Logger() << ",SmoothingSigma=" << this->m_SmoothingSigmas[currentLevel];
+        }
+        if (currentLevel < this->m_NumberOfIterations.size())
+        {
+          this->Logger() << ",MaxIterations=" << this->m_NumberOfIterations[currentLevel];
+        }
         if (this->m_ComputeFullScaleCCInterval != 0)
         {
-          // Print header line one time
-          this->Logger() << "XXDIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST,"
-                            "FullScaleCCInterval="
-                         << this->m_ComputeFullScaleCCInterval << std::flush << std::endl;
+          this->Logger() << ",FullScaleCCInterval=" << this->m_ComputeFullScaleCCInterval;
         }
-        else
-        {
-          this->Logger() << "XXDIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST"
-                         << std::endl;
-        }
+        this->Logger() << std::flush << std::endl;
       }
       m_clock.Stop();
       const itk::RealTimeClock::TimeStampType now = m_clock.GetTotal();
@@ -206,6 +212,18 @@ public:
   SetNumberOfIterations(const std::vector<unsigned int> & iterations)
   {
     this->m_NumberOfIterations = iterations;
+  }
+
+  void
+  SetShrinkFactors(const std::vector<unsigned int> & shrinkFactors)
+  {
+    this->m_ShrinkFactors = shrinkFactors;
+  }
+
+  void
+  SetSmoothingSigmas(const std::vector<float> & smoothingSigmas)
+  {
+    this->m_SmoothingSigmas = smoothingSigmas;
   }
 
   void
@@ -508,6 +526,8 @@ private:
 
   std::string                       m_OutputPrefix;
   std::vector<unsigned int>         m_NumberOfIterations;
+  std::vector<unsigned int>         m_ShrinkFactors;
+  std::vector<float>                m_SmoothingSigmas;
   std::ostream *                    m_LogStream;
   itk::TimeProbe                    m_clock;
   itk::RealTimeClock::TimeStampType m_lastTotalTime;

--- a/Examples/antsRegistrationCommandIterationUpdate.h
+++ b/Examples/antsRegistrationCommandIterationUpdate.h
@@ -84,9 +84,21 @@ public:
       const unsigned int lCurrentIteration = filter->GetCurrentIteration();
       if (lCurrentIteration == 1)
       {
-        // Print header line one time
-        this->Logger() << "XDIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST"
-                       << std::flush << std::endl;
+        const unsigned int currentLevel = filter->GetCurrentLevel();
+        this->Logger() << "XDIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST";
+        if (currentLevel < this->m_ShrinkFactors.size())
+        {
+          this->Logger() << ",ShrinkFactor=" << this->m_ShrinkFactors[currentLevel];
+        }
+        if (currentLevel < this->m_SmoothingSigmas.size())
+        {
+          this->Logger() << ",SmoothingSigma=" << this->m_SmoothingSigmas[currentLevel];
+        }
+        if (currentLevel < this->m_NumberOfIterations.size())
+        {
+          this->Logger() << ",MaxIterations=" << this->m_NumberOfIterations[currentLevel];
+        }
+        this->Logger() << std::flush << std::endl;
       }
 
       m_clock.Stop();
@@ -108,6 +120,18 @@ public:
   }
 
   void
+  SetShrinkFactors(const std::vector<unsigned int> & shrinkFactors)
+  {
+    this->m_ShrinkFactors = shrinkFactors;
+  }
+
+  void
+  SetSmoothingSigmas(const std::vector<float> & smoothingSigmas)
+  {
+    this->m_SmoothingSigmas = smoothingSigmas;
+  }
+
+  void
   SetLogStream(std::ostream & logStream)
   {
     this->m_LogStream = &logStream;
@@ -121,6 +145,8 @@ private:
   }
 
   std::vector<unsigned int>         m_NumberOfIterations;
+  std::vector<unsigned int>         m_ShrinkFactors;
+  std::vector<float>                m_SmoothingSigmas;
   std::ostream *                    m_LogStream;
   itk::TimeProbe                    m_clock;
   itk::RealTimeClock::TimeStampType m_lastTotalTime;

--- a/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
+++ b/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
@@ -100,17 +100,26 @@ public:
         this->m_Optimizer->SetNumberOfIterations(this->m_NumberOfIterations[this->m_CurrentLevel]);
         this->m_CurrentLevel++;
 
-        if (this->m_ComputeFullScaleCCInterval != 0)
         {
-          // Print header line one time
-          this->Logger()
-            << "DIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST,FullScaleCCInterval="
-            << this->m_ComputeFullScaleCCInterval << std::flush << std::endl;
-        }
-        else
-        {
-          this->Logger() << "DIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST"
-                         << std::flush << std::endl;
+          const unsigned int levelIdx = this->m_CurrentLevel - 1;
+          this->Logger() << "DIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST";
+          if (levelIdx < this->m_ShrinkFactors.size())
+          {
+            this->Logger() << ",ShrinkFactor=" << this->m_ShrinkFactors[levelIdx];
+          }
+          if (levelIdx < this->m_SmoothingSigmas.size())
+          {
+            this->Logger() << ",SmoothingSigma=" << this->m_SmoothingSigmas[levelIdx];
+          }
+          if (levelIdx < this->m_NumberOfIterations.size())
+          {
+            this->Logger() << ",MaxIterations=" << this->m_NumberOfIterations[levelIdx];
+          }
+          if (this->m_ComputeFullScaleCCInterval != 0)
+          {
+            this->Logger() << ",FullScaleCCInterval=" << this->m_ComputeFullScaleCCInterval;
+          }
+          this->Logger() << std::flush << std::endl;
         }
       }
       m_clock.Stop();
@@ -182,6 +191,18 @@ public:
   SetNumberOfIterations(const std::vector<unsigned int> & iterations)
   {
     this->m_NumberOfIterations = iterations;
+  }
+
+  void
+  SetShrinkFactors(const std::vector<unsigned int> & shrinkFactors)
+  {
+    this->m_ShrinkFactors = shrinkFactors;
+  }
+
+  void
+  SetSmoothingSigmas(const std::vector<float> & smoothingSigmas)
+  {
+    this->m_SmoothingSigmas = smoothingSigmas;
   }
 
   void
@@ -447,6 +468,8 @@ private:
 
   std::string                       m_OutputPrefix;
   std::vector<unsigned int>         m_NumberOfIterations;
+  std::vector<unsigned int>         m_ShrinkFactors;
+  std::vector<float>                m_SmoothingSigmas;
   std::ostream *                    m_LogStream;
   itk::TimeProbe                    m_clock;
   itk::RealTimeClock::TimeStampType m_lastTotalTime;

--- a/Examples/itkantsRegistrationHelper.h
+++ b/Examples/itkantsRegistrationHelper.h
@@ -1068,6 +1068,8 @@ private:
     typename TransformCommandType::Pointer transformObserver = TransformCommandType::New();
     transformObserver->SetLogStream(*this->m_LogStream);
     transformObserver->SetNumberOfIterations(this->m_Iterations[currentStageNumber]);
+    transformObserver->SetShrinkFactors(this->m_ShrinkFactors[currentStageNumber]);
+    transformObserver->SetSmoothingSigmas(this->m_SmoothingSigmas[currentStageNumber]);
     registrationMethod->AddObserver(itk::IterationEvent(), transformObserver);
     registrationMethod->AddObserver(itk::InitializeEvent(), transformObserver);
 

--- a/Examples/itkantsRegistrationHelper.hxx
+++ b/Examples/itkantsRegistrationHelper.hxx
@@ -1381,6 +1381,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
     typename OptimizerCommandType::Pointer optimizerObserver = OptimizerCommandType::New();
     optimizerObserver->SetLogStream(*this->m_LogStream);
     optimizerObserver->SetNumberOfIterations(currentStageIterations);
+    optimizerObserver->SetShrinkFactors(factors);
+    optimizerObserver->SetSmoothingSigmas(sigmas);
     optimizerObserver->SetOptimizer(optimizer);
     optimizerObserver->SetOutputPrefix(this->m_OutputPrefix);
 
@@ -1419,6 +1421,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
     typename OptimizerCommandType2::Pointer optimizerObserver2 = OptimizerCommandType2::New();
     optimizerObserver2->SetLogStream(*this->m_LogStream);
     optimizerObserver2->SetNumberOfIterations(currentStageIterations);
+    optimizerObserver2->SetShrinkFactors(factors);
+    optimizerObserver2->SetSmoothingSigmas(sigmas);
     optimizerObserver2->SetOptimizer(optimizer2);
     if (!this->IsPointSetMetric(this->m_Metrics[0].m_MetricType))
     {
@@ -1813,6 +1817,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
           DisplacementFieldCommandType::New();
         displacementFieldRegistrationObserver->SetLogStream(*this->m_LogStream);
         displacementFieldRegistrationObserver->SetNumberOfIterations(currentStageIterations);
+        displacementFieldRegistrationObserver->SetShrinkFactors(factors);
+        displacementFieldRegistrationObserver->SetSmoothingSigmas(sigmas);
 
         registrationMethod->AddObserver(itk::IterationEvent(), displacementFieldRegistrationObserver);
         registrationMethod->AddObserver(itk::InitializeEvent(), displacementFieldRegistrationObserver);
@@ -1947,6 +1953,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
           DisplacementFieldCommandType::New();
         displacementFieldRegistrationObserver->SetLogStream(*this->m_LogStream);
         displacementFieldRegistrationObserver->SetNumberOfIterations(currentStageIterations);
+        displacementFieldRegistrationObserver->SetShrinkFactors(factors);
+        displacementFieldRegistrationObserver->SetSmoothingSigmas(sigmas);
 
         registrationMethod->AddObserver(itk::IterationEvent(), displacementFieldRegistrationObserver);
         registrationMethod->AddObserver(itk::InitializeEvent(), displacementFieldRegistrationObserver);
@@ -2163,6 +2171,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
           DisplacementFieldCommandType2::New();
         displacementFieldRegistrationObserver2->SetLogStream(*this->m_LogStream);
         displacementFieldRegistrationObserver2->SetNumberOfIterations(currentStageIterations);
+        displacementFieldRegistrationObserver2->SetShrinkFactors(factors);
+        displacementFieldRegistrationObserver2->SetSmoothingSigmas(sigmas);
         displacementFieldRegistrationObserver2->SetOrigFixedImage(this->m_Metrics[0].m_FixedImage);
         displacementFieldRegistrationObserver2->SetOrigMovingImage(this->m_Metrics[0].m_MovingImage);
         displacementFieldRegistrationObserver2->SetOutputPrefix(this->m_OutputPrefix);
@@ -2334,6 +2344,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
             DisplacementFieldCommandType::New();
           displacementFieldRegistrationObserver->SetLogStream(*this->m_LogStream);
           displacementFieldRegistrationObserver->SetNumberOfIterations(currentStageIterations);
+          displacementFieldRegistrationObserver->SetShrinkFactors(factors);
+          displacementFieldRegistrationObserver->SetSmoothingSigmas(sigmas);
 
           registrationMethod->AddObserver(itk::IterationEvent(), displacementFieldRegistrationObserver);
           registrationMethod->AddObserver(itk::InitializeEvent(), displacementFieldRegistrationObserver);
@@ -2449,6 +2461,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
             DisplacementFieldCommandType::New();
           displacementFieldRegistrationObserver->SetLogStream(*this->m_LogStream);
           displacementFieldRegistrationObserver->SetNumberOfIterations(currentStageIterations);
+          displacementFieldRegistrationObserver->SetShrinkFactors(factors);
+          displacementFieldRegistrationObserver->SetSmoothingSigmas(sigmas);
 
           registrationMethod->AddObserver(itk::IterationEvent(), displacementFieldRegistrationObserver);
           registrationMethod->AddObserver(itk::InitializeEvent(), displacementFieldRegistrationObserver);
@@ -2683,6 +2697,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
         typename VelocityFieldCommandType::Pointer velocityFieldRegistrationObserver = VelocityFieldCommandType::New();
         velocityFieldRegistrationObserver->SetLogStream(*this->m_LogStream);
         velocityFieldRegistrationObserver->SetNumberOfIterations(currentStageIterations);
+        velocityFieldRegistrationObserver->SetShrinkFactors(factors);
+        velocityFieldRegistrationObserver->SetSmoothingSigmas(sigmas);
 
         velocityFieldRegistration->AddObserver(itk::IterationEvent(), velocityFieldRegistrationObserver);
         velocityFieldRegistration->AddObserver(itk::InitializeEvent(), velocityFieldRegistrationObserver);
@@ -2905,6 +2921,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
             VelocityFieldCommandType::New();
           velocityFieldRegistrationObserver->SetLogStream(*this->m_LogStream);
           velocityFieldRegistrationObserver->SetNumberOfIterations(currentStageIterations);
+          velocityFieldRegistrationObserver->SetShrinkFactors(factors);
+          velocityFieldRegistrationObserver->SetSmoothingSigmas(sigmas);
 
           velocityFieldRegistration->AddObserver(itk::IterationEvent(), velocityFieldRegistrationObserver);
           velocityFieldRegistration->AddObserver(itk::InitializeEvent(), velocityFieldRegistrationObserver);
@@ -3064,6 +3082,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
             VelocityFieldCommandType::New();
           velocityFieldRegistrationObserver->SetLogStream(*this->m_LogStream);
           velocityFieldRegistrationObserver->SetNumberOfIterations(currentStageIterations);
+          velocityFieldRegistrationObserver->SetShrinkFactors(factors);
+          velocityFieldRegistrationObserver->SetSmoothingSigmas(sigmas);
 
           velocityFieldRegistration->AddObserver(itk::IterationEvent(), velocityFieldRegistrationObserver);
           velocityFieldRegistration->AddObserver(itk::InitializeEvent(), velocityFieldRegistrationObserver);
@@ -3227,6 +3247,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
           DisplacementFieldCommandType::New();
         displacementFieldRegistrationObserver->SetLogStream(*this->m_LogStream);
         displacementFieldRegistrationObserver->SetNumberOfIterations(currentStageIterations);
+        displacementFieldRegistrationObserver->SetShrinkFactors(factors);
+        displacementFieldRegistrationObserver->SetSmoothingSigmas(sigmas);
 
         displacementFieldRegistration->AddObserver(itk::IterationEvent(), displacementFieldRegistrationObserver);
         displacementFieldRegistration->AddObserver(itk::InitializeEvent(), displacementFieldRegistrationObserver);
@@ -3409,6 +3431,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
           DisplacementFieldCommandType::New();
         displacementFieldRegistrationObserver->SetLogStream(*this->m_LogStream);
         displacementFieldRegistrationObserver->SetNumberOfIterations(currentStageIterations);
+        displacementFieldRegistrationObserver->SetShrinkFactors(factors);
+        displacementFieldRegistrationObserver->SetSmoothingSigmas(sigmas);
 
         displacementFieldRegistration->AddObserver(itk::IterationEvent(), displacementFieldRegistrationObserver);
         displacementFieldRegistration->AddObserver(itk::InitializeEvent(), displacementFieldRegistrationObserver);
@@ -3515,6 +3539,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
         typename BSplineCommandType::Pointer bsplineObserver = BSplineCommandType::New();
         bsplineObserver->SetLogStream(*this->m_LogStream);
         bsplineObserver->SetNumberOfIterations(currentStageIterations);
+        bsplineObserver->SetShrinkFactors(factors);
+        bsplineObserver->SetSmoothingSigmas(sigmas);
 
         registrationMethod->AddObserver(itk::IterationEvent(), bsplineObserver);
         registrationMethod->AddObserver(itk::InitializeEvent(), bsplineObserver);


### PR DESCRIPTION
## Summary

Propagates per-stage registration parameters (`ShrinkFactor`, `SmoothingSigma`, `MaxIterations`) into the CSV diagnostic header lines emitted by all three observer/command classes at iteration 1.

Previously the diagnostic header only included `FullScaleCCInterval` when non-zero. Now the header conditionally appends all available per-stage metadata, making log output more self-describing for downstream analysis.

## Changes

**Observer classes** — all three gain `m_ShrinkFactors`, `m_SmoothingSigmas` members with setters and conditional header appends:
- `antsRegistrationCommandIterationUpdate.h` — uses `currentLevel` from filter
- `antsRegistrationOptimizerCommandIterationUpdate.h` — uses `levelIdx = m_CurrentLevel - 1`
- `antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h` — uses `currentLevel` from filter

**Registration helper** — wires `SetShrinkFactors`/`SetSmoothingSigmas` at all 14 observer creation sites:
- `itkantsRegistrationHelper.h` — linear registration observer (1 site)
- `itkantsRegistrationHelper.hxx` — all observer types in `DoRegistration()` (13 sites)

## Details

- Header prefixes preserved: `XXDIAGNOSTIC`, `XDIAGNOSTIC`, `DIAGNOSTIC`
- Bounds-checked: each field only appended when index is valid for the vector
- No new out-of-bounds risk — same indices already used for `m_Iterations` lookups
- 5 files changed, +118 / -21 lines