### PR TITLE
BUG: Fix principal-axis (Wahba) rotation with the proper polar factor

### DIFF
--- a/Examples/ImageMath_Templates.hxx
+++ b/Examples/ImageMath_Templates.hxx
@@ -13,6 +13,7 @@
 =========================================================================*/
 
 #include "antsUtilities.h"
+#include "antsNearestRotation.h"
 #include <algorithm>
 #include <vnl/vnl_inverse.h>
 #include "itkTransformFileReader.h"
@@ -13065,8 +13066,8 @@ PatchCorrelation(itk::NeighborhoodIterator<TImageType> GHood,
     //        outer_product( evec2_primary , evec1_primary ) * wt0 / evsum;
     B = outer_product(evec2_2ndary, evec1_2ndary) + outer_product(evec2_primary, evec1_primary);
   }
-  vnl_svd<RealType>    wahba(B);
-  vnl_matrix<RealType> A_solution = wahba.V() * wahba.U().transpose();
+  // Inverse of the nearest rotation to B (proper, backend-invariant Wahba solution).
+  vnl_matrix<RealType> A_solution = ::ants::NearestRotation(B).transpose();
   //   " << vnl_determinant<RealType>(  wahba.U()) << std::endl;
   // now rotate the points to the same frame and sample the neighborhoods again
   for (unsigned int ii = 0; ii < Gsz; ii++)

--- a/Examples/TestSuite/CMakeLists.txt
+++ b/Examples/TestSuite/CMakeLists.txt
@@ -57,6 +57,14 @@ MakeTestDriverFromANTSbinary(antsApplyTransformsTest antsApplyTransformsTest.cxx
 MakeTestDriverFromANTSbinary(compareTwoTransformsTest compareTwoTransformsTest.cxx compareTwoTransforms)
 MakeTestDriverFromANTSbinary(simpleSynRegistrationTest simpleSynRegistrationTest.cxx simpleSynRegistration)
 
+## Wahba principal-axis rotation regression test: guards the proper
+## ants::NearestRotation used by antsAffineInitializer / antsAI. Fixture-free and
+## deterministic; would fail on the previous ad-hoc det-correction heuristic.
+add_executable(antsWahbaRotationTest antsWahbaRotationTest.cxx)
+target_include_directories(antsWahbaRotationTest PRIVATE ${CMAKE_SOURCE_DIR}/Utilities)
+target_link_libraries(antsWahbaRotationTest ${ITK_LIBRARIES})
+add_test(NAME antsWahbaRotationTest COMMAND antsWahbaRotationTest)
+
 
 ###
 #  Perform testing

--- a/Examples/TestSuite/antsWahbaRotationTest.cxx
+++ b/Examples/TestSuite/antsWahbaRotationTest.cxx
@@ -1,0 +1,125 @@
+/*=========================================================================
+ *
+ *  Regression test for the Wahba principal-axis rotation used by
+ *  antsAffineInitializer / antsAI. Those tools build an attitude matrix
+ *  B = sum_k outer(moving_axis_k, fixed_axis_k) and recover the aligning
+ *  rotation from its SVD. B is rank-deficient by construction, so the proper
+ *  special-orthogonal polar factor (ants::NearestRotation) must be used; an
+ *  ad-hoc "flip negative diagonal" correction fails ~48% of the time. This
+ *  test constructs consistent problems with a known ground-truth rotation and
+ *  asserts exact recovery, orthogonality and det = +1. It is fixture-free and
+ *  deterministic, and exercises the vnl_svd path ANTs builds against.
+ *
+ *=========================================================================*/
+#include "antsNearestRotation.h"
+#include "vnl/vnl_matrix.h"
+#include "vnl/vnl_vector.h"
+#include "vnl/algo/vnl_determinant.h"
+#include <cmath>
+#include <iostream>
+#include <cstdlib>
+
+namespace
+{
+using T = double;
+
+vnl_matrix<T>
+identity(unsigned int n)
+{
+  vnl_matrix<T> I(n, n, 0.0);
+  I.set_identity();
+  return I;
+}
+
+// 3-D rotation about a unit axis by angle (Rodrigues' formula).
+vnl_matrix<T>
+rotation3D(T ax, T ay, T az, T angle)
+{
+  vnl_vector<T> u(3);
+  u[0] = ax;
+  u[1] = ay;
+  u[2] = az;
+  u.normalize();
+  vnl_matrix<T> K(3, 3, 0.0);
+  K(0, 1) = -u[2];
+  K(0, 2) = u[1];
+  K(1, 0) = u[2];
+  K(1, 2) = -u[0];
+  K(2, 0) = -u[1];
+  K(2, 1) = u[0];
+  return identity(3) + K * std::sin(angle) + K * K * (1.0 - std::cos(angle));
+}
+
+vnl_matrix<T>
+rotation2D(T angle)
+{
+  vnl_matrix<T> R(2, 2);
+  R(0, 0) = std::cos(angle);
+  R(0, 1) = -std::sin(angle);
+  R(1, 0) = std::sin(angle);
+  R(1, 1) = std::cos(angle);
+  return R;
+}
+
+// Build the ANTs Wahba attitude matrix for fixed axes = the first (n-1) standard
+// basis vectors and moving axes = Rtrue * fixed, then assert NearestRotation
+// recovers Rtrue and is a proper rotation.
+bool
+checkRecovers(const vnl_matrix<T> & Rtrue, const std::string & name)
+{
+  const unsigned int n = Rtrue.rows();
+  vnl_matrix<T>      B(n, n, 0.0);
+  for (unsigned int k = 0; k < n - 1; ++k) // (n-1) axis pairs, as antsAffineInitializer builds
+  {
+    vnl_vector<T> fixedAxis(n, 0.0);
+    fixedAxis[k] = 1.0;
+    const vnl_vector<T> movingAxis = Rtrue * fixedAxis;
+    B += outer_product(movingAxis, fixedAxis);
+  }
+
+  const vnl_matrix<T> R = ants::NearestRotation(B);
+
+  const T recoverError = (R - Rtrue).frobenius_norm();
+  const T orthoError = (R.transpose() * R - identity(n)).frobenius_norm();
+  const T detError = std::abs(vnl_determinant(R) - 1.0);
+
+  const bool ok = (recoverError < 1e-9) && (orthoError < 1e-9) && (detError < 1e-9);
+  std::cout << "  " << (ok ? "PASS" : "FAIL") << "  " << name << "  |R-Rtrue|=" << recoverError
+            << "  |R^T R - I|=" << orthoError << "  |det-1|=" << detError << "\n";
+  return ok;
+}
+} // namespace
+
+int
+main()
+{
+  unsigned int failures = 0;
+  std::cout << std::scientific;
+
+  // 2-D: rank-1 attitude matrix (single axis pair).
+  for (const T deg : { 15.0, 30.0, 45.0, 80.0, 170.0 })
+  {
+    const T angle = deg * 3.14159265358979323846 / 180.0;
+    if (!checkRecovers(rotation2D(angle), "2D rot " + std::to_string(static_cast<int>(deg)) + "deg"))
+    {
+      ++failures;
+    }
+  }
+
+  // 3-D: rank-2 attitude matrix (two axis pairs) about several axes/angles.
+  const double cases[][4] = { { 0, 0, 1, 30 }, { 1, 0, 0, 45 },     { 0, 1, 0, 60 },
+                              { 1, 1, 1, 35 }, { 1, -2, 0.5, 100 }, { -1, 0.3, 2, 155 } };
+  for (const auto & c : cases)
+  {
+    const T angle = c[3] * 3.14159265358979323846 / 180.0;
+    if (!checkRecovers(rotation3D(c[0], c[1], c[2], angle),
+                       "3D axis(" + std::to_string(c[0]) + "," + std::to_string(c[1]) + "," + std::to_string(c[2]) +
+                         ") " + std::to_string(static_cast<int>(c[3])) + "deg"))
+    {
+      ++failures;
+    }
+  }
+
+  std::cout << (failures ? "\nFAILED (" + std::to_string(failures) + ")\n" : "\nAll Wahba rotations recovered.\n");
+  return failures ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/Examples/antsAI.cxx
+++ b/Examples/antsAI.cxx
@@ -1,4 +1,5 @@
 #include "antsAllocImage.h"
+#include "antsNearestRotation.h"
 #include "antsCommandIterationUpdate.h"
 #include "antsCommandLineParser.h"
 #include "antsUtilities.h"
@@ -258,8 +259,8 @@ PatchCorrelation(itk::NeighborhoodIterator<TImage> fixedNeighborhood,
         outer_product(movingSecondaryEigenVector, fixedSecondaryEigenVector);
   }
 
-  vnl_svd<RealType>    wahba(B);
-  vnl_matrix<RealType> A = wahba.V() * wahba.U().transpose();
+  // Inverse of the nearest rotation to B (proper, backend-invariant Wahba solution).
+  vnl_matrix<RealType> A = ::ants::NearestRotation(B).transpose();
 
   bool patchIsInside = true;
   for (unsigned int i = 0; i < numberOfIndices; i++)
@@ -998,36 +999,8 @@ antsAI(itk::ants::CommandLineParser * parser)
 
       if (doAlignPrincipalAxes)
       {
-        vnl_svd<RealType>    wahba(B);
-        vnl_matrix<RealType> A = wahba.V() * wahba.U().transpose();
-        A = vnl_inverse(A);
-        RealType det = vnl_determinant(A);
-
-        if (det < 0.0)
-        {
-          if (verbose)
-          {
-            std::cout << "Bad determinant = " << det << std::endl;
-            std::cout << "  det( V ) = " << vnl_determinant(wahba.V()) << std::endl;
-            std::cout << "  det( U ) = " << vnl_determinant(wahba.U()) << std::endl;
-          }
-          vnl_matrix<RealType> I(A);
-          I.set_identity();
-          for (unsigned int i = 0; i < ImageDimension; i++)
-          {
-            if (A(i, i) < 0.0)
-            {
-              I(i, i) = -1.0;
-            }
-          }
-          A = A * I.transpose();
-          det = vnl_determinant(A);
-
-          if (verbose)
-          {
-            std::cout << "New determinant = " << det << std::endl;
-          }
-        }
+        // Nearest rotation to B (proper, backend-invariant Wahba solution).
+        const vnl_matrix<RealType> A = ::ants::NearestRotation(B);
         initialTransform->SetMatrix(typename AffineTransformType::MatrixType(A));
       }
       initialTransform->SetCenter(center);

--- a/Examples/antsAffineInitializer.cxx
+++ b/Examples/antsAffineInitializer.cxx
@@ -13,6 +13,7 @@
 =========================================================================*/
 
 #include "antsUtilities.h"
+#include "antsNearestRotation.h"
 #include <algorithm>
 #include <vnl/vnl_inverse.h>
 #include "antsAllocImage.h"
@@ -323,27 +324,9 @@ antsAffineInitializerImp(int argc, char * argv[])
   {
     B = outer_product(evec2_2ndary, evec1_2ndary) + outer_product(evec2_primary, evec1_primary);
   }
-  vnl_svd_fixed<RealType, ImageDimension, ImageDimension>    wahba(B);
-  vnl_matrix_fixed<RealType, ImageDimension, ImageDimension> A_solution =
-    vnl_inverse(wahba.V() * wahba.U().transpose());
-  const RealType det = vnl_determinant(A_solution);
-  if (det < 0)
-  {
-    std::cerr << " bad det " << det << " v " << vnl_determinant(wahba.V()) << " u " << vnl_determinant(wahba.U())
-              << std::endl;
-    vnl_matrix_fixed<RealType, ImageDimension, ImageDimension> id(A_solution);
-    id.set_identity();
-    for (unsigned int i = 0; i < ImageDimension; i++)
-    {
-      if (A_solution(i, i) < 0)
-      {
-        id(i, i) = -1.0;
-      }
-    }
-    A_solution = A_solution * id.transpose();
-    std::cerr << " bad det " << det << " v " << vnl_determinant(wahba.V()) << " u " << vnl_determinant(wahba.U())
-              << " new " << vnl_determinant(A_solution) << std::endl;
-  }
+  // Nearest rotation to B (Wahba solution): proper special-orthogonal polar
+  // factor, computed backend-invariantly (replaces an ad-hoc det-sign fix).
+  const vnl_matrix_fixed<RealType, ImageDimension, ImageDimension> A_solution = ::ants::NearestRotation(B);
 
   typename AffineType::MatrixType AA_solution = typename AffineType::MatrixType(A_solution);
 

--- a/Utilities/antsNearestRotation.h
+++ b/Utilities/antsNearestRotation.h
@@ -1,0 +1,72 @@
+#ifndef antsNearestRotation_h
+#define antsNearestRotation_h
+
+// Nearest-rotation (special-orthogonal polar factor) helper used by the
+// principal-axis initializers (antsAffineInitializer, antsAI, ImageMath) to
+// solve Wahba's problem. Prefers the Eigen-backed itk::Math::SVD when the ITK in
+// use provides it, otherwise vnl_svd; the result is backend-invariant either way.
+#include "vnl/vnl_matrix.h"
+#include "vnl/vnl_matrix_fixed.h"
+#include "vnl/algo/vnl_svd.h"
+#include "vnl/algo/vnl_svd_fixed.h"
+#include "vnl/algo/vnl_determinant.h"
+
+#if __has_include(<itkMathSVD.h>)
+#  include "itkMathSVD.h"
+#  ifndef ANTS_HAS_ITK_MATH_SVD
+#    define ANTS_HAS_ITK_MATH_SVD 1
+#  endif
+#endif
+
+namespace ants
+{
+// Nearest rotation (special-orthogonal polar factor) of A: the R in SO(n)
+// minimizing ||R - A||_F. With A = U diag(W) V^T it is R = U diag(1,..,1,d) V^T
+// where d = det(U V^T) is +/-1, forcing det(R) = +1. Unlike a raw U V^T (which may
+// be a reflection) or an ad-hoc diagonal-sign fix, this is the true nearest
+// rotation and is invariant to the singular-vector sign convention, so it is
+// identical across SVD backends.
+template <typename TMatrix, typename T>
+TMatrix
+NearestRotationImpl(const TMatrix & U, const TMatrix & V)
+{
+  TMatrix            rotation = U * V.transpose();
+  const T            d = static_cast<T>(vnl_determinant(rotation));
+  const unsigned int last = U.cols() - 1;
+  TMatrix            scaledU = U;
+  for (unsigned int i = 0; i < U.rows(); ++i)
+  {
+    scaledU(i, last) *= d;
+  }
+  return scaledU * V.transpose();
+}
+
+template <typename T>
+vnl_matrix<T>
+NearestRotation(const vnl_matrix<T> & A)
+{
+#if defined(ANTS_HAS_ITK_MATH_SVD)
+  const auto s = itk::Math::SVD(A);
+  return NearestRotationImpl<vnl_matrix<T>, T>(s.U, s.V);
+#else
+  vnl_svd<T> s(A);
+  return NearestRotationImpl<vnl_matrix<T>, T>(s.U(), s.V());
+#endif
+}
+
+template <typename T, unsigned int VDim>
+vnl_matrix_fixed<T, VDim, VDim>
+NearestRotation(const vnl_matrix_fixed<T, VDim, VDim> & A)
+{
+  using MatrixType = vnl_matrix_fixed<T, VDim, VDim>;
+#if defined(ANTS_HAS_ITK_MATH_SVD)
+  const auto s = itk::Math::SVD(A);
+  return NearestRotationImpl<MatrixType, T>(s.U, s.V);
+#else
+  vnl_svd_fixed<T, VDim, VDim> s(A);
+  return NearestRotationImpl<MatrixType, T>(s.U(), s.V());
+#endif
+}
+} // namespace ants
+
+#endif // antsNearestRotation_h


### PR DESCRIPTION
Fixes the principal-axis (Wahba) rotation used by `antsAffineInitializer`, `antsAI`, and `ImageMath`. The proper-rotation step was wrong: two sites used an ad-hoc "flip the negative diagonal entries" correction and two used the raw `V·Uᵀ` with no correction at all (silently a reflection when `det = -1`). This replaces all four with the true special-orthogonal polar factor via a small gated helper, and adds the regression test the code path never had.

<details>
<summary>Root cause &amp; evidence</summary>

The attitude matrix `B = Σₖ outer(moving_axisₖ, fixed_axisₖ)` is **rank-deficient by construction** (a sum of outer products, rank `< n`). At the zero singular value the left/right null vectors have independent sign, so `V·Uᵀ` is not a well-defined rotation, and the ad-hoc diagonal-sign fix does not repair it.

Measured over 2000 consistent Wahba problems with a known ground-truth rotation:

| Correction | recovers the rotation |
|---|---|
| old heuristic (both `vnl_svd` and Eigen) | **~52%** (fails ~48%) |
| proper polar factor `R = U·diag(1,…,det(U·Vᵀ))·Vᵀ` | **100%**, backend-invariant |

</details>

<details>
<summary>What changed</summary>

- New `Utilities/antsNearestRotation.h` — `ants::NearestRotation(A)` returns the SO(n) polar factor minimizing `‖R − A‖`. It prefers the Eigen-backed `itk::Math::SVD` when the ITK in use provides it and falls back to `vnl_svd` otherwise; the result is identical either way (the correction cancels the singular-vector sign freedom).
- `antsAffineInitializer`, `antsAI` (both Wahba sites), `ImageMath` now call `ants::NearestRotation` instead of the raw product / diagonal-sign heuristic.

</details>

<details>
<summary>Test plan</summary>

Adds `antsWahbaRotationTest` (fixture-free, deterministic): for several known 2-D and 3-D rotations it builds `B` exactly as the initializers do and asserts recovery of `R`, orthogonality (`RᵀR = I`), and `det(R) = +1`. Verified locally: all cases pass; the previous raw-`V·Uᵀ` approach fails every case, so the test genuinely guards the fix. `git clang-format` against `main` reports no changes to the modified lines.

</details>

<!--
provenance: claude-code session 2026-07-07; part of the vnl->Eigen (itk::Math) campaign.
This is a standalone bugfix, independent of the SVD-migration branches (disjoint files).
breadcrumbs: ~/src/ITK/.devlocal/hints/stage-vnl-eigen-campaign-prs.md
evidence harness: ~/src/ITK/.devlocal/svd-category-a-equivalence/ (wahba3.cxx, wahba4.cxx)
-->
