### PR TITLE
COMP: Add explicit itkImageRegionIteratorWithIndex.h includes for ITKv6

### DIFF
--- a/Examples/antsUtilities.h
+++ b/Examples/antsUtilities.h
@@ -20,6 +20,7 @@
 #include <iostream>
 
 #include "itkVector.h"
+#include "itkImageRegionIteratorWithIndex.h"
 #include "itkBinaryThresholdImageFilter.h"
 #include "itkBinaryBallStructuringElement.h"
 #include "itkBinaryDilateImageFilter.h"

--- a/Examples/iMathFunctions.hxx
+++ b/Examples/iMathFunctions.hxx
@@ -15,6 +15,7 @@
 #include "antsUtilities.h"
 
 #include "itkAddImageFilter.h"
+#include "itkImageRegionIteratorWithIndex.h"
 #include "itkAdaptiveHistogramEqualizationImageFilter.h"
 #include "itkBinaryBallStructuringElement.h"
 #include "itkBinaryErodeImageFilter.h"

--- a/Examples/iMathFunctions1.hxx
+++ b/Examples/iMathFunctions1.hxx
@@ -15,6 +15,7 @@
 #include "antsUtilities.h"
 
 #include "itkAddImageFilter.h"
+#include "itkImageRegionIteratorWithIndex.h"
 #include "itkAdaptiveHistogramEqualizationImageFilter.h"
 #include "itkBinaryBallStructuringElement.h"
 #include "itkBinaryErodeImageFilter.h"

--- a/Examples/iMathFunctions2.hxx
+++ b/Examples/iMathFunctions2.hxx
@@ -15,6 +15,7 @@
 #include "antsUtilities.h"
 
 #include "itkAddImageFilter.h"
+#include "itkImageRegionIteratorWithIndex.h"
 #include "itkAdaptiveHistogramEqualizationImageFilter.h"
 #include "itkBinaryBallStructuringElement.h"
 #include "itkBinaryErodeImageFilter.h"

--- a/Utilities/antsSCCANObject.hxx
+++ b/Utilities/antsSCCANObject.hxx
@@ -14,6 +14,7 @@
 
 =========================================================================*/
 #include "itkMinimumMaximumImageFilter.h"
+#include "itkImageRegionIteratorWithIndex.h"
 #include "itkConnectedComponentImageFilter.h"
 #include "itkRelabelComponentImageFilter.h"
 #include "itkExtractImageFilter.h"

--- a/Utilities/itkAverageOverDimensionImageFilter.hxx
+++ b/Utilities/itkAverageOverDimensionImageFilter.hxx
@@ -19,6 +19,7 @@
 #define __itkAverageOverDimensionImageFilter_hxx
 
 #include "itkImageAlgorithm.h"
+#include "itkImageRegionIteratorWithIndex.h"
 #include "itkObjectFactory.h"
 #include "itkProgressReporter.h"
 #include "itkImageRegionIterator.h"

--- a/Utilities/itkDisplacementFieldFromMultiTransformFilter.h
+++ b/Utilities/itkDisplacementFieldFromMultiTransformFilter.h
@@ -2,6 +2,7 @@
 #define ITKDEFORMATIONFIELDFROMMULTITRANSFORMFILTER_H_
 
 #include "itkWarpImageMultiTransformFilter.h"
+#include "itkImageRegionIteratorWithIndex.h"
 
 namespace itk
 {

--- a/Utilities/itkMaskedSmoothingImageFilter.hxx
+++ b/Utilities/itkMaskedSmoothingImageFilter.hxx
@@ -16,6 +16,7 @@
 
 
 #include "itkCastImageFilter.h"
+#include "itkImageRegionIteratorWithIndex.h"
 
 namespace itk
 {

--- a/Utilities/itkSliceTimingCorrectionImageFilter.hxx
+++ b/Utilities/itkSliceTimingCorrectionImageFilter.hxx
@@ -19,6 +19,7 @@
 #define __itkSliceTimingCorrectionImageFilter_hxx
 
 #include "itkProgressReporter.h"
+#include "itkImageRegionIteratorWithIndex.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageRegionConstIterator.h"
 

--- a/Utilities/itkSurfaceImageCurvature.hxx
+++ b/Utilities/itkSurfaceImageCurvature.hxx
@@ -17,6 +17,7 @@
 #include <vnl/algo/vnl_real_eigensystem.h>
 
 // #include "itkLevelSetCurvatureFunction.h"
+#include "itkImageRegionIteratorWithIndex.h"
 #include "itkCastImageFilter.h"
 #include "itkDiscreteGaussianImageFilter.h"
 #include <queue>


### PR DESCRIPTION
Adds explicit `#include "itkImageRegionIteratorWithIndex.h"` to the translation units that use `itk::ImageRegionIteratorWithIndex`, restoring compilation under ITKv6.

<details>
<summary>Why this is needed</summary>

ITKv6 reduced transitive header inclusion. Translation units that use `itk::ImageRegionIteratorWithIndex` previously relied on the header being pulled in indirectly by another ITK header; under ITKv6 they must include it directly. This is an include-what-you-use (IWYU) fix — no functional change.

Files touched (one `#include` line each):
- `Examples/antsUtilities.h`
- `Examples/iMathFunctions.hxx`, `iMathFunctions1.hxx`, `iMathFunctions2.hxx`
- `Utilities/antsSCCANObject.hxx`
- `Utilities/itkAverageOverDimensionImageFilter.hxx`
- `Utilities/itkDisplacementFieldFromMultiTransformFilter.h`
- `Utilities/itkMaskedSmoothingImageFilter.hxx`
- `Utilities/itkSliceTimingCorrectionImageFilter.hxx`
- `Utilities/itkSurfaceImageCurvature.hxx`

</details>

<details>
<summary>Test plan</summary>

Built the full ANTs target set against a local ITKv6 (`upstream/main`) build in the itk_forest_build_testbed; all executables compiled and linked.

</details>
