### PR TITLE
COMP: Remove unused spacing variable in GetConnectedComponentsFeatureImages

### DIFF
--- a/Examples/GetConnectedComponentsFeatureImages.cxx
+++ b/Examples/GetConnectedComponentsFeatureImages.cxx
@@ -45,8 +45,6 @@ GetConnectedComponentsFeatureImages(int itkNotUsed(argc), char * argv[])
     outputImages.push_back(output);
   }
 
-  typename ImageType::SpacingType spacing = inputImage->GetSpacing();
-
   using RelabelerType = itk::RelabelComponentImageFilter<ImageType, ImageType>;
   typename RelabelerType::Pointer relabeler = RelabelerType::New();
   relabeler->SetInput(inputImage);


### PR DESCRIPTION
Removes an unused local in `GetConnectedComponentsFeatureImages`. Surfaces as a GCC 14 `-Wunused-but-set-variable` warning.

The `spacing` variable was assigned from `inputImage->GetSpacing()` but never read.
