### PR TITLE
CI: use step-security/msvc-dev-cmd instead of abandoned original

### DIFF
--- a/.github/workflows/release-win-binaries.yml
+++ b/.github/workflows/release-win-binaries.yml
@@ -27,7 +27,7 @@ jobs:
           ref: ${{ github.ref }}
       # Set up vs studio. Use default windows shell (powershell) not bash,
       # to avoid conflicts with link executable
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: step-security/msvc-dev-cmd@v1
         with:
           arch: ${{ runner.arch }}
           vsversion: ${{ matrix.vs }}


### PR DESCRIPTION
Avoids node.js 20 deprecation issue


