### PR TITLE
COMP: Use minimal CPU flags by default

### DIFF
--- a/CMake/ITKSetStandardCompilerFlags.cmake
+++ b/CMake/ITKSetStandardCompilerFlags.cmake
@@ -151,81 +151,6 @@ function(check_compiler_warning_flags c_warning_flags_var cxx_warning_flags_var)
   set(${cxx_warning_flags_var} "${CMAKE_CXX_WARNING_FLAGS}" PARENT_SCOPE)
 endfunction()
 
-# Check for the presence of AVX and figure out the flags to use for it.
-# Adapted from https://gist.github.com/UnaNancyOwen/263c243ae1e05a2f9d0e
-function(check_avx_flags avx_flags_var)
-  set(avx_flags_var)
-
-  include(CheckCXXSourceRuns)
-  set(_safe_cmake_required_flags "${CMAKE_REQUIRED_FLAGS}")
-  set(CMAKE_REQUIRED_FLAGS)
-
-  # Check AVX
-  if(MSVC)
-    set(CMAKE_REQUIRED_FLAGS "/arch:AVX") # set flags to be used in check_cxx_source_runs below
-  endif()
-  check_cxx_source_runs(
-    "
-    #include <immintrin.h>
-    int main()
-    {
-      __m256 a, b, c;
-      const float src[8] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f };
-      float dst[8];
-      a = _mm256_loadu_ps(src);
-      b = _mm256_loadu_ps(src);
-      c = _mm256_add_ps(a, b);
-      _mm256_storeu_ps(dst, c);
-
-      for(int i = 0; i < 8; i++){
-        if(( src[i] + src[i]) != dst[i]){
-          return -1;
-        }
-      }
-
-      return 0;
-    }"
-    have_avx_extensions_var
-  )
-
-  # Check AVX2
-  if(MSVC)
-    set(CMAKE_REQUIRED_FLAGS "/arch:AVX2") # set flags to be used in check_cxx_source_runs below
-  endif()
-  check_cxx_source_runs(
-    "
-    #include <immintrin.h>
-    int main()
-    {
-      __m256i a, b, c;
-      const int src[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
-      int dst[8];
-      a =  _mm256_loadu_si256( (__m256i*)src);
-      b =  _mm256_loadu_si256( (__m256i*)src);
-      c = _mm256_add_epi32( a, b);
-      _mm256_storeu_si256( (__m256i*)dst, c);
-
-      for(int i = 0; i < 8; i++){
-        if(( src[i] + src[i]) != dst[i]){
-          return -1;
-        }
-      }
-
-      return 0;
-    }"
-    have_avx2_extensions_var
-  )
-
-  set(CMAKE_REQUIRED_FLAGS "${_safe_cmake_required_flags}")
-
-  # Set Flags
-  if(have_avx2_extensions_var AND MSVC)
-    set(avx_flags_var "${avx_flags_var} /arch:AVX2")
-  elseif(have_avx_extensions_var AND MSVC)
-    set(avx_flags_var "${avx_flags_var} /arch:AVX")
-  endif()
-endfunction()
-
 # Check for the presence of SSE2.
 # Adapted from the AVX check and https://github.com/InsightSoftwareConsortium/ITK/blob/4cbe24cb4a45d689cadd56d554b8ccf3584a5ca6/Modules/ThirdParty/VNL/src/vxl/config/cmake/config/vxl_platform_tests.cxx#L164-L178
 function(check_sse2_flags sse2_flags_var)
@@ -279,61 +204,18 @@ function(
   set(${c_optimization_flags_var} "" PARENT_SCOPE)
   set(${cxx_optimization_flags_var} "" PARENT_SCOPE)
 
-  if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "(x86_64|AMD64)")
-    if(MSVC)
-      check_avx_flags(InstructionSetOptimizationFlags)
-      if("${CMAKE_SIZEOF_VOID_P}" EQUAL "4")
-        list(
-          APPEND
-          InstructionSetOptimizationFlags
-          /arch:SSE
-          /arch:SSE2
-        )
-      endif()
-    elseif(NOT EMSCRIPTEN OR WASI)
-      if(${CMAKE_C_COMPILER} MATCHES "icc.*$")
-        set(USING_INTEL_ICC_COMPILER TRUE)
-      endif()
-      if(${CMAKE_CXX_COMPILER} MATCHES "icpc.*$")
-        set(USING_INTEL_ICC_COMPILER TRUE)
-      endif()
-      if(USING_INTEL_ICC_COMPILER)
-        set(InstructionSetOptimizationFlags "")
-      else()
-        set(InstructionSetOptimizationFlags "")
-      endif()
+  # No architecture-specific optimization flags are set by default,
+  # ensuring maximum redistributability for pip wheels, Docker images,
+  # and hardware translation layers (Rosetta, QEMU).
+  # Users building for local performance should add -march=native via
+  # CMAKE_C_FLAGS/CMAKE_CXX_FLAGS or CMakeUserPresets.json.
+  # NOTE: When using -march=native on CPUs with AVX-512, also add
+  # -mprefer-vector-width=256 to avoid Intel CPU frequency throttling.
+  # See: https://github.com/InsightSoftwareConsortium/ITK/issues/2634
+  #      https://github.com/InsightSoftwareConsortium/ITK/issues/1939
 
-      # Check this list on C compiler only
-      set(c_flags "")
-
-      # Check this list on C++ compiler only
-      set(cxx_flags "")
-
-      # Check this list on both C and C++ compilers
-      if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "ppc64le")
-        EXECUTE_PROCESS(COMMAND lscpu COMMAND grep "Model name:" OUTPUT_VARIABLE CPU OUTPUT_STRIP_TRAILING_WHITESPACE)
-        if (${CPU} MATCHES "POWER8")
-          set(CPU "power8")
-        else()
-          set(CPU "power9")
-        endif()
-        set(InstructionSetOptimizationFlags
-        -m64 -mcpu=${CPU} -mtune=${CPU} -ffast-math -fpeel-loops -funroll-loops -fvect-cost-model -mcmodel=medium -DNO_WARN_X86_INTRINSICS
-        )
-      else()
-        # https://gcc.gnu.org/onlinedocs/gcc-4.8.0/gcc/i386-and-x86_002d64-Options.html
-        # NOTE the corei7 release date was 2008
-        set(InstructionSetOptimizationFlags
-        -mtune=generic # for reproducible results https://github.com/InsightSoftwareConsortium/ITK/issues/1939
-        -march=corei7 # Use ABI settings to support corei7 (circa 2008 ABI feature sets, core-avx circa 2013)
-        )
-      endif()
-    endif()
-    set(c_and_cxx_flags ${InstructionSetOptimizationFlags})
-  endif()
-
-  check_c_compiler_flags(CMAKE_C_WARNING_FLAGS ${c_and_cxx_flags} ${c_flags})
-  check_cxx_compiler_flags(CMAKE_CXX_WARNING_FLAGS ${c_and_cxx_flags} ${cxx_flags})
+  check_c_compiler_flags(CMAKE_C_WARNING_FLAGS)
+  check_cxx_compiler_flags(CMAKE_CXX_WARNING_FLAGS)
 
   set(${c_optimization_flags_var} "${CMAKE_C_WARNING_FLAGS}" PARENT_SCOPE)
   set(${cxx_optimization_flags_var} "${CMAKE_CXX_WARNING_FLAGS}" PARENT_SCOPE)

--- a/CMake/ITKSetStandardCompilerFlags.cmake
+++ b/CMake/ITKSetStandardCompilerFlags.cmake
@@ -59,11 +59,7 @@ function(check_compiler_warning_flags c_warning_flags_var cxx_warning_flags_var)
   set(${cxx_warning_flags_var} "" PARENT_SCOPE)
 
   # Check this list on C compiler only
-  set(
-    c_flags
-    -Wno-uninitialized
-    -Wno-unused-parameter
-  )
+  set(c_flags -Wno-unused-parameter)
 
   ## On windows, the most verbose compiler options
   ## is reporting 1000's of wanings in windows
@@ -75,66 +71,27 @@ function(check_compiler_warning_flags c_warning_flags_var cxx_warning_flags_var)
     ## and then disable warnings one by one
     ## set(VerboseWarningsFlag -Wall -wd4820 -wd4682)
   else()
-    ## with Intel compiler, the -Wall compiler options
-    ## is reporting 1000's of remarks of trivial items
-    ## that will only slow day-to-day operations
-    ## specify -w2 to restrict to only warnings and errors
-    if(${CMAKE_C_COMPILER} MATCHES "icc.*$")
-      set(USING_INTEL_ICC_COMPILER TRUE)
-    endif()
-    if(${CMAKE_CXX_COMPILER} MATCHES "icpc.*$")
-      set(USING_INTEL_ICC_COMPILER TRUE)
-    endif()
-    if(USING_INTEL_ICC_COMPILER)
-      # NOTE -w2 is close to gcc's -Wall warning level, -w5 is intels -Wall warning level, and it is too verbose.
-      set(
-        VerboseWarningsFlag
-        -w2
-        -wd1268
-        -wd981
-        -wd383
-        -wd1418
-        -wd1419
-        -wd2259
-        -wd1572
-        -wd424
-      )
-      #-wd424  #Needed for Intel compilers with remarki  #424: extra ";" ignored
-      #-wd383  #Needed for Intel compilers with remark   #383: value copied to temporary, reference to temporary used
-      #-wd981  #Needed for Intel compilers with remark   #981: operands are evaluated in unspecified order
-      #-wd1418 #Needed for Intel compilers with remark  #1418: external function definition with no prior declaration
-      #-wd1419 #Needed for Intel compilers with remark  #1419: external declaration in primary source file
-      #-wd1572 #Needed for Intel compilers with remark  #1572: floating-point equality and inequality comparisons are unreliable
-      #-wd2259 #Needed for Intel compilers with remark  #2259: non-pointer conversion from "itk::SizeValueType={unsigned long}" to "double" may lose significant bits
-      #-wd1268 #Needed for Intel compilers with warning #1268: support for exported templates is disabled
-    else()
-      set(VerboseWarningsFlag -Wall)
-    endif()
+    set(VerboseWarningsFlag -Wall)
   endif()
 
   # Check this list on both C and C++ compilers
   set(
     c_and_cxx_flags
     ${VerboseWarningsFlag}
-    -Wno-long-double #Needed on APPLE
     -Wcast-align
     -Wdisabled-optimization
     -Wextra
     -Wformat=2
     -Winvalid-pch
-    -Wno-format-nonliteral
     -Wpointer-arith
     -Wshadow
     -Wunused
     -Wwrite-strings
-    -Wno-strict-overflow
   )
 
   # Check this list on C++ compiler only
   set(
     cxx_flags
-    -Wno-deprecated
-    -Wno-invalid-offsetof
     -Wno-undefined-var-template # suppress invalid warning when explicitly instantiated in another translation unit
     -Woverloaded-virtual
     -Wctad-maybe-unsupported
@@ -219,7 +176,6 @@ function(
 
   set(${c_optimization_flags_var} "${CMAKE_C_WARNING_FLAGS}" PARENT_SCOPE)
   set(${cxx_optimization_flags_var} "${CMAKE_CXX_WARNING_FLAGS}" PARENT_SCOPE)
-
 endfunction()
 
 macro(check_compiler_platform_flags)
@@ -339,43 +295,15 @@ macro(check_compiler_platform_flags)
       )
     endif()
 
-    check_sse2_flags(${PROJECT_NAME}_SSE2_CFLAGS_IF_AVAILABLE)
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+      # Setting sse2 flags only make sense on 32 bit architectures
+      # on 64bit systems, sse2 support is required, and compiler support is defaulted
+      check_sse2_flags(${PROJECT_NAME}_SSE2_CFLAGS_IF_AVAILABLE)
+    endif()
     set(
       ${PROJECT_NAME}_REQUIRED_CXX_FLAGS
       "${${PROJECT_NAME}_REQUIRED_CXX_FLAGS} ${${PROJECT_NAME}_SSE2_CFLAGS_IF_AVAILABLE}"
     )
-  endif()
-
-  #-----------------------------------------------------------------------------
-
-  # for the gnu compiler a -D_PTHREADS is needed on sun
-  # for the native compiler a -mt flag is needed on the sun
-  if(CMAKE_SYSTEM MATCHES "SunOS.*")
-    if(CMAKE_COMPILER_IS_GNUCXX)
-      set(${PROJECT_NAME}_REQUIRED_CXX_FLAGS "${${PROJECT_NAME}_REQUIRED_CXX_FLAGS} -D_PTHREADS")
-      set(${PROJECT_NAME}_REQUIRED_LINK_FLAGS "${${PROJECT_NAME}_REQUIRED_LINK_FLAGS} -lrt")
-    else()
-      set(${PROJECT_NAME}_REQUIRED_CXX_FLAGS "${${PROJECT_NAME}_REQUIRED_CXX_FLAGS} -mt")
-      set(${PROJECT_NAME}_REQUIRED_C_FLAGS "${${PROJECT_NAME}_REQUIRED_C_FLAGS} -mt")
-    endif()
-    # Add flags for the SUN compiler to provide all the methods for std::allocator.
-    #
-    check_cxx_source_compiles(
-      "-features=no%anachronisms"
-      SUN_COMPILER
-    )
-    if(SUN_COMPILER)
-      check_cxx_source_compiles(
-        "-library=stlport4"
-        SUN_COMPILER_HAS_STL_PORT_4
-      )
-      if(SUN_COMPILER_HAS_STL_PORT_4)
-        set(
-          ${PROJECT_NAME}_REQUIRED_CXX_FLAGS
-          "${${PROJECT_NAME}_REQUIRED_CXX_FLAGS} -library=stlport4"
-        )
-      endif()
-    endif()
   endif()
 
   # mingw thread support


### PR DESCRIPTION
Should make life easier for distribution. Users can add optimizations for local builds if they like

Fixes #2007 