### PR TITLE
BUG: Initialize velocity-field resample spacing/size on the time axis

### DIFF
--- a/ImageRegistration/itkANTSImageRegistrationOptimizer.h
+++ b/ImageRegistration/itkANTSImageRegistrationOptimizer.h
@@ -369,11 +369,11 @@ public:
     using VelocityFieldSpacingType = typename TimeVaryingVelocityFieldType::SpacingType;
     using VelocityFieldSizeType = typename TimeVaryingVelocityFieldType::SizeType;
 
-    VelocityFieldSpacingType outputSpacing;
-    VelocityFieldSizeType    outputSize;
-
     VelocityFieldSpacingType inputSpacing = this->m_TimeVaryingVelocity->GetSpacing();
     VelocityFieldSizeType    inputSize = this->m_TimeVaryingVelocity->GetLargestPossibleRegion().GetSize();
+
+    VelocityFieldSpacingType outputSpacing = inputSpacing;
+    VelocityFieldSizeType    outputSize = inputSize;
 
     for (unsigned int d = 0; d < ImageDimension; d++)
     {


### PR DESCRIPTION
Initializes the time-axis spacing/size when resampling a time-varying velocity field in `ANTSImageRegistrationOptimizer::ExpandVelocity`. Surfaces as a GCC 14 `-Wmaybe-uninitialized` warning (via `ResampleImageFilter::SetOutputSpacing`).

<details>
<summary>Root cause</summary>

`outputSpacing` / `outputSize` span the full velocity-field dimension (spatial + time), but the fill loop only writes the `ImageDimension` spatial entries, leaving the trailing time-axis element uninitialized before it is handed to the resampler. Seeding the outputs from the input field keeps the time axis at the input spacing/size; the loop then overwrites the spatial dimensions as before.
</details>
