### PR TITLE
BUG: Value-initialize timeSeriesIndex in ReadWriteData conversions

### DIFF
--- a/Utilities/ReadWriteData.h
+++ b/Utilities/ReadWriteData.h
@@ -1067,7 +1067,7 @@ ConvertTimeSeriesImageToFiveDimensionalImage(TTimeSeriesImageType * timeSeriesIm
   for (It.GoToBegin(); !It.IsAtEnd(); ++It)
   {
     typename FiveDimensionalImageType::IndexType index = It.GetIndex();
-    typename TTimeSeriesImageType::IndexType     timeSeriesIndex;
+    typename TTimeSeriesImageType::IndexType     timeSeriesIndex{};
 
     timeSeriesIndex[0] = index[0];
     timeSeriesIndex[1] = index[1];
@@ -1123,7 +1123,7 @@ ConvertFiveDimensionalImageToTimeSeriesImage(FiveDimensionalImageType * FiveDime
   for (It.GoToBegin(); !It.IsAtEnd(); ++It)
   {
     typename FiveDimensionalImageType::IndexType index = It.GetIndex();
-    typename TimeSeriesImageType::IndexType      timeSeriesIndex;
+    typename TimeSeriesImageType::IndexType      timeSeriesIndex{};
 
     timeSeriesIndex[0] = index[0];
     timeSeriesIndex[1] = index[1];


### PR DESCRIPTION
Value-initializes the time-series index in the 4D/5D `ReadWriteData` conversion helpers. Surfaces as a GCC 14 `-Wmaybe-uninitialized` warning (via `itkImageHelper.h` offset computation).

<details>
<summary>Root cause</summary>

`ConvertTimeSeriesImageToFiveDimensionalImage` / `ConvertFiveDimensionalImageToTimeSeriesImage` declare the index uninitialized and assign only components `[0..3]`:

```cpp
typename TimeSeriesImageType::IndexType timeSeriesIndex;
timeSeriesIndex[0] = index[0]; ... timeSeriesIndex[3] = index[4];
```

When these templates instantiate with a 5-D index type, the trailing component is never set and is then consumed by `ImageBase::FastComputeOffset` in `Get/SetPixel`. Value-initializing (`... timeSeriesIndex{};`) zeroes the index before assignment.
</details>
