### PR TITLE
COMP: Build the compareTwoTransforms and simpleSynRegistration test drivers

### DIFF
--- a/Examples/TestSuite/CMakeLists.txt
+++ b/Examples/TestSuite/CMakeLists.txt
@@ -54,6 +54,8 @@ file(GLOB_RECURSE INCS ${CMAKE_SOURCE_DIR}/Examples/"*.h")
 
 MakeTestDriverFromANTSbinary(antsRegistrationTest antsRegistrationTest.cxx antsRegistration)
 MakeTestDriverFromANTSbinary(antsApplyTransformsTest antsApplyTransformsTest.cxx antsApplyTransforms)
+MakeTestDriverFromANTSbinary(compareTwoTransformsTest compareTwoTransformsTest.cxx compareTwoTransforms)
+MakeTestDriverFromANTSbinary(simpleSynRegistrationTest simpleSynRegistrationTest.cxx simpleSynRegistration)
 
 
 ###


### PR DESCRIPTION
The TestSuite invokes `compareTwoTransformsTestDriver` and `simpleSynRegistrationTestDriver` in `add_test()` commands, but no target builds them — so the four tests that use them are Not Run or fail to locate the executable. Two `MakeTestDriverFromANTSbinary()` calls wire the already-existing driver sources and `l_` libraries together.

<details>
<summary>Affected tests</summary>

Currently Not Run / failing for lack of the drivers:
- `antsRegistrationTest_initializePerStage_ComparisonTesting` (needs `compareTwoTransformsTestDriver`)
- `simpleSynRegistrationTesting` (needs `simpleSynRegistrationTestDriver`)
- `antsApplyTransformsTestForSimpleSynRegistration` (chained on the above)
- `simpleSynRegistration_Vs_antsRegistration` (chained on the above)

The `Examples/compareTwoTransforms.cxx` / `Examples/simpleSynRegistration.cxx` sources and the `l_compareTwoTransforms` / `l_simpleSynRegistration` libraries already exist (both tools are registered in `Examples/CMakeLists.txt`); only the two `MakeTestDriverFromANTSbinary()` invocations were missing. The `TEST Development SHOULD BE CONTINUED FROM HERE` marker in the TestSuite suggests these were scaffolded but never wired.

</details>

<details>
<summary>Testing performed</summary>

Built against ITK 6 (main), macOS arm64, clang 19. With the fix, both drivers compile and link, and the four tests transition from Not Run/error:

- `simpleSynRegistrationTesting` — **Pass**
- `antsApplyTransformsTestForSimpleSynRegistration` — **Pass**
- `simpleSynRegistration_Vs_antsRegistration` — **Pass**
- `antsRegistrationTest_initializePerStage_ComparisonTesting` — now **executes** and reports a transform-parameter mismatch against its stored `DATA{...Composite.result.h5}` baseline; the baseline appears stale (the test had never run), so it likely needs a baseline refresh in a follow-up. This PR restores the ability to build and run the driver; it does not touch the baseline.

</details>

<!--
provenance: found while validating an ITK vnl_svd engine change through a downstream ANTs build; the missing drivers were the only ANTs-side build gap. base ANTsX/ANTs main d2fbf8bd.
-->
