### PR TITLE
TEST: Pin random seed for antsRegistrationTest_MSEAffineRotationMasks

### DIFF
--- a/Examples/TestSuite/CMakeLists.txt
+++ b/Examples/TestSuite/CMakeLists.txt
@@ -310,6 +310,7 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ${antsRegistrationTestName}
 
   antsRegistrationTest
   -v --dimensionality 3
+  --random-seed 1
   --convergence 25x20x5
   --shrink-factors 1x1x1
   --smoothing-sigmas 0.1x0.1x0.1


### PR DESCRIPTION
`antsRegistrationTest_MSEAffineRotationMasks` seeds its RNG from the wall clock, so the differing-pixel count against the baseline drifts run to run (observed 281–1043 vs a tolerance of 250), making it intermittently fail. Pin `--random-seed 1` for determinism — it now yields a stable 59 differing pixels, within tolerance. Same one-line fix already applied to `SimilarityRotationMasks` in #1990.

<details>
<summary>Validation</summary>

Reconfigured a built ANTs tree with the change and ran the test 5×: 100% pass each time (previously flaky, ~50% pass). Stable ImageError = 59 (tolerance 250).

</details>

<!--
provenance: surfaced during an ITK vnl_svd engine-swap forest validation; MSEAffineRotationMasks was the last flaky rotation test after #1990 pinned SimilarityRotationMasks. Companion to the integration/itkv6-ants-fixes branch.
-->
