### PR TITLE
ENH: Allow building against ITK v5 or v6 (default v6)

### DIFF
--- a/ANTS.cmake
+++ b/ANTS.cmake
@@ -47,6 +47,15 @@ endif()
 
 # Set up ITK
 find_package(ITK ${ITK_VERSION_ID} REQUIRED)
+if(NOT ITK_VERSION_MAJOR VERSION_EQUAL ANTs_EXPECTED_ITK_VERSION_MAJOR)
+  message(FATAL_ERROR "ANTs is configured for ITK v${ANTs_EXPECTED_ITK_VERSION_MAJOR} "
+                      "(ITK_VERSION_MAJOR), but found ITK ${ITK_VERSION} in ${ITK_DIR}.")
+endif()
+# ITK v5.4 ships no TractographyTRX remote-module entry, so the module cannot be fetched there.
+if(USE_TractographyTRX AND ITK_VERSION_MAJOR VERSION_LESS 6)
+  message(FATAL_ERROR "USE_TractographyTRX needs the ITK v6 TractographyTRX remote module, "
+                      "but found ITK ${ITK_VERSION}.")
+endif()
 include(${ITK_USE_FILE})
 
 # Set up which ANTs apps to build

--- a/CTestCustom.cmake
+++ b/CTestCustom.cmake
@@ -303,6 +303,7 @@ set(CTEST_CUSTOM_WARNING_EXCEPTION
   ".*OpenCV.*"
   ".*VTK.*"
   ".*has no symbols."
+  "ITKv5"
   "ITKv6"
   "SlicerExecutionModel"
   "SimpleITK"
@@ -353,6 +354,7 @@ set(CTEST_CUSTOM_ERROR_EXCEPTION
   ".*VTK.*"
   ".*has no symbols."
   "ITKv5"
+  "ITKv6"
   "SlicerExecutionModel"
   "SimpleITK"
 

--- a/Common.cmake
+++ b/Common.cmake
@@ -44,23 +44,18 @@ mark_as_advanced(ITK_USE_SYSTEM_PNG)
 # endif()
 #####################################################################################################
 
-set(USE_ITKv6 ON)
-set(ITK_VERSION_MAJOR 6 CACHE STRING "Choose the expected ITK major version to build ANTS only version 6 allowed.")
+set(ITK_VERSION_MAJOR 6 CACHE STRING "Choose the expected ITK major version to build ANTs: 6 (default) or 5.")
 # Set the possible values of ITK major version for cmake-gui
-set_property(CACHE ITK_VERSION_MAJOR PROPERTY STRINGS "6")
-set(expected_ITK_VERSION_MAJOR ${ITK_VERSION_MAJOR})
-if(${ITK_VERSION_MAJOR} VERSION_LESS ${expected_ITK_VERSION_MAJOR})
-  # Note: Since ITKv3 doesn't include a ITKConfigVersion.cmake file, let's check the version
-  #       explicitly instead of passing the version as an argument to find_package() command.
-  message(FATAL_ERROR "Could not find a configuration file for package \"ITK\" that is compatible "
-                      "with requested version \"${expected_ITK_VERSION_MAJOR}\".\n"
-                      "The following configuration files were considered but not accepted:\n"
-                      "  ${ITK_CONFIG}, version: ${ITK_VERSION_MAJOR}.${ITK_VERSION_MINOR}.${ITK_VERSION_PATCH}\n")
+set_property(CACHE ITK_VERSION_MAJOR PROPERTY STRINGS "6" "5")
+if(NOT ITK_VERSION_MAJOR MATCHES "^[56]$")
+  message(FATAL_ERROR "ITK_VERSION_MAJOR must be 6 (default) or 5, but is \"${ITK_VERSION_MAJOR}\".")
 endif()
+set(USE_ITKv5 OFF)
+set(USE_ITKv6 OFF)
+set(USE_ITKv${ITK_VERSION_MAJOR} ON)
 
-if(${ITK_VERSION_MAJOR} STREQUAL "3")
-  message(FATAL_ERROR "ITKv3 is no longer supported")
-endif()
+# find_package(ITK) overwrites ITK_VERSION_MAJOR with the version actually found.
+set(ANTs_EXPECTED_ITK_VERSION_MAJOR ${ITK_VERSION_MAJOR})
 
 
 #-----------------------------------------------------------------------------

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -106,7 +106,11 @@ CMAKE_DEPENDENT_OPTION(
      "USE_VTK" OFF
      )
 
-option(USE_TractographyTRX "Build antsApplyTransformsToTRX using the ITK TractographyTRX module" ON)
+# ITK v5.4 ships no TractographyTRX remote-module entry, so Module_TractographyTRX is a no-op there.
+CMAKE_DEPENDENT_OPTION(
+     USE_TractographyTRX "Build antsApplyTransformsToTRX using the ITK TractographyTRX module" ON
+     "ITK_VERSION_MAJOR EQUAL 6" OFF
+     )
 
 option(BUILD_ALL_ANTS_APPS "Build all ANTs apps" ON)
 option(RUN_SHORT_TESTS    "Run the quick unit tests."                                   ON  )

--- a/SuperBuild/External_ITKv5.cmake
+++ b/SuperBuild/External_ITKv5.cmake
@@ -1,0 +1,197 @@
+
+# Make sure this file is included only once by creating globally unique varibles
+# based on the name of this included file.
+get_filename_component(CMAKE_CURRENT_LIST_FILENAME ${CMAKE_CURRENT_LIST_FILE} NAME_WE)
+if(${CMAKE_CURRENT_LIST_FILENAME}_FILE_INCLUDED)
+  return()
+endif()
+set(${CMAKE_CURRENT_LIST_FILENAME}_FILE_INCLUDED 1)
+
+## External_${extProjName}.cmake files can be recurisvely included,
+## and cmake variables are global, so when including sub projects it
+## is important make the extProjName and proj variables
+## appear to stay constant in one of these files.
+## Store global variables before overwriting (then restore at end of this file.)
+ProjectDependancyPush(CACHED_extProjName ${extProjName})
+ProjectDependancyPush(CACHED_proj ${proj})
+
+# Make sure that the ExtProjName/IntProjName variables are unique globally
+# even if other External_${ExtProjName}.cmake files are sourced by
+# SlicerMacroCheckExternalProjectDependency
+set(extProjName ITK) #The find_package known name
+set(proj      ITKv5) #This local name
+set(${extProjName}_REQUIRED_VERSION ${${extProjName}_VERSION_MAJOR})  #If a required version is necessary, then set this, else leave blank
+
+#if(${USE_SYSTEM_${extProjName}})
+#  unset(${extProjName}_DIR CACHE)
+#endif()
+
+# Sanity checks
+if(DEFINED ${extProjName}_DIR AND NOT EXISTS ${${extProjName}_DIR})
+  message(FATAL_ERROR "${extProjName}_DIR variable is defined but corresponds to non-existing directory (${${extProjName}_DIR})")
+endif()
+
+# Set dependency list
+set(${proj}_DEPENDENCIES "")
+if(${PROJECT_NAME}_BUILD_DICOM_SUPPORT)
+  list(APPEND ${proj}_DEPENDENCIES DCMTK JPEG TIFF)
+endif()
+
+# Include dependent projects if any
+SlicerMacroCheckExternalProjectDependency(${proj})
+
+if(NOT DEFINED ${extProjName}_DIR AND NOT ${USE_SYSTEM_${extProjName}})
+  #message(STATUS "${__indent}Adding project ${proj}")
+
+  # Set CMake OSX variable to pass down the external project
+  set(CMAKE_OSX_EXTERNAL_PROJECT_ARGS)
+  if(APPLE)
+    list(APPEND CMAKE_OSX_EXTERNAL_PROJECT_ARGS
+      -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}
+      -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT}
+      -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
+  endif()
+
+  ### --- Project specific additions here
+  set(${proj}_DCMTK_ARGS)
+  if(${PROJECT_NAME}_BUILD_DICOM_SUPPORT)
+    set(${proj}_DCMTK_ARGS
+      -DITK_USE_SYSTEM_DCMTK:BOOL=ON
+      -DDCMTK_DIR:PATH=${DCMTK_DIR}
+      -DModule_ITKDCMTK:BOOL=ON
+      -DModule_ITKIODCMTK:BOOL=ON
+      )
+  endif()
+
+  if(${PROJECT_NAME}_BUILD_FFTWF_SUPPORT)
+    set(${proj}_FFTWF_ARGS
+      -DITK_USE_FFTWF:BOOL=ON
+      )
+  endif()
+  if(${PROJECT_NAME}_BUILD_FFTWD_SUPPORT)
+    set(${proj}_FFTWD_ARGS
+      -DITK_USE_FFTWD:BOOL=ON
+      )
+  endif()
+  if(${extProjName}_BUILD_MINC_SUPPORT)
+    set(${proj}_MINC_ARGS
+        -DModule_ITKIOMINC:BOOL=ON
+        -DModule_ITKIOTransformMINC:BOOL=ON
+        -DModule_ITKMINC:BOOL=ON
+       )
+  endif()
+
+  set(${proj}_WRAP_ARGS)
+  #if(foo)
+    #set(${proj}_WRAP_ARGS
+    #  -DINSTALL_WRAP_ITK_COMPATIBILITY:BOOL=OFF
+    #  -DWRAP_float:BOOL=ON
+    #  -DWRAP_unsigned_char:BOOL=ON
+    #  -DWRAP_signed_short:BOOL=ON
+    #  -DWRAP_unsigned_short:BOOL=ON
+    #  -DWRAP_complex_float:BOOL=ON
+    #  -DWRAP_vector_float:BOOL=ON
+    #  -DWRAP_covariant_vector_float:BOOL=ON
+    #  -DWRAP_rgb_signed_short:BOOL=ON
+    #  -DWRAP_rgb_unsigned_char:BOOL=ON
+    #  -DWRAP_rgb_unsigned_short:BOOL=ON
+    #  -DWRAP_ITK_TCL:BOOL=OFF
+    #  -DWRAP_ITK_JAVA:BOOL=OFF
+    #  -DWRAP_ITK_PYTHON:BOOL=ON
+    #  -DPYTHON_EXECUTABLE:PATH=${${CMAKE_PROJECT_NAME}_PYTHON_EXECUTABLE}
+    #  -DPYTHON_INCLUDE_DIR:PATH=${${CMAKE_PROJECT_NAME}_PYTHON_INCLUDE}
+    #  -DPYTHON_LIBRARY:FILEPATH=${${CMAKE_PROJECT_NAME}_PYTHON_LIBRARY}
+    #  )
+  #endif()
+
+  # HACK This code fixes a loony problem with HDF5 -- it doesn't
+  #      link properly if -fopenmp is used.
+  string(REPLACE "-fopenmp" "" ITK_CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+  string(REPLACE "-fopenmp" "" ITK_CMAKE_CXX_FLAGS "${CMAKE_CX_FLAGS}")
+
+  set(${proj}_CMAKE_OPTIONS
+      -DBUILD_TESTING:BOOL=OFF
+      -DBUILD_EXAMPLES:BOOL=OFF
+      -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_BINARY_DIR}/staging
+      -DITK_LEGACY_REMOVE:BOOL=ON
+      -DITK_FUTURE_LEGACY_REMOVE:BOOL=OFF
+      -DITKV3_COMPATIBILITY:BOOL=OFF
+      -DITK_BUILD_DEFAULT_MODULES:BOOL=ON
+      -DITK_USE_SYSTEM_PNG=${ITK_USE_SYSTEM_PNG}
+      -DITK_C_OPTIMIZATION_FLAGS:STRING=${ITK_C_OPTIMIZATION_FLAGS}
+      -DITK_CXX_OPTIMIZATION_FLAGS:STRING=${ITK_CXX_OPTIMIZATION_FLAGS}
+#      -DITK_MODULE_Core:BOOL=ON
+#      -DITK_MODULE_IO:BOOL=ON
+#      -DITK_MODULE_Filtering:BOOL=ON
+#      -DITK_MODULE_Registration:BOOL=ON
+      #-DITK_INSTALL_NO_DEVELOPMENT:BOOL=ON
+      -DKWSYS_USE_MD5:BOOL=ON # Required by SlicerExecutionModel
+      -DITK_WRAPPING:BOOL=OFF #${BUILD_SHARED_LIBS} ## HACK:  QUICK CHANGE
+      -DModule_MGHIO:BOOL=ON
+      -DModule_ITKReview:BOOL=ON
+      -DModule_GenericLabelInterpolator:BOOL=ON
+      -DModule_AdaptiveDenoising:BOOL=ON
+      ${${proj}_DCMTK_ARGS}
+      ${${proj}_WRAP_ARGS}
+      ${${proj}_FFTWF_ARGS}
+      ${${proj}_FFTWD_ARGS}
+      ${${proj}_MINC_ARGS}
+  )
+
+    if( USE_VTK STREQUAL "ON" )
+      list(APPEND ${proj}_CMAKE_OPTIONS -DModule_ITKVtkGlue:BOOL=ON)
+      if( USE_SYSTEM_VTK STREQUAL "OFF" )
+        list(INSERT CMAKE_PREFIX_PATH 0 ${CMAKE_BINARY_DIR}/staging)
+        list(APPEND ${proj}_CMAKE_OPTIONS -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH})
+      endif()
+      list(APPEND ${proj}_DEPENDENCIES VTK)
+    else()
+      list(APPEND ${proj}_CMAKE_OPTIONS -DModule_ITKVtkGlue:BOOL=OFF)
+    endif()
+
+
+  ### --- End Project specific additions
+  set(${proj}_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITK.git)
+  set(${proj}_GIT_TAG f7ff6ad56d487d9f52e6ba1dbbd9a816a14b5158) # v5.4.6, 2026-04-20
+  set(ITK_VERSION_ID ITK-5.4) ### NOTE: When updating GIT_TAG, also update ITK_VERSION_ID if ITK version has changed
+
+  ExternalProject_Add(${proj}
+    GIT_REPOSITORY ${${proj}_REPOSITORY}
+    GIT_TAG ${${proj}_GIT_TAG}
+    SOURCE_DIR ${proj}
+    BINARY_DIR ${proj}-build
+    LOG_CONFIGURE 0  # Wrap configure in script to ignore log output from dashboards
+    LOG_BUILD     0  # Wrap build in script to to ignore log output from dashboards
+    LOG_TEST      0  # Wrap test in script to to ignore log output from dashboards
+    LOG_INSTALL   0  # Wrap install in script to to ignore log output from dashboards
+    ${cmakeversion_external_update} "${cmakeversion_external_update_value}"
+    CMAKE_GENERATOR ${gen}
+    CMAKE_ARGS
+      -Wno-dev
+      --no-warn-unused-cli
+      ${CMAKE_OSX_EXTERNAL_PROJECT_ARGS}
+      ${COMMON_EXTERNAL_PROJECT_ARGS}
+      ${${proj}_CMAKE_OPTIONS}
+      -DCMAKE_GENERATOR_PLATFORM:STRING=${CMAKE_GENERATOR_PLATFORM}
+## We really do want to install in order to limit # of include paths INSTALL_COMMAND ""
+    DEPENDS
+      ${${proj}_DEPENDENCIES}
+  )
+  set(${extProjName}_DIR ${CMAKE_BINARY_DIR}/staging/${CMAKE_INSTALL_LIBDIR}/cmake/${ITK_VERSION_ID})
+else()
+  if(${USE_SYSTEM_${extProjName}})
+    find_package(${extProjName} ${ITK_VERSION_MAJOR} REQUIRED)
+    if(NOT ${extProjName}_DIR)
+      message(FATAL_ERROR "To use the system ${extProjName}, set ${extProjName}_DIR")
+    endif()
+    message("USING the system ${extProjName}, set ${extProjName}_DIR=${${extProjName}_DIR}")
+  endif()
+  # The project is provided using ${extProjName}_DIR, nevertheless since other
+  # project may depend on ${extProjName}, let's add an 'empty' one
+  SlicerMacroEmptyExternalProject(${proj} "${${proj}_DEPENDENCIES}")
+endif()
+
+list(APPEND ${CMAKE_PROJECT_NAME}_SUPERBUILD_EP_VARS ${extProjName}_DIR:PATH)
+
+ProjectDependancyPop(CACHED_extProjName extProjName)
+ProjectDependancyPop(CACHED_proj proj)

--- a/SuperBuild/External_SlicerExecutionModel.cmake
+++ b/SuperBuild/External_SlicerExecutionModel.cmake
@@ -31,7 +31,7 @@ if(DEFINED ${extProjName}_DIR AND NOT EXISTS ${${extProjName}_DIR})
 endif()
 
 # Set dependency list
-set(${proj}_DEPENDENCIES ITKv6)
+set(${proj}_DEPENDENCIES ITKv${ITK_VERSION_MAJOR})
 
 # Include dependent projects if any
 SlicerMacroCheckExternalProjectDependency(${proj})


### PR DESCRIPTION
Restores the ability to configure ANTs against ITK **v5** (`release-5.4`) while keeping **v6 as the default**, via `cmake -DITK_VERSION_MAJOR=5`. Being able to compile the *same* ANTs source against both ITK majors is an important transition step: it is what lets us validate results and quantify the algorithmic differences between ITK v5 and v6 that can make tests produce slightly different numbers. Without it, an ITK-induced change in output is indistinguishable from an ANTs change.

Verified locally against ITK v5.4.6: **494/494 targets, 0 errors**, and the **full test suite passes 171/171** (`RUN_SHORT_TESTS` and `RUN_LONG_TESTS` both ON). The ITK v6 default path is unchanged.

<details>
<summary>Why: commit 0c1d30c5 ("WIP: Update to ITK6") may have been merged in error</summary>

`0c1d30c5` is labelled **WIP** in its own subject line, which suggests it was not intended to land as-is. It hard-wired `ITK_VERSION_MAJOR` to `6` (`set_property(CACHE ITK_VERSION_MAJOR PROPERTY STRINGS "6")`) and renamed `SuperBuild/External_ITKv5.cmake` → `External_ITKv6.cmake`, removing any way to build against ITK v5.

That turns out to have been unnecessarily lossy: **ANTs on ITK 5.4.6 is not merely compilable, it is test-clean** (171/171). The ITK6-only part of that commit was the CMake plumbing, not the C++. So dropping v5 support cost us the cross-major comparison capability without any corresponding source-level requirement.

This PR does not revert `0c1d30c5` — the move to ITK v6 as the default is correct and is preserved. It only makes v5 selectable again.

</details>

<details>
<summary>What changed</summary>

- **`Common.cmake`** — `ITK_VERSION_MAJOR` is a validated `6`-or-`5` choice (default `6`); sets `USE_ITKv5`/`USE_ITKv6` accordingly and records the requested major before `find_package(ITK)` overwrites the variable. Also drops a dead self-comparison block (`expected_ITK_VERSION_MAJOR` was assigned from `ITK_VERSION_MAJOR` and then compared against it, so the guard could never fire).
- **`SuperBuild/External_ITKv5.cmake`** — restored, pinned to ITK **v5.4.6** (`f7ff6ad5`, the newest tag on `release-5.4`).
- **`SuperBuild/External_SlicerExecutionModel.cmake`** — depends on `ITKv${ITK_VERSION_MAJOR}` rather than the literal `ITKv6`.
- **`SuperBuild.cmake`** — `USE_TractographyTRX` becomes a `CMAKE_DEPENDENT_OPTION` gated on `ITK_VERSION_MAJOR EQUAL 6`, so it is only selectable when ITK v6 is chosen and is forced OFF (hidden from the cache) otherwise.
- **`ANTS.cmake`** — configure-time `FATAL_ERROR` if the ITK actually found does not match the requested major (a silent mismatch would otherwise surface as confusing compile errors), and a `FATAL_ERROR` if `USE_TractographyTRX` is requested with ITK v5.
- **`CTestCustom.cmake`** — warning/error exception lists carry both `ITKv5` and `ITKv6`.

</details>

<details>
<summary>Why TractographyTRX is gated on ITK v6 (it is a CMake coupling, not an API requirement)</summary>

To be precise, TRX does **not** require ITK v6 at the API level. Its `CMakeLists.txt` asks only for `find_package(ITK REQUIRED)` with no version floor, and its `itk-module.cmake` depends on `ITKCommon`, `ITKTransform`, `ITKEigen3`, `ITKIONIFTI`, `ITKMathematicalMorphology` — all present in 5.4. Two CMake-level couplings block it anyway:

1. **No remote-module entry.** ITK 5.4 ships no `Modules/Remote/TractographyTRX.remote.cmake` (added to ITK `main` in `43f49d75`). ANTs' SuperBuild enables TRX by passing `-DModule_TractographyTRX:BOOL=ON` to ITK, which is simply a no-op on `release-5.4`.

2. **A hardcoded ITK v6 zlib export name.** Building TRX standalone against an ITK 5.4.6 tree fails at CMake *generate*, before compiling anything: `Target "zip" links to: ITK::ITKZLIBModule but the target was not found.` TRX's `itk-module-init.cmake` bridges ITK's internal zlib to `ZLIB::ZLIB` for its vendored libzip and assumes the target is named `ITKZLIBModule` / `ITK::ITKZLIBModule`. ITK v6 exports that name; **ITK 5.4 exports only `itkzlib`.**

Item 2 looks like a small fix, but it belongs upstream in [ITKTractographyTRX](https://github.com/tee-ar-ex/ITKTractographyTRX), not in ANTs. Until both are addressed, TRX cannot be enabled through ANTs on ITK v5, so gating the option is the honest behavior. An ITK v5 build therefore does not build `antsApplyTransformsToTRX` or `PrintTRXHeader`, and `USE_TractographyTRX` is hidden from the cache rather than silently ignored.

</details>

<details>
<summary>Local validation</summary>

| Configuration | Result |
|---|---|
| Inner build, `ITK_VERSION_MAJOR=5`, real ITK 5.4.6 | **494/494 targets, 0 errors; ctest 171/171 passed, 0 failed** |
| Inner build, default (v6), real ITK 6 | **494/494 targets, 0 errors; ctest 171/171 passed, 0 failed** |
| SuperBuild, `ITK_VERSION_MAJOR=5` | configures; resolves `ITKv5`; TRX hidden from cache |
| SuperBuild, `ITK_VERSION_MAJOR=6` | configures; resolves `ITKv6`; `USE_TractographyTRX:BOOL=ON` |
| Default (v6) pointed at an ITK 5 tree | fails at configure: *"ANTs is configured for ITK v6 … but found ITK 5.4.6"* |
| `ITK_VERSION_MAJOR=5` + `USE_TractographyTRX=ON` | fails at configure: *"USE_TractographyTRX needs the ITK v6 TractographyTRX remote module"* |

Both runs cover the full suite with `RUN_SHORT_TESTS=ON` and `RUN_LONG_TESTS=ON` (131 short + 40 long, including the `antsRegistrationTest_*`, `ANTS_ROT_*` and `ANTS_SYN_WITH_TIME` registrations). Both majors register the same 171 tests and both pass all of them, so at current tolerances the suite shows no ITK v5 → v6 behavioral difference.

Not covered: the ITK v5 **SuperBuild** path was configure-tested only — the full clone-and-build of `External_ITKv5.cmake` was not run end to end.

</details>

<!--
provenance: claude-code session 2026-07-14, forest build_forest-ITK-main, repo ANTsX/ANTs
branch: hjmjohnson:allow-itk5-or-itk6, base ANTsX/ANTs main @ 3f95bdce
itkv5_pin: f7ff6ad56d487d9f52e6ba1dbbd9a816a14b5158 (v5.4.6, 2026-04-20)
key_files: Common.cmake, ANTS.cmake, SuperBuild.cmake, SuperBuild/External_ITKv5.cmake,
           SuperBuild/External_SlicerExecutionModel.cmake, CTestCustom.cmake
itk5_evidence: 494/494 ninja targets 0 errors; ctest 171/171 pass (short+long) vs ITK 5.4.6
trx_real_blockers: (1) no Modules/Remote/TractographyTRX.remote.cmake on ITK release-5.4
                   (2) TRX itk-module-init.cmake hardcodes ITK::ITKZLIBModule; ITK 5.4 exports itkzlib
                   -> fix (2) upstream in tee-ar-ex/ITKTractographyTRX, not in ANTs
untested: full ITK v5 SuperBuild (External_ITKv5.cmake clone+build); configure-only there
-->
