### PR TITLE
BUG: Make ANTSConfig.cmake usable from the build tree

### DIFF
--- a/ANTS.cmake
+++ b/ANTS.cmake
@@ -229,9 +229,24 @@ if(NOT ANTS_INSTALL_BIN_ONLY)
     DESTINATION "${ANTS_CONFIG_INSTALL_DIR}"
     COMPONENT DEVELOPMENT_antsUtilities)
 
+  # Two configs from one template: consumers may point ANTS_DIR at either the
+  # build tree (headers rooted in the source tree) or the install tree
+  # (headers relocated under <prefix>/include/ANTs).
+  set(ANTS_CONFIG_IS_BUILD_TREE TRUE)
+  set(ANTS_CONFIG_INCLUDE_ROOT "${${PROJECT_NAME}_SOURCE_DIR}")
+  set(ANTS_CONFIG_GENERATED_HEADER_DIR "${CMAKE_CURRENT_BINARY_DIR}")
   configure_package_config_file(
     "${${PROJECT_NAME}_SOURCE_DIR}/CMake/ANTSConfig.cmake.in"
     "${CMAKE_CURRENT_BINARY_DIR}/ANTSConfig.cmake"
+    INSTALL_DESTINATION "${CMAKE_CURRENT_BINARY_DIR}"
+    INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}")
+
+  set(ANTS_CONFIG_IS_BUILD_TREE FALSE)
+  set(ANTS_CONFIG_INCLUDE_ROOT "")
+  set(ANTS_CONFIG_GENERATED_HEADER_DIR "")
+  configure_package_config_file(
+    "${${PROJECT_NAME}_SOURCE_DIR}/CMake/ANTSConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/install/ANTSConfig.cmake"
     INSTALL_DESTINATION "${ANTS_CONFIG_INSTALL_DIR}")
 
   write_basic_package_version_file(
@@ -240,7 +255,7 @@ if(NOT ANTS_INSTALL_BIN_ONLY)
     COMPATIBILITY SameMajorVersion)
 
   install(FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/ANTSConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/install/ANTSConfig.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/ANTSConfigVersion.cmake"
     DESTINATION "${ANTS_CONFIG_INSTALL_DIR}"
     COMPONENT DEVELOPMENT_antsUtilities)

--- a/CMake/ANTSConfig.cmake.in
+++ b/CMake/ANTSConfig.cmake.in
@@ -22,8 +22,19 @@ include("${CMAKE_CURRENT_LIST_DIR}/ANTSTargets.cmake")
 # list, not an imported-target's INTERFACE_INCLUDE_DIRECTORIES with embedded
 # generator expressions). Modern consumers should prefer ANTS::antsUtilities
 # directly. Subdir list is generated from ANTS_PUBLIC_HEADER_DIRS in ANTS.cmake.
-set_and_check(ANTS_INCLUDE_DIR  "${PACKAGE_PREFIX_DIR}/include/ANTs")
-set(ANTS_INCLUDE_DIRS "${ANTS_INCLUDE_DIR}")
+set(_ANTS_BUILD_TREE_CONFIG @ANTS_CONFIG_IS_BUILD_TREE@)
+if(_ANTS_BUILD_TREE_CONFIG)
+  # In the build tree the public headers are still rooted in the source tree,
+  # and ANTsVersionConfig.h is generated into the build tree.
+  set_and_check(ANTS_INCLUDE_DIR "@ANTS_CONFIG_INCLUDE_ROOT@")
+  set_and_check(_ANTS_GENERATED_HEADER_DIR "@ANTS_CONFIG_GENERATED_HEADER_DIR@")
+  set(ANTS_INCLUDE_DIRS "${ANTS_INCLUDE_DIR}" "${_ANTS_GENERATED_HEADER_DIR}")
+  unset(_ANTS_GENERATED_HEADER_DIR)
+else()
+  set_and_check(ANTS_INCLUDE_DIR  "${PACKAGE_PREFIX_DIR}/include/ANTs")
+  set(ANTS_INCLUDE_DIRS "${ANTS_INCLUDE_DIR}")
+endif()
+unset(_ANTS_BUILD_TREE_CONFIG)
 set(_ANTS_HEADER_SUBDIRS "@ANTS_PUBLIC_HEADER_DIRS@")
 foreach(_ants_dir IN LISTS _ANTS_HEADER_SUBDIRS)
   list(APPEND ANTS_INCLUDE_DIRS "${ANTS_INCLUDE_DIR}/${_ants_dir}")


### PR DESCRIPTION
`ANTSConfig.cmake` was only usable from an install tree; pointing `ANTS_DIR` at an ANTs **build** tree made `find_package(ANTS)` fail in `set_and_check(ANTS_INCLUDE_DIR ...)`. Generate the config template twice — once for each tree — so both are consumable.

<details>
<summary>Root cause</summary>

One config was generated with `INSTALL_DESTINATION lib/cmake/ANTS`, then both left in the build tree *and* installed. `@PACKAGE_INIT@` derives `PACKAGE_PREFIX_DIR` by walking up as many levels as the install destination is deep (`../../../`). That is correct from `<prefix>/lib/cmake/ANTS/`, but from `<ants-build>/` it walks three levels above the build directory, so:

```
ANTS_INCLUDE_DIR = <somewhere-above-the-build-dir>/include/ANTs   # does not exist
CMake Error: File or directory ... referenced by variable ANTS_INCLUDE_DIR does not exist !
```

</details>

<details>
<summary>The change</summary>

- `ANTS.cmake`: call `configure_package_config_file` twice — a build-tree config (left in the build dir) and a relocatable install-tree config (staged under `CMakeFiles/install/`, and that copy is the one installed).
- `CMake/ANTSConfig.cmake.in`: branch on which tree it was generated for. The build-tree config roots includes at the **source** dir and adds the binary dir for the generated `ANTsVersionConfig.h`; the install-tree config keeps the existing `PACKAGE_PREFIX_DIR`-relative form.

`install(DIRECTORY <source>/<subdir>/ DESTINATION include/ANTs/<subdir>)` preserves the per-subdir layout, so the existing `ANTS_PUBLIC_HEADER_DIRS` loop appends `<root>/<subdir>` correctly for both trees and needed no duplication. `export(EXPORT ANTSTargets ...)` already emitted build-tree targets.

Both branches use `set_and_check`, so a bad include root still fails loudly rather than silently propagating.

</details>

<details>
<summary>Test plan</summary>

A consumer project calling `find_package(ANTS REQUIRED)` that asserts every `ANTS_INCLUDE_DIRS` entry exists on disk and that the imported target resolves, configured against each tree:

| `ANTS_DIR` | `ANTS_INCLUDE_DIRS` | `ANTS::antsUtilities` | exit |
|---|---|---|---|
| build tree | 9 entries, all exist | OK | 0 |
| install tree (full `cmake --install`) | 8 entries, all exist | OK | 0 |

The build tree has one extra entry: the binary dir holding the generated `ANTsVersionConfig.h`.

Downstream: BRAINSTools consumes ANTs via `ANTS_DIR=<ants-build>` and previously failed at its configure step; it now configures and builds.

CMake-config-only change; no new tests. The reconfigure is the test.

</details>
