### PR TITLE
BUG: Fix out-of-bounds tensor component write in antsApplyTransforms

### DIFF
--- a/Examples/antsApplyTransforms.cxx
+++ b/Examples/antsApplyTransforms.cxx
@@ -188,7 +188,7 @@ antsApplyTransforms(itk::ants::CommandLineParser::Pointer & parser, unsigned int
   using AffineTransformType = typename RegistrationHelperType::AffineTransformType;
   using CompositeTransformType = typename RegistrationHelperType::CompositeTransformType;
 
-  const unsigned int NumberOfTensorElements = numTensorElements<Dimension>();
+  const unsigned int NumberOfTensorElements = TensorPixelType::InternalDimension;
 
   std::vector<unsigned int> tensorDiagIndices = tensorDiagonalArrayIndices<Dimension>();
 


### PR DESCRIPTION
Fixes an out-of-bounds tensor-component write in `antsApplyTransforms` when reassembling a diffusion-tensor image after resampling. Surfaces as a GCC 14 `-Waggressive-loop-optimizations` "iteration 6 invokes undefined behavior" warning.

<details>
<summary>Root cause</summary>

`TensorPixelType` is always `itk::DiffusionTensor3D` (6 unique components), but the component count was computed from the image dimension:

```cpp
const unsigned int NumberOfTensorElements = numTensorElements<Dimension>(); // = Dimension*(Dimension+1)/2
```

For the `Dimension == 4` instantiation that yields 10, so the component loops (`SetNthComponent(n, ...)` / selector index `n`) run past the tensor's 6 elements, writing out of bounds. Bound the loops by the tensor's own component count instead:

```cpp
const unsigned int NumberOfTensorElements = TensorPixelType::InternalDimension; // = 6
```

`numTensorElements<3>()` already equals 6, so behavior for 3-D images is unchanged.
</details>
