### PR TITLE
ENH: Print smoothing sigmas with fixed precision

### DIFF
--- a/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
+++ b/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
@@ -127,7 +127,9 @@ public:
         }
         if (currentLevel < this->m_SmoothingSigmas.size())
         {
-          this->Logger() << ",SmoothingSigma=" << this->m_SmoothingSigmas[currentLevel];
+            std::ostringstream ss;
+            ss << std::scientific << std::setprecision(6) << this->m_SmoothingSigmas[currentLevel];
+            this->Logger() << ",SmoothingSigma=" << ss.str();
         }
         if (currentLevel < this->m_NumberOfIterations.size())
         {

--- a/Examples/antsRegistrationCommandIterationUpdate.h
+++ b/Examples/antsRegistrationCommandIterationUpdate.h
@@ -92,7 +92,9 @@ public:
         }
         if (currentLevel < this->m_SmoothingSigmas.size())
         {
-          this->Logger() << ",SmoothingSigma=" << this->m_SmoothingSigmas[currentLevel];
+          std::ostringstream ss;
+          ss << std::scientific << std::setprecision(6) << this->m_SmoothingSigmas[currentLevel];
+          this->Logger() << ",SmoothingSigma=" << ss.str();
         }
         if (currentLevel < this->m_NumberOfIterations.size())
         {

--- a/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
+++ b/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
@@ -109,7 +109,9 @@ public:
           }
           if (levelIdx < this->m_SmoothingSigmas.size())
           {
-            this->Logger() << ",SmoothingSigma=" << this->m_SmoothingSigmas[levelIdx];
+            std::ostringstream ss;
+            ss << std::scientific << std::setprecision(6) << this->m_SmoothingSigmas[levelIdx];
+            this->Logger() << ",SmoothingSigma=" << ss.str();
           }
           if (levelIdx < this->m_NumberOfIterations.size())
           {


### PR DESCRIPTION
Minor tweak to #1980, sometimes the default would print as an integer and sometimes as a float. 

Now print with fixed precision in scientific notation, so it will stay consistent between levels and maybe more readable for smaller voxels.