### PR TITLE
BUG: Value-initialize output vector in ReplicateDisplacement

### DIFF
--- a/Examples/ImageMath_Templates.hxx
+++ b/Examples/ImageMath_Templates.hxx
@@ -10603,7 +10603,7 @@ ReplicateDisplacement(int argc, char * argv[])
   typename VectorImageType::IndexType  ind;
   typename VectorRImageType::IndexType indp1;
   Iterator                             It1(vecimage1, vecimage1->GetLargestPossibleRegion());
-  typename VectorRImageType::PixelType vec;
+  typename VectorRImageType::PixelType vec{};
   for (It1.GoToBegin(); !It1.IsAtEnd(); ++It1)
   {
     ind = It1.GetIndex();


### PR DESCRIPTION
Value-initializes the output pixel in `ImageMath`'s `ReplicateDisplacement`. Surfaces as a GCC 14 `-Wmaybe-uninitialized` warning.

<details>
<summary>Root cause</summary>

The output vector is filled only for the `ImageDimension` input components; the remaining component of the wider output vector was written to the image uninitialized. Value-initializing (`... vec{};`) zeroes it first.
</details>
