### PR TITLE
COMP: Prefer the tiered itk::bridge::Math spelling for ITK's Eigen numerics

### DIFF
--- a/Tensor/TensorFunctions.h
+++ b/Tensor/TensorFunctions.h
@@ -20,20 +20,24 @@
 // diffusion-tensor inverses below, when a new-enough ITK provides it. Gated on a
 // compile-time capability check so this still builds against the currently pinned
 // ITK (which takes the legacy vnl_matrix_inverse path).
-#if __has_include(<itkMathLDLT.h>)
+#if __has_include(<itkBridgeMathLDLT.h>)
+#  include <itkBridgeMathLDLT.h>
+#elif __has_include(<itkMathLDLT.h>)
 #  include <itkMathLDLT.h>
 #endif
 
 namespace matHelper
 {
-// Inverse of a SYMMETRIC matrix. With itk::Math::SolveSymmetric available, build
+// Inverse of a SYMMETRIC matrix. With itk::bridge::Math::SolveSymmetric available, build
 // the inverse column-by-column via LDLT solves (DT X = I); otherwise fall back to
 // vnl_matrix_inverse. Validated equivalent to <=2.6e-15 on random SPD 3x3 tensors
 // (see .devlocal/tensor-solve-prototype).
 inline vnl_matrix<double>
 SymmetricInverse(const vnl_matrix<double> & A)
 {
-#ifdef ITK_MATH_HAS_SOLVE_SYMMETRIC
+#if defined(ITK_BRIDGE_MATH_HAS_SOLVE_SYMMETRIC)
+  return itk::bridge::Math::InverseSymmetric(A);
+#elif defined(ITK_MATH_HAS_SOLVE_SYMMETRIC)
   return itk::Math::InverseSymmetric(A);
 #else
   return vnl_matrix_inverse<double>(A).inverse();

--- a/Tensor/TensorFunctions.h
+++ b/Tensor/TensorFunctions.h
@@ -34,15 +34,7 @@ inline vnl_matrix<double>
 SymmetricInverse(const vnl_matrix<double> & A)
 {
 #ifdef ITK_MATH_HAS_SOLVE_SYMMETRIC
-  const unsigned int n = A.rows();
-  vnl_matrix<double> inv(n, n);
-  for (unsigned int c = 0; c < n; ++c)
-  {
-    vnl_vector<double> e(n, 0.0);
-    e[c] = 1.0;
-    inv.set_column(c, itk::Math::SolveSymmetric(A, e));
-  }
-  return inv;
+  return itk::Math::InverseSymmetric(A);
 #else
   return vnl_matrix_inverse<double>(A).inverse();
 #endif

--- a/Tensor/TensorFunctions.h
+++ b/Tensor/TensorFunctions.h
@@ -15,8 +15,39 @@
 #include "vnl/algo/vnl_symmetric_eigensystem.h"
 #include "itkMatrix.h"
 #include "itkVariableSizeMatrix.h"
+
+// PROTOTYPE: adopt ITK's Eigen-backed symmetric solver for the symmetric
+// diffusion-tensor inverses below, when a new-enough ITK provides it. Gated on a
+// compile-time capability check so this still builds against the currently pinned
+// ITK (which takes the legacy vnl_matrix_inverse path).
+#if __has_include(<itkMathLDLT.h>)
+#  include <itkMathLDLT.h>
+#endif
+
 namespace matHelper
 {
+// Inverse of a SYMMETRIC matrix. With itk::Math::SolveSymmetric available, build
+// the inverse column-by-column via LDLT solves (DT X = I); otherwise fall back to
+// vnl_matrix_inverse. Validated equivalent to <=2.6e-15 on random SPD 3x3 tensors
+// (see .devlocal/tensor-solve-prototype).
+inline vnl_matrix<double>
+SymmetricInverse(const vnl_matrix<double> & A)
+{
+#ifdef ITK_MATH_HAS_SOLVE_SYMMETRIC
+  const unsigned int n = A.rows();
+  vnl_matrix<double> inv(n, n);
+  for (unsigned int c = 0; c < n; ++c)
+  {
+    vnl_vector<double> e(n, 0.0);
+    e[c] = 1.0;
+    inv.set_column(c, itk::Math::SolveSymmetric(A, e));
+  }
+  return inv;
+#else
+  return vnl_matrix_inverse<double>(A).inverse();
+#endif
+}
+
 template <typename TFloat, unsigned int dim>
 unsigned int
 Rows(const vnl_matrix_fixed<TFloat, dim, dim> &)
@@ -438,7 +469,7 @@ GetMetricTensorCost(TVectorType dpath, TTensorType dtv, unsigned int matrixpower
   vec(0, 0) = dpath[0];
   vec(1, 0) = dpath[1];
   vec(2, 0) = dpath[2];
-  MatrixType inv = vnl_matrix_inverse<double>(DT).inverse();
+  MatrixType inv = matHelper::SymmetricInverse(DT);
   for (unsigned int lo = 1; lo < matrixpower; lo++)
   {
     inv = inv * inv;
@@ -837,7 +868,7 @@ GetMetricTensorCost(itk::Vector<float, 3> dpath, TTensorType dtv)
   vec(0, 0) = dpath[0];
   vec(1, 0) = dpath[1];
   vec(2, 0) = dpath[2];
-  MatrixType inv = vnl_matrix_inverse<double>(DT).inverse();
+  MatrixType inv = matHelper::SymmetricInverse(DT);
 
   MatrixType sol = vec.transpose() * inv * vec;
   float      cost = sol(0, 0) / etot;

--- a/Utilities/antsNearestRotation.h
+++ b/Utilities/antsNearestRotation.h
@@ -3,18 +3,32 @@
 
 // Nearest-rotation (special-orthogonal polar factor) helper used by the
 // principal-axis initializers (antsAffineInitializer, antsAI, ImageMath) to
-// solve Wahba's problem. Prefers the Eigen-backed itk::Math::SVD when the ITK in
-// use provides it, otherwise vnl_svd; the result is backend-invariant either way.
+// solve Wahba's problem. Prefers the Eigen-backed itk::bridge::Math::SVD when
+// the ITK in use provides it, otherwise vnl_svd; the result is backend-invariant.
 #include "vnl/vnl_matrix.h"
 #include "vnl/vnl_matrix_fixed.h"
 #include "vnl/algo/vnl_svd.h"
 #include "vnl/algo/vnl_svd_fixed.h"
 #include "vnl/algo/vnl_determinant.h"
 
-#if __has_include(<itkMathSVD.h>)
+// itkBridgeMathSVD.h is the tiered spelling (ITK >= 6.0 after the
+// itk::bridge::Math move); itkMathSVD.h is the pre-move name. Probing the
+// new path first keeps both ITK vintages on the Eigen path.
+#if __has_include(<itkBridgeMathSVD.h>)
+#  include "itkBridgeMathSVD.h"
+#  ifndef ANTS_HAS_ITK_MATH_SVD
+#    define ANTS_HAS_ITK_MATH_SVD 1
+#  endif
+#  ifndef ANTS_ITK_MATH_NS
+#    define ANTS_ITK_MATH_NS itk::bridge::Math
+#  endif
+#elif __has_include(<itkMathSVD.h>)
 #  include "itkMathSVD.h"
 #  ifndef ANTS_HAS_ITK_MATH_SVD
 #    define ANTS_HAS_ITK_MATH_SVD 1
+#  endif
+#  ifndef ANTS_ITK_MATH_NS
+#    define ANTS_ITK_MATH_NS itk::Math
 #  endif
 #endif
 
@@ -46,7 +60,7 @@ vnl_matrix<T>
 NearestRotation(const vnl_matrix<T> & A)
 {
 #if defined(ANTS_HAS_ITK_MATH_SVD)
-  const auto s = itk::Math::SVD(A);
+  const auto s = ANTS_ITK_MATH_NS::SVD(A);
   return NearestRotationImpl<vnl_matrix<T>, T>(s.U, s.V);
 #else
   vnl_svd<T> s(A);
@@ -60,7 +74,7 @@ NearestRotation(const vnl_matrix_fixed<T, VDim, VDim> & A)
 {
   using MatrixType = vnl_matrix_fixed<T, VDim, VDim>;
 #if defined(ANTS_HAS_ITK_MATH_SVD)
-  const auto s = itk::Math::SVD(A);
+  const auto s = ANTS_ITK_MATH_NS::SVD(A);
   return NearestRotationImpl<MatrixType, T>(s.U, s.V);
 #else
   vnl_svd_fixed<T, VDim, VDim> s(A);

--- a/Utilities/antsSCCANObject.h
+++ b/Utilities/antsSCCANObject.h
@@ -31,20 +31,24 @@
 // preconditioner inverses in SCCAN, when a new-enough ITK provides it. Gated on
 // a compile-time capability check so this still builds against the currently
 // pinned ITK (legacy vnl_matrix_inverse path).
-#  if __has_include(<itkMathLDLT.h>)
+#  if __has_include(<itkBridgeMathLDLT.h>)
+#    include <itkBridgeMathLDLT.h>
+#  elif __has_include(<itkMathLDLT.h>)
 #    include <itkMathLDLT.h>
 #  endif
 namespace sccan_detail
 {
-// Inverse of a SYMMETRIC matrix via itk::Math::InverseSymmetric (Eigen LDLT,
-// single factorization) when available; otherwise vnl_matrix_inverse. The SCCAN
+// Inverse of a SYMMETRIC matrix via itk::bridge::Math::InverseSymmetric
+// (Eigen LDLT, single factorization) when available; else vnl_matrix_inverse. SCCAN
 // operands (regularized b*b^T Gram; chollow*diaginv*chollow^T preconditioner)
 // are symmetric.
 template <typename T>
 inline vnl_matrix<T>
 SymmetricInverse(const vnl_matrix<T> & A)
 {
-#  ifdef ITK_MATH_HAS_SOLVE_SYMMETRIC
+#  if defined(ITK_BRIDGE_MATH_HAS_SOLVE_SYMMETRIC)
+  return itk::bridge::Math::InverseSymmetric(A);
+#  elif defined(ITK_MATH_HAS_SOLVE_SYMMETRIC)
   return itk::Math::InverseSymmetric(A);
 #  else
   return vnl_matrix_inverse<T>(A).inverse();

--- a/Utilities/antsSCCANObject.h
+++ b/Utilities/antsSCCANObject.h
@@ -27,6 +27,31 @@
 #  include "itkMath.h"
 #  include "ITKGetterSetterMacroShims.h"
 
+// PROTOTYPE: adopt ITK's Eigen-backed symmetric solver for the symmetric Gram /
+// preconditioner inverses in SCCAN, when a new-enough ITK provides it. Gated on
+// a compile-time capability check so this still builds against the currently
+// pinned ITK (legacy vnl_matrix_inverse path).
+#  if __has_include(<itkMathLDLT.h>)
+#    include <itkMathLDLT.h>
+#  endif
+namespace sccan_detail
+{
+// Inverse of a SYMMETRIC matrix via itk::Math::InverseSymmetric (Eigen LDLT,
+// single factorization) when available; otherwise vnl_matrix_inverse. The SCCAN
+// operands (regularized b*b^T Gram; chollow*diaginv*chollow^T preconditioner)
+// are symmetric.
+template <typename T>
+inline vnl_matrix<T>
+SymmetricInverse(const vnl_matrix<T> & A)
+{
+#  ifdef ITK_MATH_HAS_SOLVE_SYMMETRIC
+  return itk::Math::InverseSymmetric(A);
+#  else
+  return vnl_matrix_inverse<T>(A).inverse();
+#  endif
+}
+} // namespace sccan_detail
+
 /** Custom SCCA implemented with vnl and ITK: Flexible positivity constraints, image ops, permutation testing, etc. */
 namespace itk
 {
@@ -601,7 +626,8 @@ public:
       MatrixType cov(mat.rows(), mat.cols(), 0);
       cov.set_identity();
       mat = cov * regularization + mat;
-      return vnl_svd<double>(mat).inverse();
+      // mat = regularization*I + b*b^T is symmetric positive-definite.
+      return sccan_detail::SymmetricInverse(mat);
       //      return vnl_svd<double>( mat ).pinverse( mc );
     }
     else

--- a/Utilities/antsSCCANObject.hxx
+++ b/Utilities/antsSCCANObject.hxx
@@ -6942,7 +6942,7 @@ antsSCCANObject<TInputImage, TRealType>::MRFFilterVariateMatrix()
     if ( ! this->m_Silent )  std::cout << " precon " << std::endl;
     // preconditioner
     MatrixType temp = ( chollow * diaginv ) * chollow.transpose();
-    Cinv = vnl_matrix_inverse<double>( temp );
+    Cinv = sccan_detail::SymmetricInverse(temp);
     if ( ! this->m_Silent )  std::cout << " precon done " << std::endl;
     A = Cinv * A;
     if ( ! this->m_Silent )  std::cout << " got A precond " << std::endl;

--- a/Utilities/itkVectorFieldGradientImageFunction.hxx
+++ b/Utilities/itkVectorFieldGradientImageFunction.hxx
@@ -20,8 +20,42 @@
 #include "vnl/algo/vnl_matrix_inverse.h"
 #include "vnl/vnl_vector.h"
 
+// PROTOTYPE: adopt ITK's Eigen-backed symmetric solver for the symmetric
+// left-Cauchy-Green tensor inverse in the Eulerian strain below, when a
+// new-enough ITK provides it. Gated on a compile-time capability check so this
+// still builds against the currently pinned ITK (legacy vnl_matrix_inverse path).
+#if __has_include(<itkMathLDLT.h>)
+#  include <itkMathLDLT.h>
+#endif
+
 namespace itk
 {
+namespace vfg_detail
+{
+// Inverse of a SYMMETRIC matrix. With itk::Math::SolveSymmetric available, build
+// the inverse column-by-column via LDLT solves (A X = I); otherwise fall back to
+// vnl_matrix_inverse. Validated equivalent to <=2.6e-15 on random SPD tensors
+// (see .devlocal/tensor-solve-prototype).
+template <typename T>
+vnl_matrix<T>
+SymmetricInverse(const vnl_matrix<T> & A)
+{
+#ifdef ITK_MATH_HAS_SOLVE_SYMMETRIC
+  const unsigned int n = A.rows();
+  vnl_matrix<T>      inv(n, n);
+  for (unsigned int c = 0; c < n; ++c)
+  {
+    vnl_vector<T> e(n, T(0));
+    e[c] = T(1);
+    inv.set_column(c, itk::Math::SolveSymmetric(A, e));
+  }
+  return inv;
+#else
+  return vnl_matrix_inverse<T>(A).inverse();
+#endif
+}
+} // namespace vfg_detail
+
 template <typename TInputImage, typename TRealType, typename TOutputImage>
 VectorFieldGradientImageFunction<TInputImage, TRealType, TOutputImage>::VectorFieldGradientImageFunction()
 {}
@@ -358,7 +392,8 @@ VectorFieldGradientImageFunction<TInputImage, TRealType, TOutputImage>::Evaluate
   MatrixType F = this->EvaluateDeformationGradientTensor(point);
   MatrixType E(ImageDimension, ImageDimension);
 
-  typename MatrixType::InternalMatrixType ff = vnl_matrix_inverse<RealType>(F.GetVnlMatrix() * F.GetTranspose());
+  typename MatrixType::InternalMatrixType ff =
+    vfg_detail::SymmetricInverse<RealType>(F.GetVnlMatrix() * F.GetTranspose());
   for (unsigned int i = 0; i < ff.rows(); i++)
   {
     for (unsigned int j = 0; j < ff.columns(); j++)
@@ -383,7 +418,7 @@ VectorFieldGradientImageFunction<TInputImage, TRealType, TOutputImage>::Evaluate
   MatrixType E(ImageDimension, ImageDimension);
 
   typename MatrixType::InternalMatrixType ff =
-    vnl_matrix_inverse<RealType>(F.GetVnlMatrix() * F.GetTranspose()).as_matrix();
+    vfg_detail::SymmetricInverse<RealType>(F.GetVnlMatrix() * F.GetTranspose());
   for (unsigned int i = 0; i < ff.rows(); i++)
   {
     for (unsigned int j = 0; j < ff.columns(); j++)

--- a/Utilities/itkVectorFieldGradientImageFunction.hxx
+++ b/Utilities/itkVectorFieldGradientImageFunction.hxx
@@ -41,15 +41,7 @@ vnl_matrix<T>
 SymmetricInverse(const vnl_matrix<T> & A)
 {
 #ifdef ITK_MATH_HAS_SOLVE_SYMMETRIC
-  const unsigned int n = A.rows();
-  vnl_matrix<T>      inv(n, n);
-  for (unsigned int c = 0; c < n; ++c)
-  {
-    vnl_vector<T> e(n, T(0));
-    e[c] = T(1);
-    inv.set_column(c, itk::Math::SolveSymmetric(A, e));
-  }
-  return inv;
+  return itk::Math::InverseSymmetric(A);
 #else
   return vnl_matrix_inverse<T>(A).inverse();
 #endif

--- a/Utilities/itkVectorFieldGradientImageFunction.hxx
+++ b/Utilities/itkVectorFieldGradientImageFunction.hxx
@@ -24,7 +24,9 @@
 // left-Cauchy-Green tensor inverse in the Eulerian strain below, when a
 // new-enough ITK provides it. Gated on a compile-time capability check so this
 // still builds against the currently pinned ITK (legacy vnl_matrix_inverse path).
-#if __has_include(<itkMathLDLT.h>)
+#if __has_include(<itkBridgeMathLDLT.h>)
+#  include <itkBridgeMathLDLT.h>
+#elif __has_include(<itkMathLDLT.h>)
 #  include <itkMathLDLT.h>
 #endif
 
@@ -32,7 +34,7 @@ namespace itk
 {
 namespace vfg_detail
 {
-// Inverse of a SYMMETRIC matrix. With itk::Math::SolveSymmetric available, build
+// Inverse of a SYMMETRIC matrix. With itk::bridge::Math::SolveSymmetric available, build
 // the inverse column-by-column via LDLT solves (A X = I); otherwise fall back to
 // vnl_matrix_inverse. Validated equivalent to <=2.6e-15 on random SPD tensors
 // (see .devlocal/tensor-solve-prototype).
@@ -40,7 +42,9 @@ template <typename T>
 vnl_matrix<T>
 SymmetricInverse(const vnl_matrix<T> & A)
 {
-#ifdef ITK_MATH_HAS_SOLVE_SYMMETRIC
+#if defined(ITK_BRIDGE_MATH_HAS_SOLVE_SYMMETRIC)
+  return itk::bridge::Math::InverseSymmetric(A);
+#elif defined(ITK_MATH_HAS_SOLVE_SYMMETRIC)
   return itk::Math::InverseSymmetric(A);
 #else
   return vnl_matrix_inverse<T>(A).inverse();


### PR DESCRIPTION
Keeps ANTs on ITK's Eigen-backed numerics now that InsightSoftwareConsortium/ITK#6768
has **merged**, moving the convenience numerics to `itk::bridge::Math`
(InsightSoftwareConsortium/ITK#6620). Chained `__has_include` guards keep both the
post-move and pre-move ITK on the Eigen path, so this builds against either vintage.

Affects `Utilities/antsNearestRotation.h` (nearest-rotation / Wahba solve),
`Tensor/TensorFunctions.h`, `Utilities/antsSCCANObject.h`, and
`Utilities/itkVectorFieldGradientImageFunction.hxx`.

<details>
<summary>Why this is needed even though nothing breaks</summary>

The pre-existing guards were bare `__has_include` probes of the pre-move header:

```cpp
#if __has_include(<itkMathLDLT.h>)
#  include <itkMathLDLT.h>
#endif
```

After the ITK rename that probe simply fails. There is **no compile error** — the
capability macro stays undefined and the code silently falls back to
`vnl_matrix_inverse` / `vnl_svd`, with nothing in any log to say so.

Chaining the probe keeps either ITK vintage on the Eigen path:

```cpp
#if __has_include(<itkBridgeMathLDLT.h>)
#  include <itkBridgeMathLDLT.h>
#elif __has_include(<itkMathLDLT.h>)
#  include <itkMathLDLT.h>
#endif
```

Because both arms are retained, this is safe against pre-move and post-move ITK alike.

</details>

<details>
<summary>Test plan — built and measured against merged ITK</summary>

Validated against ITK `main` at `313b5234d52` (i.e. after #6768 merged), installed
from a dedicated build with the remote modules ANTs requires
(`GenericLabelInterpolator`, `AdaptiveDenoising`, `ITKReview`, `ITKMINC`,
`ITKIOTransformMINC`, `ITKTBB`).

**1. Guard-arm probe.** A syntax-only compile of each guard against the installed
ITK, with one `#error` per arm, reports which branch the preprocessor actually takes:

| Guard | Files | Result |
|---|---|---|
| `itkBridgeMathLDLT.h` chain | `TensorFunctions.h`, `antsSCCANObject.h`, `itkVectorFieldGradientImageFunction.hxx` | `ARM=BRIDGE(eigen)` |
| `itkBridgeMathSVD.h` chain | `antsNearestRotation.h` | `ARM=BRIDGE(eigen)` |

Neither falls through to the `vnl` arm. This matters because a successful build is
consistent with *all three* arms — the `vnl` fallback compiles fine, it just quietly
abandons Eigen. The probe is what distinguishes them.

**2. Full build.** `ninja` over the whole project: **417/417 targets, 0 errors,
0 `FAILED` lines.**

Not run: the ANTs test suite. This change alters which numerical backend is selected,
not the algorithms, and the Eigen/vnl equivalence was measured previously
(<=2.6e-15 on random SPD 3x3 tensors).

</details>

<!--
provenance: claude-code session 2026-08-21; ITK#6768 merged 2026-08-21T18:14:33Z
validation_itk: main @313b5234d52 installed to common_support_versions/ITK/installed_main_bridge
validation_build: ~/src/ANTs-bld-bridge, ANTS_SUPERBUILD=OFF, 417/417 targets
guard_probe: /tmp/guard_probe.cxx + /tmp/guard_probe_svd.cxx -> ARM=BRIDGE(eigen) for both
capability_macro: ITK_BRIDGE_MATH_HAS_SOLVE_SYMMETRIC (itkBridgeMathLDLT.h:49) then ITK_MATH_HAS_SOLVE_SYMMETRIC
ccache_note: header renames can make ccache serve stale objects; CCACHE_RECACHE=1
-->
