### PR TITLE
ENH: Diagnostic log metadata as separate CSV-stable line (supersedes #1978)

### DIFF
--- a/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
+++ b/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
@@ -120,18 +120,24 @@ public:
       const unsigned int lCurrentIteration = filter->GetCurrentIteration();
       if (lCurrentIteration == 1)
       {
+        this->Logger() << "XXDIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST";
+        if (currentLevel < this->m_ShrinkFactors.size())
+        {
+          this->Logger() << ",ShrinkFactor=" << this->m_ShrinkFactors[currentLevel];
+        }
+        if (currentLevel < this->m_SmoothingSigmas.size())
+        {
+          this->Logger() << ",SmoothingSigma=" << this->m_SmoothingSigmas[currentLevel];
+        }
+        if (currentLevel < this->m_NumberOfIterations.size())
+        {
+          this->Logger() << ",MaxIterations=" << this->m_NumberOfIterations[currentLevel];
+        }
         if (this->m_ComputeFullScaleCCInterval != 0)
         {
-          // Print header line one time
-          this->Logger() << "XXDIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST,"
-                            "FullScaleCCInterval="
-                         << this->m_ComputeFullScaleCCInterval << std::flush << std::endl;
+          this->Logger() << ",FullScaleCCInterval=" << this->m_ComputeFullScaleCCInterval;
         }
-        else
-        {
-          this->Logger() << "XXDIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST"
-                         << std::endl;
-        }
+        this->Logger() << std::flush << std::endl;
       }
       m_clock.Stop();
       const itk::RealTimeClock::TimeStampType now = m_clock.GetTotal();
@@ -206,6 +212,18 @@ public:
   SetNumberOfIterations(const std::vector<unsigned int> & iterations)
   {
     this->m_NumberOfIterations = iterations;
+  }
+
+  void
+  SetShrinkFactors(const std::vector<unsigned int> & shrinkFactors)
+  {
+    this->m_ShrinkFactors = shrinkFactors;
+  }
+
+  void
+  SetSmoothingSigmas(const std::vector<float> & smoothingSigmas)
+  {
+    this->m_SmoothingSigmas = smoothingSigmas;
   }
 
   void
@@ -508,6 +526,8 @@ private:
 
   std::string                       m_OutputPrefix;
   std::vector<unsigned int>         m_NumberOfIterations;
+  std::vector<unsigned int>         m_ShrinkFactors;
+  std::vector<float>                m_SmoothingSigmas;
   std::ostream *                    m_LogStream;
   itk::TimeProbe                    m_clock;
   itk::RealTimeClock::TimeStampType m_lastTotalTime;

--- a/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
+++ b/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
@@ -120,7 +120,7 @@ public:
       const unsigned int lCurrentIteration = filter->GetCurrentIteration();
       if (lCurrentIteration == 1)
       {
-        this->Logger() << "XXDIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST";
+        this->Logger() << "XXMETADATA,Level=" << currentLevel;
         if (currentLevel < this->m_ShrinkFactors.size())
         {
           this->Logger() << ",ShrinkFactor=" << this->m_ShrinkFactors[currentLevel];
@@ -138,6 +138,8 @@ public:
           this->Logger() << ",FullScaleCCInterval=" << this->m_ComputeFullScaleCCInterval;
         }
         this->Logger() << std::flush << std::endl;
+        this->Logger() << "XXDIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST"
+                       << std::flush << std::endl;
       }
       m_clock.Stop();
       const itk::RealTimeClock::TimeStampType now = m_clock.GetTotal();

--- a/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
+++ b/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
@@ -100,7 +100,7 @@ public:
         this->Logger() << " vox" << std::endl;
       }
       this->Logger() << "    required fixed parameters = " << adaptors[currentLevel]->GetRequiredFixedParameters()
-                     << std::flush << std::endl;
+                     << std::endl;
       // this->Logger() << "\n  LEVEL_TIME_INDEX: " << now << " SINCE_LAST: " << (now-this->m_lastTotalTime) <<
       // std::endl;
       this->m_lastTotalTime = now;
@@ -137,9 +137,9 @@ public:
         {
           this->Logger() << ",FullScaleCCInterval=" << this->m_ComputeFullScaleCCInterval;
         }
-        this->Logger() << std::flush << std::endl;
+        this->Logger() << std::endl;
         this->Logger() << "XXDIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST"
-                       << std::flush << std::endl;
+                       << std::endl;
       }
       m_clock.Stop();
       const itk::RealTimeClock::TimeStampType now = m_clock.GetTotal();
@@ -178,7 +178,7 @@ public:
                      << now << ", " << std::setprecision(4) << (now - this->m_lastTotalTime) << ", ";
       if ((this->m_ComputeFullScaleCCInterval != 0) && fabs(metricValue) > 1e-7)
       {
-        this->Logger() << std::scientific << std::setprecision(12) << metricValue << std::flush << std::endl;
+        this->Logger() << std::scientific << std::setprecision(12) << metricValue << std::endl;
       }
       else
       {

--- a/Examples/antsRegistrationCommandIterationUpdate.h
+++ b/Examples/antsRegistrationCommandIterationUpdate.h
@@ -84,9 +84,21 @@ public:
       const unsigned int lCurrentIteration = filter->GetCurrentIteration();
       if (lCurrentIteration == 1)
       {
-        // Print header line one time
-        this->Logger() << "XDIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST"
-                       << std::flush << std::endl;
+        const unsigned int currentLevel = filter->GetCurrentLevel();
+        this->Logger() << "XDIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST";
+        if (currentLevel < this->m_ShrinkFactors.size())
+        {
+          this->Logger() << ",ShrinkFactor=" << this->m_ShrinkFactors[currentLevel];
+        }
+        if (currentLevel < this->m_SmoothingSigmas.size())
+        {
+          this->Logger() << ",SmoothingSigma=" << this->m_SmoothingSigmas[currentLevel];
+        }
+        if (currentLevel < this->m_NumberOfIterations.size())
+        {
+          this->Logger() << ",MaxIterations=" << this->m_NumberOfIterations[currentLevel];
+        }
+        this->Logger() << std::flush << std::endl;
       }
 
       m_clock.Stop();
@@ -108,6 +120,18 @@ public:
   }
 
   void
+  SetShrinkFactors(const std::vector<unsigned int> & shrinkFactors)
+  {
+    this->m_ShrinkFactors = shrinkFactors;
+  }
+
+  void
+  SetSmoothingSigmas(const std::vector<float> & smoothingSigmas)
+  {
+    this->m_SmoothingSigmas = smoothingSigmas;
+  }
+
+  void
   SetLogStream(std::ostream & logStream)
   {
     this->m_LogStream = &logStream;
@@ -121,6 +145,8 @@ private:
   }
 
   std::vector<unsigned int>         m_NumberOfIterations;
+  std::vector<unsigned int>         m_ShrinkFactors;
+  std::vector<float>                m_SmoothingSigmas;
   std::ostream *                    m_LogStream;
   itk::TimeProbe                    m_clock;
   itk::RealTimeClock::TimeStampType m_lastTotalTime;

--- a/Examples/antsRegistrationCommandIterationUpdate.h
+++ b/Examples/antsRegistrationCommandIterationUpdate.h
@@ -65,7 +65,7 @@ public:
         this->Logger() << " vox" << std::endl;
       }
       this->Logger() << "    required fixed parameters = " << adaptors[currentLevel]->GetRequiredFixedParameters()
-                     << std::flush << std::endl;
+                     << std::endl;
       // this->Logger() << "\n  LEVEL_TIME_INDEX: " << now << " SINCE_LAST: " << (now-this->m_lastTotalTime) <<
       // std::endl;
       this->m_lastTotalTime = now;
@@ -98,9 +98,9 @@ public:
         {
           this->Logger() << ",MaxIterations=" << this->m_NumberOfIterations[currentLevel];
         }
-        this->Logger() << std::flush << std::endl;
+        this->Logger() << std::endl;
         this->Logger() << "XDIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST"
-                       << std::flush << std::endl;
+                       << std::endl;
       }
 
       m_clock.Stop();
@@ -108,8 +108,7 @@ public:
       this->Logger() << "WDIAGNOSTIC, " << std::setw(5) << lCurrentIteration << ", " << std::scientific
                      << std::setprecision(12) << filter->GetCurrentMetricValue() << ", " << std::scientific
                      << std::setprecision(12) << filter->GetCurrentConvergenceValue() << ", " << std::setprecision(4)
-                     << now << ", " << std::setprecision(4) << (now - this->m_lastTotalTime) << ", " << std::flush
-                     << std::endl;
+                     << now << ", " << std::setprecision(4) << (now - this->m_lastTotalTime) << ", " << std::endl;
       this->m_lastTotalTime = now;
       m_clock.Start();
     }

--- a/Examples/antsRegistrationCommandIterationUpdate.h
+++ b/Examples/antsRegistrationCommandIterationUpdate.h
@@ -85,7 +85,7 @@ public:
       if (lCurrentIteration == 1)
       {
         const unsigned int currentLevel = filter->GetCurrentLevel();
-        this->Logger() << "XDIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST";
+        this->Logger() << "XMETADATA,Level=" << currentLevel;
         if (currentLevel < this->m_ShrinkFactors.size())
         {
           this->Logger() << ",ShrinkFactor=" << this->m_ShrinkFactors[currentLevel];
@@ -99,6 +99,8 @@ public:
           this->Logger() << ",MaxIterations=" << this->m_NumberOfIterations[currentLevel];
         }
         this->Logger() << std::flush << std::endl;
+        this->Logger() << "XDIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST"
+                       << std::flush << std::endl;
       }
 
       m_clock.Stop();

--- a/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
+++ b/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
@@ -100,17 +100,26 @@ public:
         this->m_Optimizer->SetNumberOfIterations(this->m_NumberOfIterations[this->m_CurrentLevel]);
         this->m_CurrentLevel++;
 
-        if (this->m_ComputeFullScaleCCInterval != 0)
         {
-          // Print header line one time
-          this->Logger()
-            << "DIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST,FullScaleCCInterval="
-            << this->m_ComputeFullScaleCCInterval << std::flush << std::endl;
-        }
-        else
-        {
-          this->Logger() << "DIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST"
-                         << std::flush << std::endl;
+          const unsigned int levelIdx = this->m_CurrentLevel - 1;
+          this->Logger() << "DIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST";
+          if (levelIdx < this->m_ShrinkFactors.size())
+          {
+            this->Logger() << ",ShrinkFactor=" << this->m_ShrinkFactors[levelIdx];
+          }
+          if (levelIdx < this->m_SmoothingSigmas.size())
+          {
+            this->Logger() << ",SmoothingSigma=" << this->m_SmoothingSigmas[levelIdx];
+          }
+          if (levelIdx < this->m_NumberOfIterations.size())
+          {
+            this->Logger() << ",MaxIterations=" << this->m_NumberOfIterations[levelIdx];
+          }
+          if (this->m_ComputeFullScaleCCInterval != 0)
+          {
+            this->Logger() << ",FullScaleCCInterval=" << this->m_ComputeFullScaleCCInterval;
+          }
+          this->Logger() << std::flush << std::endl;
         }
       }
       m_clock.Stop();
@@ -182,6 +191,18 @@ public:
   SetNumberOfIterations(const std::vector<unsigned int> & iterations)
   {
     this->m_NumberOfIterations = iterations;
+  }
+
+  void
+  SetShrinkFactors(const std::vector<unsigned int> & shrinkFactors)
+  {
+    this->m_ShrinkFactors = shrinkFactors;
+  }
+
+  void
+  SetSmoothingSigmas(const std::vector<float> & smoothingSigmas)
+  {
+    this->m_SmoothingSigmas = smoothingSigmas;
   }
 
   void
@@ -447,6 +468,8 @@ private:
 
   std::string                       m_OutputPrefix;
   std::vector<unsigned int>         m_NumberOfIterations;
+  std::vector<unsigned int>         m_ShrinkFactors;
+  std::vector<float>                m_SmoothingSigmas;
   std::ostream *                    m_LogStream;
   itk::TimeProbe                    m_clock;
   itk::RealTimeClock::TimeStampType m_lastTotalTime;

--- a/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
+++ b/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
@@ -78,7 +78,7 @@ public:
         this->Logger() << " vox" << std::endl;
         }
       this->Logger() << "    required fixed parameters = " << adaptors[currentLevel]->GetRequiredFixedParameters()
-                     << std::flush << std::endl;
+                     << std::endl;
       // this->Logger() << "\n  LEVEL_TIME_INDEX: " << now << " SINCE_LAST: " << (now-this->m_lastTotalTime) <<
       // std::endl;
       this->m_lastTotalTime = now;
@@ -119,9 +119,9 @@ public:
           {
             this->Logger() << ",FullScaleCCInterval=" << this->m_ComputeFullScaleCCInterval;
           }
-          this->Logger() << std::flush << std::endl;
+          this->Logger() << std::endl;
           this->Logger() << "DIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST"
-                         << std::flush << std::endl;
+                         << std::endl;
         }
       }
       m_clock.Stop();
@@ -160,11 +160,11 @@ public:
                      << ", ";
       if ((this->m_ComputeFullScaleCCInterval != 0) && std::fabs(metricValue) > static_cast<MeasureType>(1e-7))
       {
-        this->Logger() << std::scientific << std::setprecision(12) << metricValue << std::flush << std::endl;
+        this->Logger() << std::scientific << std::setprecision(12) << metricValue << std::endl;
       }
       else
       {
-        this->Logger() << std::flush << std::endl;
+        this->Logger() << std::endl;
       }
 
       this->m_lastTotalTime = now;

--- a/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
+++ b/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
@@ -102,7 +102,7 @@ public:
 
         {
           const unsigned int levelIdx = this->m_CurrentLevel - 1;
-          this->Logger() << "DIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST";
+          this->Logger() << "METADATA,Level=" << levelIdx;
           if (levelIdx < this->m_ShrinkFactors.size())
           {
             this->Logger() << ",ShrinkFactor=" << this->m_ShrinkFactors[levelIdx];
@@ -120,6 +120,8 @@ public:
             this->Logger() << ",FullScaleCCInterval=" << this->m_ComputeFullScaleCCInterval;
           }
           this->Logger() << std::flush << std::endl;
+          this->Logger() << "DIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST"
+                         << std::flush << std::endl;
         }
       }
       m_clock.Stop();

--- a/Examples/itkantsRegistrationHelper.h
+++ b/Examples/itkantsRegistrationHelper.h
@@ -1068,6 +1068,8 @@ private:
     typename TransformCommandType::Pointer transformObserver = TransformCommandType::New();
     transformObserver->SetLogStream(*this->m_LogStream);
     transformObserver->SetNumberOfIterations(this->m_Iterations[currentStageNumber]);
+    transformObserver->SetShrinkFactors(this->m_ShrinkFactors[currentStageNumber]);
+    transformObserver->SetSmoothingSigmas(this->m_SmoothingSigmas[currentStageNumber]);
     registrationMethod->AddObserver(itk::IterationEvent(), transformObserver);
     registrationMethod->AddObserver(itk::InitializeEvent(), transformObserver);
 

--- a/Examples/itkantsRegistrationHelper.hxx
+++ b/Examples/itkantsRegistrationHelper.hxx
@@ -1381,6 +1381,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
     typename OptimizerCommandType::Pointer optimizerObserver = OptimizerCommandType::New();
     optimizerObserver->SetLogStream(*this->m_LogStream);
     optimizerObserver->SetNumberOfIterations(currentStageIterations);
+    optimizerObserver->SetShrinkFactors(factors);
+    optimizerObserver->SetSmoothingSigmas(sigmas);
     optimizerObserver->SetOptimizer(optimizer);
     optimizerObserver->SetOutputPrefix(this->m_OutputPrefix);
 
@@ -1419,6 +1421,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
     typename OptimizerCommandType2::Pointer optimizerObserver2 = OptimizerCommandType2::New();
     optimizerObserver2->SetLogStream(*this->m_LogStream);
     optimizerObserver2->SetNumberOfIterations(currentStageIterations);
+    optimizerObserver2->SetShrinkFactors(factors);
+    optimizerObserver2->SetSmoothingSigmas(sigmas);
     optimizerObserver2->SetOptimizer(optimizer2);
     if (!this->IsPointSetMetric(this->m_Metrics[0].m_MetricType))
     {
@@ -1813,6 +1817,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
           DisplacementFieldCommandType::New();
         displacementFieldRegistrationObserver->SetLogStream(*this->m_LogStream);
         displacementFieldRegistrationObserver->SetNumberOfIterations(currentStageIterations);
+        displacementFieldRegistrationObserver->SetShrinkFactors(factors);
+        displacementFieldRegistrationObserver->SetSmoothingSigmas(sigmas);
 
         registrationMethod->AddObserver(itk::IterationEvent(), displacementFieldRegistrationObserver);
         registrationMethod->AddObserver(itk::InitializeEvent(), displacementFieldRegistrationObserver);
@@ -1947,6 +1953,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
           DisplacementFieldCommandType::New();
         displacementFieldRegistrationObserver->SetLogStream(*this->m_LogStream);
         displacementFieldRegistrationObserver->SetNumberOfIterations(currentStageIterations);
+        displacementFieldRegistrationObserver->SetShrinkFactors(factors);
+        displacementFieldRegistrationObserver->SetSmoothingSigmas(sigmas);
 
         registrationMethod->AddObserver(itk::IterationEvent(), displacementFieldRegistrationObserver);
         registrationMethod->AddObserver(itk::InitializeEvent(), displacementFieldRegistrationObserver);
@@ -2163,6 +2171,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
           DisplacementFieldCommandType2::New();
         displacementFieldRegistrationObserver2->SetLogStream(*this->m_LogStream);
         displacementFieldRegistrationObserver2->SetNumberOfIterations(currentStageIterations);
+        displacementFieldRegistrationObserver2->SetShrinkFactors(factors);
+        displacementFieldRegistrationObserver2->SetSmoothingSigmas(sigmas);
         displacementFieldRegistrationObserver2->SetOrigFixedImage(this->m_Metrics[0].m_FixedImage);
         displacementFieldRegistrationObserver2->SetOrigMovingImage(this->m_Metrics[0].m_MovingImage);
         displacementFieldRegistrationObserver2->SetOutputPrefix(this->m_OutputPrefix);
@@ -2334,6 +2344,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
             DisplacementFieldCommandType::New();
           displacementFieldRegistrationObserver->SetLogStream(*this->m_LogStream);
           displacementFieldRegistrationObserver->SetNumberOfIterations(currentStageIterations);
+          displacementFieldRegistrationObserver->SetShrinkFactors(factors);
+          displacementFieldRegistrationObserver->SetSmoothingSigmas(sigmas);
 
           registrationMethod->AddObserver(itk::IterationEvent(), displacementFieldRegistrationObserver);
           registrationMethod->AddObserver(itk::InitializeEvent(), displacementFieldRegistrationObserver);
@@ -2449,6 +2461,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
             DisplacementFieldCommandType::New();
           displacementFieldRegistrationObserver->SetLogStream(*this->m_LogStream);
           displacementFieldRegistrationObserver->SetNumberOfIterations(currentStageIterations);
+          displacementFieldRegistrationObserver->SetShrinkFactors(factors);
+          displacementFieldRegistrationObserver->SetSmoothingSigmas(sigmas);
 
           registrationMethod->AddObserver(itk::IterationEvent(), displacementFieldRegistrationObserver);
           registrationMethod->AddObserver(itk::InitializeEvent(), displacementFieldRegistrationObserver);
@@ -2683,6 +2697,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
         typename VelocityFieldCommandType::Pointer velocityFieldRegistrationObserver = VelocityFieldCommandType::New();
         velocityFieldRegistrationObserver->SetLogStream(*this->m_LogStream);
         velocityFieldRegistrationObserver->SetNumberOfIterations(currentStageIterations);
+        velocityFieldRegistrationObserver->SetShrinkFactors(factors);
+        velocityFieldRegistrationObserver->SetSmoothingSigmas(sigmas);
 
         velocityFieldRegistration->AddObserver(itk::IterationEvent(), velocityFieldRegistrationObserver);
         velocityFieldRegistration->AddObserver(itk::InitializeEvent(), velocityFieldRegistrationObserver);
@@ -2905,6 +2921,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
             VelocityFieldCommandType::New();
           velocityFieldRegistrationObserver->SetLogStream(*this->m_LogStream);
           velocityFieldRegistrationObserver->SetNumberOfIterations(currentStageIterations);
+          velocityFieldRegistrationObserver->SetShrinkFactors(factors);
+          velocityFieldRegistrationObserver->SetSmoothingSigmas(sigmas);
 
           velocityFieldRegistration->AddObserver(itk::IterationEvent(), velocityFieldRegistrationObserver);
           velocityFieldRegistration->AddObserver(itk::InitializeEvent(), velocityFieldRegistrationObserver);
@@ -3064,6 +3082,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
             VelocityFieldCommandType::New();
           velocityFieldRegistrationObserver->SetLogStream(*this->m_LogStream);
           velocityFieldRegistrationObserver->SetNumberOfIterations(currentStageIterations);
+          velocityFieldRegistrationObserver->SetShrinkFactors(factors);
+          velocityFieldRegistrationObserver->SetSmoothingSigmas(sigmas);
 
           velocityFieldRegistration->AddObserver(itk::IterationEvent(), velocityFieldRegistrationObserver);
           velocityFieldRegistration->AddObserver(itk::InitializeEvent(), velocityFieldRegistrationObserver);
@@ -3227,6 +3247,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
           DisplacementFieldCommandType::New();
         displacementFieldRegistrationObserver->SetLogStream(*this->m_LogStream);
         displacementFieldRegistrationObserver->SetNumberOfIterations(currentStageIterations);
+        displacementFieldRegistrationObserver->SetShrinkFactors(factors);
+        displacementFieldRegistrationObserver->SetSmoothingSigmas(sigmas);
 
         displacementFieldRegistration->AddObserver(itk::IterationEvent(), displacementFieldRegistrationObserver);
         displacementFieldRegistration->AddObserver(itk::InitializeEvent(), displacementFieldRegistrationObserver);
@@ -3409,6 +3431,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
           DisplacementFieldCommandType::New();
         displacementFieldRegistrationObserver->SetLogStream(*this->m_LogStream);
         displacementFieldRegistrationObserver->SetNumberOfIterations(currentStageIterations);
+        displacementFieldRegistrationObserver->SetShrinkFactors(factors);
+        displacementFieldRegistrationObserver->SetSmoothingSigmas(sigmas);
 
         displacementFieldRegistration->AddObserver(itk::IterationEvent(), displacementFieldRegistrationObserver);
         displacementFieldRegistration->AddObserver(itk::InitializeEvent(), displacementFieldRegistrationObserver);
@@ -3515,6 +3539,8 @@ RegistrationHelper<TComputeType, VImageDimension>::DoRegistration()
         typename BSplineCommandType::Pointer bsplineObserver = BSplineCommandType::New();
         bsplineObserver->SetLogStream(*this->m_LogStream);
         bsplineObserver->SetNumberOfIterations(currentStageIterations);
+        bsplineObserver->SetShrinkFactors(factors);
+        bsplineObserver->SetSmoothingSigmas(sigmas);
 
         registrationMethod->AddObserver(itk::IterationEvent(), bsplineObserver);
         registrationMethod->AddObserver(itk::InitializeEvent(), bsplineObserver);


### PR DESCRIPTION
Supersedes #1978 — addresses @hjmjohnson's CSV-preservation concern and the redundant-flush nits raised by Copilot, on top of @gdevenyi's original commit, rebased onto latest `master`.

<details>
<summary>What changed vs #1978</summary>

Three commits:

1. **`ENH: Add shrink factors, ...`** — @gdevenyi's original commit, unchanged, with `Co-Authored-By:` attribution preserved via cherry-pick.
2. **`ENH: Split per-level metadata into separate METADATA line`** — moves the `Key=Value` pairs (`ShrinkFactor=`, `SmoothingSigma=`, `MaxIterations=`, `FullScaleCCInterval=`) out of the `DIAGNOSTIC` header onto a separate `METADATA` line emitted once per level. The `DIAGNOSTIC` header reverts to pure CSV column names so downstream plotting tools see a stable schema. Prefixes mirror the existing pattern: `METADATA` / `XMETADATA` / `XXMETADATA` paired with `DIAGNOSTIC` / `XDIAGNOSTIC` / `XXDIAGNOSTIC`.
3. **`STYLE: Remove redundant std::flush before std::endl`** — `std::endl` already flushes; drop the redundant `std::flush`.

Example output (per level):

```
METADATA,Level=0,ShrinkFactor=4,SmoothingSigma=2,MaxIterations=100
DIAGNOSTIC,Iteration,metricValue,convergenceValue,ITERATION_TIME_INDEX,SINCE_LAST
2DIAGNOSTIC,     1, ...
2DIAGNOSTIC,     2, ...
```

</details>

<details>
<summary>Review threads from #1978 addressed</summary>

| Thread | Resolution |
|---|---|
| @hjmjohnson: "retain CSV output" | Header is now pure column names; values moved to `METADATA` line |
| Copilot: variable-schema header (3×) | Same — `METADATA` line carries the config |
| Copilot: redundant `std::flush << std::endl` (3×) | Removed across all three observer headers |

</details>

<!--
provenance: claude-code session 2026-06-08, supersedes ANTsX/ANTs#1978
key_facts:
  base: origin/master (fc7557f9)
  commits: ca3b5f49 (gdevenyi cherry-pick) + 5e937deb (METADATA split) + 2a95ac2e (flush cleanup)
  files_touched: Examples/antsRegistration*CommandIterationUpdate.h x3, Examples/itkantsRegistrationHelper.h{,xx}
related_prs: ANTsX/ANTs#1978 (original)
post_merge_action: close #1978 with appreciative comment crediting @gdevenyi
-->
