### PR TITLE
TEST: Pin random seed for antsRegistrationTest_AffineScaleMasks

### DIFF
--- a/Examples/TestSuite/CMakeLists.txt
+++ b/Examples/TestSuite/CMakeLists.txt
@@ -115,6 +115,7 @@ ExternalData_add_test( ${PROJECT_NAME}FetchData NAME ${antsRegistrationTestName}
 
   antsRegistrationTest
   -v --dimensionality 3
+  --random-seed 1
   --convergence 25x20x5 #numberOfIterations 2500
   --shrink-factors 1x1x1
   --smoothing-sigmas 0.1x0.1x0.1


### PR DESCRIPTION
`antsRegistrationTest_AffineScaleMasks` seeded its RNG from the wall clock, so it failed roughly 1 run in 10. Pinning `--random-seed 1` makes it deterministic — 20/20 passes against both ITK 5.4.6 and ITK 6.0.0, with the existing baseline and tolerance unchanged.

Completes the pattern already applied to `antsRegistrationTest_MSEAffineRotationMasks` (b181e3a4) and `antsRegistrationTest_SimilarityRotationMasks` (5aaef6c4).

<details>
<summary>Evidence</summary>

Found while testing ANTs main against two ITK versions to look for v5-vs-v6 regressions. The test failed once on the ITK-main sweep and passed on release-5.4, which looked like a v6 regression — repeated runs showed otherwise:

| | before (no seed) | after (`--random-seed 1`) |
|---|---|---|
| ITK 5.4.6 | 9 pass / 1 fail of 10 | **20 pass / 0 fail of 20** |
| ITK 6.0.0 | 9 pass / 1 fail of 10 | **20 pass / 0 fail of 20** |

Identical failure rates on both ITK versions — the flake is version-independent, not an ITK regression.

The failing run reported `ImageError = 1043` differing pixels against `--compareNumberOfPixelsTolerance 1000`; the count varies run to run and crosses the tolerance intermittently. This matches the mechanism recorded in b181e3a4 / 5aaef6c4 (measured 1288–5311 against a tolerance of 1000).

Both ITK versions were built with the same ANTs commit (ebeb304a), `RUN_LONG_TESTS=ON`, and `ITK_VERSION_MAJOR` matched per side.

</details>

<!--
provenance: found via itk_forest_build_testbed ANTs v5-vs-v6 comparison, 2026-07-16
base: ebeb304a (ANTsX/ANTs main)
file: Examples/TestSuite/CMakeLists.txt (AffineScaleMasks block, adds --random-seed 1)
verification: 20/20 both sides post-fix; 9/10 both sides pre-fix
sibling fixes: b181e3a4 MSEAffineRotationMasks, 5aaef6c4 SimilarityRotationMasks
note: AffineScaleNoMasks and other siblings were NOT audited for the same gap
-->
