### PR TITLE
BUG: antsAI principal axes not initialized properly for 2D

### DIFF
--- a/Examples/antsAI.cxx
+++ b/Examples/antsAI.cxx
@@ -1007,8 +1007,10 @@ antsAI(itk::ants::CommandLineParser * parser)
 
       if (ImageDimension == 2)
       {
-        fixedTertiaryEigenVector = fixedSecondaryEigenVector;
         fixedSecondaryEigenVector = fixedPrimaryEigenVector;
+        fixedTertiaryEigenVector.set_size(2);
+        fixedTertiaryEigenVector[0] = -fixedPrimaryEigenVector[1];
+        fixedTertiaryEigenVector[1] = fixedPrimaryEigenVector[0];
       }
       if (ImageDimension == 3)
       {


### PR DESCRIPTION
The tertiary eigenvector was assigned as

`fixedTertiaryEigenVector = fixedSecondaryEigenVector;`

but `fixedSecondaryEigenVector` has not yet been initalized at this point.

The error is probably harmless because the axis1 and axis2 variables aren't used for 2D optimization, but may as well avoid it.