### PR TITLE
ENH: Further QoL improvements for template scripts

### DIFF
--- a/Scripts/ANTSpexec.sh
+++ b/Scripts/ANTSpexec.sh
@@ -15,7 +15,7 @@ Optional arguments:
 
      -r:  Replace asterix * in the command string with argument
 
-     -j:  Number of cpu cores to use (default 2)
+     -j:  Number of concurrent jobs to run (default 2, must be more than 1)
 
 Examples:
 
@@ -38,7 +38,7 @@ function Help {
     cat <<HELP
 
 This is a simple wrapper for running processes in parallel. Tested both on
-Mac (Darwin) and Linux (CentOS 5).
+Mac (Darwin) and Linux.
 
 Usage:
 
@@ -50,7 +50,7 @@ Optional arguments:
 
      -r:  Replace asterix * in the command string with argument
 
-     -j:  Number of cpu cores to use (default 2)
+     -j:  Number of concurrent jobs to run (default 2, must be more than 1)
 
 Examples:
 
@@ -59,6 +59,9 @@ Examples:
     `basename $0` -j 3 \"somecommand -r -p\" arg1 arg2 arg3
 
     `basename $0` -j 6 -r \"convert -scale 50% * small/small_*\" *.jpg"
+
+The script does not account for multi-threading, if you specify "-j N" it will
+run N concurrent jobs, even if each of those spawns multiple threads.
 
 CTRL + C and SIGTERM automatically terminate processes started by this script.
 If the script is killed in a way that prevents cleanup, run ./killme.sh to
@@ -82,56 +85,16 @@ function queue {
     NUM=$(($NUM+1))
 }
 
-function regeneratequeuelinux {
+function regeneratequeue {
     OLDREQUEUE=$QUEUE
     QUEUE=""
     NUM=0
     for PID in $OLDREQUEUE
     do
-        if [ -d /proc/$PID ] ; then
+        if kill -0 "$PID" 2>/dev/null; then
             QUEUE="$QUEUE $PID"
             NUM=$(($NUM+1))
         fi
-    done
-}
-
-function checkqueuelinux {
-    OLDCHQUEUE=$QUEUE
-    for PID in $OLDCHQUEUE
-    do
-        if [ ! -d /proc/$PID ] ; then
-            regeneratequeuelinux # at least one PID has finished
-            break
-        fi
-    done
-}
-
-function regeneratequeuemac {
-    OLDREQUEUE=$QUEUE
-    QUEUE=""
-    NUM=0
-    for PID in $OLDREQUEUE
-    do
-	whm=` whoami `
-	num=` ps U $whm | grep -i "${PID} "  | wc -l `
-        if [ $num = 2 ]    ;  then
-            QUEUE="$QUEUE $PID"
-            NUM=$(($NUM+1))
-	fi
-
-    done
-}
-
-function checkqueuemac {
-    OLDCHQUEUE=$QUEUE
-    for PID in $OLDCHQUEUE
-    do
-	whm=` whoami `
-	num=` ps U $whm | grep -i "${PID} "  | wc -l `
-        if [ $num = 1 ]  ; then
-            regeneratequeuemac # at least one PID has finished
-            break
-	fi
     done
 }
 
@@ -238,26 +201,10 @@ do
     printf 'kill %s\n' "$PID" >> "${here}/killme.sh"
     queue $PID
 
-    osmac=0
-    osmac="` uname -a | grep Darwin  `"
-    oslin=0
-    oslin="`uname -a | grep Linux`"
-
-    if [ ${#osmac} -ne 0 ]
-    then
-	while [ $NUM -ge $MAX_NPROC ]; do
-            checkqueuemac
-            sleep 0.5
-	done
-    elif [ ${#oslin} -ne 0 ]
-    then
-	while [ $NUM -ge $MAX_NPROC ]; do
-            checkqueuelinux
-            sleep 0.5
-	done
-    fi
-
-
+    while [ $NUM -ge $MAX_NPROC ]; do
+        sleep 2
+        regeneratequeue
+    done
 done
 
 wait # wait for all processes to finish before exit

--- a/Scripts/ANTSpexec.sh
+++ b/Scripts/ANTSpexec.sh
@@ -25,8 +25,10 @@ Examples:
 
     `basename $0` -j 6 -r \"convert -scale 50% * small/small_*\" *.jpg"
 
-In case you terminate this script prematurely by pressing CTRL + C, run
-${here}/killme.sh to terminate any remaining processes.
+CTRL + C and SIGTERM automatically terminate processes started by this script.
+If the script is killed in a way that prevents cleanup, run ./killme.sh to
+terminate any processes recorded before it stopped.
+
 
 USAGE
     exit 0
@@ -58,8 +60,9 @@ Examples:
 
     `basename $0` -j 6 -r \"convert -scale 50% * small/small_*\" *.jpg"
 
-In case you terminate this script prematurely by pressing CTRL + C, run
-${here}/killme.sh to terminate any remaining processes.
+CTRL + C and SIGTERM automatically terminate processes started by this script.
+If the script is killed in a way that prevents cleanup, run ./killme.sh to
+terminate any processes recorded before it stopped.
 
 --------------------------------------------------------------------------------------
 Original script by Kawakamasu:
@@ -132,11 +135,60 @@ function checkqueuemac {
     done
 }
 
+function signal_descendants {
+    local parent_pid=$1
+    local signal_name=$2
+    local child_pid
+    local child_parent_pid
+
+    while read -r child_pid child_parent_pid; do
+        if [[ $child_parent_pid -eq $parent_pid ]]; then
+            signal_descendants "$child_pid" "$signal_name"
+            if kill -0 "$child_pid" 2>/dev/null; then
+                printf 'sending %s to process %s\n' "$signal_name" "$child_pid"
+                kill -s "$signal_name" "$child_pid" 2>/dev/null || true
+            fi
+        fi
+    done <<< "$PROCESS_TABLE"
+}
+
+function cleanup {
+    printf '\n*** Performing cleanup, please wait ***\n\n'
+
+    # The -Ao form is supported by both GNU/Linux and macOS/BSD ps.
+    if PROCESS_TABLE=$(ps -Ao pid=,ppid=); then
+        signal_descendants "$$" TERM
+        sleep 3
+        signal_descendants "$$" KILL
+    else
+        printf 'Unable to inspect child processes during cleanup.\n' >&2
+    fi
+
+    rm -f "${here}/killme.sh"
+}
+
+function control_c {
+    trap - SIGINT SIGTERM
+    printf '\n*** User pressed CTRL + C ***\n'
+    cleanup
+    printf '\n*** Script cancelled by user ***\n'
+    exit 130
+}
+
+function control_term {
+    trap - SIGINT SIGTERM
+    cleanup
+    exit 143
+}
+
 here=`pwd`
 NUM=0
 QUEUE=""
 MAX_NPROC=2 # default
 REPLACE_CMD=0 # no replacement by default
+
+trap control_c SIGINT
+trap control_term SIGTERM
 
 # parse command line
 if [ $# -eq 0 ]; then #  must be at least one arg
@@ -166,8 +218,8 @@ COMMAND=$1
 shift
 
 # keep list of started processes
-echo "#!/bin/bash" >> ${here}/killme.sh
-chmod +x ${here}/killme.sh
+printf '%s\n' '#!/bin/sh' > "${here}/killme.sh"
+chmod +x "${here}/killme.sh"
 
 for INS in $* # for the rest of the arguments
 do
@@ -183,7 +235,7 @@ do
     # DEFINE COMMAND END
 
     PID=$!
-    echo "kill $PID" >> ${here}/killme.sh
+    printf 'kill %s\n' "$PID" >> "${here}/killme.sh"
     queue $PID
 
     osmac=0
@@ -210,6 +262,6 @@ done
 
 wait # wait for all processes to finish before exit
 
-rm ${here}/killme.sh
+rm -f "${here}/killme.sh"
 
 exit 0

--- a/Scripts/antsMultivariateTemplateConstruction.sh
+++ b/Scripts/antsMultivariateTemplateConstruction.sh
@@ -125,9 +125,13 @@ Optional arguments:
 
      -n:  N4BiasFieldCorrection of moving image (default 1) -- 0 == off, 1 == on
 
-     -p:  Commands to prepend to job scripts. Job options for SGE/PBS/SLURM can be included here, but
-          command-line args in this script will take precedence for wall time (see -u), memory (see -v),
+     -p:  A command or directive to prepend to job scripts. Repeat -p to add multiple lines; entries
+          are written to job scripts in the order given. Job options for SGE/PBS/SLURM can be included here,
+          but command-line args in this script will take precedence for wall time (see -u), memory (see -v),
           and multithreading (see -T).
+
+          For slurm, a shebang for '/bin/sh' is always the first line in the job script. For SGE and PBS,
+          the shell interpreter is set to '/bin/bash'.
 
      -r:  Do rigid-body registration of inputs to the initial template, before doing the main
           pairwise registration. 0 == off 1 == on (default 0). If you are trying to refine or update
@@ -266,6 +270,23 @@ function reportMappingParameters {
 REPORTMAPPINGPARAMETERS
 }
 
+function write_script_prepend() {
+  if (( ${#SCRIPTPREPEND[@]} > 0 )); then
+    printf '%s\n' "${SCRIPTPREPEND[@]}"
+  fi
+}
+
+function get_image_stem() {
+  local filename=${1##*/}
+
+  # Treat .gz as a compression suffix, then remove the image-format suffix.
+  # This preserves internal periods for both compressed and uncompressed formats.
+  if [[ $filename == *.gz ]]; then
+    filename=${filename%.gz}
+  fi
+  printf '%s\n' "${filename%.*}"
+}
+
 function summarizeimageset() {
 
   local dim=$1
@@ -297,7 +318,7 @@ function summarizeimageset() {
       local image
       for image in "${images[@]}";
         do
-          echo "$image" >> "${output}_list.txt"
+          printf '%s\n' "$image" >> "${output}_list.txt"
         done
       ImageSetStatistics "$dim" "${output}_list.txt" "$output" 0
       rm "${output}_list.txt"
@@ -430,24 +451,24 @@ function jobfnamepadding {
     elif [[ ! -e ${files[0]} ]]; then
       return 0
     fi
-    BASENAME1=`echo "${files[0]}" | cut -d 'b' -f 1`
+    BASENAME1=`printf '%s\n' "${files[0]}" | cut -d 'b' -f 1`
 
     for file in "${files[@]}"
       do
 
       if [[ "${#file}" -eq "9" ]];
        then
-         BASENAME2=`echo "$file" | cut -d 'b' -f 2 `
+         BASENAME2=`printf '%s\n' "$file" | cut -d 'b' -f 2 `
          mv "$file" "${BASENAME1}b_000${BASENAME2}"
 
       elif [[ "${#file}" -eq "10" ]];
         then
-          BASENAME2=`echo "$file" | cut -d 'b' -f 2 `
+          BASENAME2=`printf '%s\n' "$file" | cut -d 'b' -f 2 `
           mv "$file" "${BASENAME1}b_00${BASENAME2}"
 
       elif [[ "${#file}" -eq "11" ]];
         then
-          BASENAME2=`echo "$file" | cut -d 'b' -f 2 `
+          BASENAME2=`printf '%s\n' "$file" | cut -d 'b' -f 2 `
           mv "$file" "${BASENAME1}b_0${BASENAME2}"
       fi
     done
@@ -467,28 +488,13 @@ for (( g = $WHICHMODALITY; g < ${#IMAGESETARRAY[@]}; g+=$NUMBEROFMODALITIES ))
 done
 }
 
-cleanup()
-{
-  echo "\n*** Performing cleanup, please wait ***\n"
-
-  runningANTSpids=$( ps --ppid $$ -o pid= )
-
-  for thePID in $runningANTSpids
-  do
-      echo "killing:  ${thePID}"
-      kill "${thePID}"
-  done
-
-  return $?
-}
-
 control_c()
 # run if user hits control-c
 {
-  echo -en "\n*** User pressed CTRL + C ***\n"
-  cleanup
-  exit $?
-  echo -en "\n*** Script cancelled by user ***\n"
+  trap - SIGINT
+  printf '\n*** User pressed CTRL + C ***\n'
+  printf '\n*** Script cancelled by user ***\n'
+  exit 130
 }
 
 #initializing variables with global scope
@@ -520,7 +526,7 @@ REGTEMPLATES=()
 TEMPLATES=()
 CURRENTIMAGESET=()
 XGRIDOPTS=""
-SCRIPTPREPEND=""
+SCRIPTPREPEND=()
 WALLTIME="20:00:00"
 MEMORY="8G"
 # System specific queue options for SGE/PBS/SLURM, eg "-q name" to submit to a specific queue.
@@ -643,7 +649,7 @@ while getopts "A:T:a:b:c:d:g:h:i:j:k:m:n:o:p:s:r:t:u:v:w:x:y:z:" OPT
    TEMPLATENAME=${OUTPUTNAME}template
    ;;
       p) #Script prepend
-   SCRIPTPREPEND=$OPTARG
+   SCRIPTPREPEND+=( "$OPTARG" )
    ;;
       s) #similarity model
    METRICTYPE[${#METRICTYPE[@]}]=$OPTARG
@@ -1041,7 +1047,7 @@ for (( i = 0; i < $NUMBEROFMODALITIES; i++ ))
         for (( j = 0; j < ${#CURRENTIMAGESET[@]}; j+=1 ))
           do
             IMGbase=`basename "${CURRENTIMAGESET[$j]}"`
-            BASENAME=` echo "${IMGbase}" | cut -d '.' -f 1 `
+            BASENAME=$(get_image_stem "$IMGbase")
             COM="${OUTPUT_DIR}/initialCOM${i}_${j}_${IMGbase}"
             COMTRANSFORM="${OUTPUT_DIR}/initialCOM${i}_${j}_${BASENAME}.mat"
             antsAI -d "${DIM}" --convergence 0 --verbose 1 -m "Mattes[${TEMPLATES[$i]},${CURRENTIMAGESET[$j]},32,None]" -o "${COMTRANSFORM}" -t AlignCentersOfMass
@@ -1102,20 +1108,20 @@ if [[ "$RIGID" -eq 1 ]];
         if [[ $DOQSUB -eq 5 ]];
             then
             # SLURM job scripts must start with a shebang
-            echo '#!/bin/sh' > "$qscript"
+            printf '%s\n' '#!/bin/sh' > "$qscript"
             fi
 
-        echo "$SCRIPTPREPEND" >> "$qscript"
+        write_script_prepend >> "$qscript"
         printf 'export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=%s\n' "$NUMBER_OF_THREADS" >> "$qscript"
 
         IMGbase=`basename "${IMAGESETARRAY[$i]}"`
-        BASENAME=` echo "${IMGbase}" | cut -d '.' -f 1 `
+        BASENAME=$(get_image_stem "$IMGbase")
         RIGID="${outdir}/rigid${i}_0_${IMGbase}"
         printf -v rigid_q '%q' "$RIGID"
 
         exe="$ANTS $DIM $IMAGEMETRICSET -o $rigid_q -i 0 $LINEARTRANSFORMPARAMS $RIGIDTYPE"
 
-        echo "$exe" >> "$qscript"
+        printf '%s\n' "$exe" >> "$qscript"
 
         exe2='';
         pexe2='';
@@ -1126,19 +1132,19 @@ if [[ "$RIGID" -eq 1 ]];
             k=0
             k=$((i+j))
             IMGbase=`basename "${IMAGESETARRAY[$k]}"`
-            BASENAME=` echo "${IMGbase}" | cut -d '.' -f 1 `
+            BASENAME=$(get_image_stem "$IMGbase")
             RIGID="${outdir}/rigid${i}_${j}_${IMGbase}"
             IMGbaseBASE=`basename "${IMAGESETARRAY[$i]}"`
-            BASENAMEBASE=` echo "${IMGbaseBASE}" | cut -d '.' -f 1 `
+            BASENAMEBASE=$(get_image_stem "$IMGbaseBASE")
             printf -v input_k_q '%q' "${IMAGESETARRAY[$k]}"
             printf -v rigid_q '%q' "$RIGID"
             printf -v affine_q '%q' "${outdir}/rigid${i}_0_${BASENAMEBASE}Affine.txt"
             printf -v template_j_q '%q' "${TEMPLATES[$j]}"
-            exe2="$exe2 ${WARP} $DIM ${input_k_q} ${rigid_q} ${affine_q} -R ${template_j_q}\n"
-            pexe2="$exe2 ${WARP} $DIM ${input_k_q} ${rigid_q} ${affine_q} -R ${template_j_q} >> ${metriclog_q}\n"
+            exe2+=" ${WARP} $DIM ${input_k_q} ${rigid_q} ${affine_q} -R ${template_j_q}"$'\n'
+            pexe2="$exe2 ${WARP} $DIM ${input_k_q} ${rigid_q} ${affine_q} -R ${template_j_q} >> ${metriclog_q}"$'\n'
         done
 
-        echo -e "$exe2" >> "$qscript";
+        printf '%s' "$exe2" >> "$qscript";
 
         if [[ $DOQSUB -eq 1 ]];
             then
@@ -1153,8 +1159,8 @@ if [[ "$RIGID" -eq 1 ]];
         elif [[ $DOQSUB -eq 2 ]];
             then
             # Send pexe and exe2 to same job file so that they execute in series
-            echo "$pexe" >> "${outdir}/job${count}_r.sh"
-            echo -e "$pexe2" >> "${outdir}/job${count}_r.sh"
+            printf '%s\n' "$pexe" >> "${outdir}/job${count}_r.sh"
+            printf '%s' "$pexe2" >> "${outdir}/job${count}_r.sh"
         elif [[ $DOQSUB -eq 3 ]];
             then
             id=`xgrid $XGRIDOPTS -job submit /bin/bash "$qscript" | awk '{sub(/;/,"");print $3}' | tr '\n' ' ' | sed 's:  *: :g'`
@@ -1253,7 +1259,7 @@ if [[ "$RIGID" -eq 1 ]];
             k=0
             k=$((i-j))
             IMGbase=`basename "${IMAGESETARRAY[$i]}"`
-            BASENAME=` echo "${IMGbase}" | cut -d '.' -f 1 `
+            BASENAME=$(get_image_stem "$IMGbase")
             RIGID="${outdir}/rigid${k}_${j}_${IMGbase}"
 
             IMAGERIGIDSET[${#IMAGERIGIDSET[@]}]=$RIGID
@@ -1470,15 +1476,15 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
                 indir=`pwd`
             fi
             IMGbase=`basename "${IMAGESETARRAY[$l]}"`
-            POO=${OUTPUTNAME}template-modality${k}-${IMGbase}
-            OUTFN=${POO%.*.*}
+            IMGstem=$(get_image_stem "$IMGbase")
+            OUTFN=${OUTPUTNAME}template-modality${k}-${IMGstem}
             OUTFN=`basename "${OUTFN}"`
             OUTFN="${OUTFN}${l}"
             DEFORMED="${outdir}/${OUTFN}${l}WarpedToTemplate.nii.gz"
 
             IMGbase=`basename "${IMAGESETARRAY[$j]}"`
-            POO=${OUTPUTNAME}${IMGbase}
-            OUTWARPFN=${POO%.*.*}
+            IMGstem=$(get_image_stem "$IMGbase")
+            OUTWARPFN=${OUTPUTNAME}${IMGstem}
             OUTWARPFN=`basename "${OUTWARPFN}"`
             OUTWARPFN="${OUTWARPFN}${j}"
 
@@ -1494,76 +1500,76 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
                 REPAIRED="${outdir}/${OUTFN}Repaired.nii.gz"
                 printf -v repaired_q '%q' "$REPAIRED"
                 if [[ ! -s ${REPAIRED} ]]; then
-                  exe=" $exe $N4 -d ${DIM} -b [ 200 ] -c [ 50x50x40x30,0.00000001 ] -i ${input_l_q} -o ${repaired_q} -r 0 -s 2\n"
-                  pexe=" $pexe $N4 -d ${DIM} -b [ 200 ] -c [ 50x50x40x30,0.00000001 ] -i ${input_l_q} -o ${repaired_q} -r 0 -s 2  >> ${metriclog_q}\n"
+                  exe=" $exe $N4 -d ${DIM} -b [ 200 ] -c [ 50x50x40x30,0.00000001 ] -i ${input_l_q} -o ${repaired_q} -r 0 -s 2"$'\n'
+                  pexe=" $pexe $N4 -d ${DIM} -b [ 200 ] -c [ 50x50x40x30,0.00000001 ] -i ${input_l_q} -o ${repaired_q} -r 0 -s 2  >> ${metriclog_q}"$'\n'
                 fi
                 IMAGEMETRICSET="$IMAGEMETRICSET -m ${METRIC}${template_k_q},${repaired_q},${METRICPARAMS}"
-                warpexe=" $warpexe ${WARP} ${DIM} ${repaired_q} ${deformed_q} -R ${template_k_q} ${warp_q} ${affine_q}\n"
-                warppexe=" $warppexe ${WARP} ${DIM} ${repaired_q} ${deformed_q} -R ${template_k_q} ${warp_q} ${affine_q} >> ${metriclog_q}\n"
+                warpexe=" $warpexe ${WARP} ${DIM} ${repaired_q} ${deformed_q} -R ${template_k_q} ${warp_q} ${affine_q}"$'\n'
+                warppexe=" $warppexe ${WARP} ${DIM} ${repaired_q} ${deformed_q} -R ${template_k_q} ${warp_q} ${affine_q} >> ${metriclog_q}"$'\n'
               else
                 IMAGEMETRICSET="$IMAGEMETRICSET -m ${METRIC}${template_k_q},${input_l_q},${METRICPARAMS}";
-                warpexe=" $warpexe ${WARP} ${DIM} ${input_l_q} ${deformed_q} -R ${template_k_q} ${warp_q} ${affine_q}\n"
-                warppexe=" $warppexe ${WARP} ${DIM} ${input_l_q} ${deformed_q} -R ${template_k_q} ${warp_q} ${affine_q} >> ${metriclog_q}\n"
+                warpexe=" $warpexe ${WARP} ${DIM} ${input_l_q} ${deformed_q} -R ${template_k_q} ${warp_q} ${affine_q}"$'\n'
+                warppexe=" $warppexe ${WARP} ${DIM} ${input_l_q} ${deformed_q} -R ${template_k_q} ${warp_q} ${affine_q} >> ${metriclog_q}"$'\n'
               fi
 
         done
 
         IMGbase=`basename "${IMAGESETARRAY[$j]}"`
-        POO=${OUTPUTNAME}${IMGbase}
-        OUTWARPFN=${POO%.*.*}
+        IMGstem=$(get_image_stem "$IMGbase")
+        OUTWARPFN=${OUTPUTNAME}${IMGstem}
         OUTWARPFN=`basename "${OUTWARPFN}${j}"`
         printf -v output_prefix_q '%q' "${outdir}/${OUTWARPFN}"
 
         LINEARTRANSFORMPARAMS="--number-of-affine-iterations 10000x10000x1000 --MI-option 32x16000"
 
-        exe="$exe $ANTS ${DIM} $IMAGEMETRICSET -i ${MAXITERATIONS} -t ${TRANSFORMATION} -r $REGULARIZATION -o ${output_prefix_q} $LINEARTRANSFORMPARAMS\n"
+        exe="$exe $ANTS ${DIM} $IMAGEMETRICSET -i ${MAXITERATIONS} -t ${TRANSFORMATION} -r $REGULARIZATION -o ${output_prefix_q} $LINEARTRANSFORMPARAMS"$'\n'
         exe="$exe $warpexe"
 
-        pexe="$pexe $ANTS ${DIM} $IMAGEMETRICSET -i ${MAXITERATIONS} -t ${TRANSFORMATION} -r $REGULARIZATION -o ${output_prefix_q} $LINEARTRANSFORMPARAMS >> ${metriclog_q}\n"
+        pexe="$pexe $ANTS ${DIM} $IMAGEMETRICSET -i ${MAXITERATIONS} -t ${TRANSFORMATION} -r $REGULARIZATION -o ${output_prefix_q} $LINEARTRANSFORMPARAMS >> ${metriclog_q}"$'\n'
         pexe="$pexe $warppexe"
 
         qscript="${outdir}/job_${count}_${i}.sh"
 
-        echo -e "$exe" >> "${outdir}/job_${count}_${i}_metriclog.txt"
+        printf '%s' "$exe" >> "${outdir}/job_${count}_${i}_metriclog.txt"
         # 6 submit to SGE (DOQSUB=1), PBS (DOQSUB=4), PEXEC (DOQSUB=2), XGrid (DOQSUB=3) or else run locally (DOQSUB=0)
         if [[ $DOQSUB -eq 1 ]];
             then
-            echo -e "$SCRIPTPREPEND" > "$qscript"
+            write_script_prepend > "$qscript"
             printf 'export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=%s\n' "$NUMBER_OF_THREADS" >> "$qscript"
-            echo -e "$exe" >> "$qscript"
+            printf '%s' "$exe" >> "$qscript"
             id=`qsub -cwd -N antsBuildTemplate_deformable_${i} -S /bin/bash $QSUBOPTS "$qscript" | awk '{print $3}'`
             jobIDs+=("$id")
             sleep 0.5
         elif [[ $DOQSUB -eq 4 ]];
             then
-            echo -e "$SCRIPTPREPEND" > "$qscript"
+            write_script_prepend > "$qscript"
             printf 'export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=%s\n' "$NUMBER_OF_THREADS" >> "$qscript"
-            echo -e "$exe" >> "$qscript"
+            printf '%s' "$exe" >> "$qscript"
             id=`qsub -N antsdef${i} -l walltime=${WALLTIME} -l mem=${MEMORY} $QSUBOPTS "$qscript" | awk '{print $1}'`
             jobIDs+=("$id")
             sleep 0.5
         elif [[ $DOQSUB -eq 2 ]];
             then
-            echo -e "$pexe" >> "${outdir}/job${count}_r.sh"
+            printf '%s' "$pexe" >> "${outdir}/job${count}_r.sh"
         elif [[ $DOQSUB -eq 3 ]];
             then
-            echo -e "$SCRIPTPREPEND" > "$qscript"
+            write_script_prepend > "$qscript"
             printf 'export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=%s\n' "$NUMBER_OF_THREADS" >> "$qscript"
-            echo -e "$exe" >> "$qscript"
+            printf '%s' "$exe" >> "$qscript"
             id=`xgrid $XGRIDOPTS -job submit /bin/bash "$qscript" | awk '{sub(/;/,"");print $3}' | tr '\n' ' ' | sed 's:  *: :g'`
             jobIDs+=("$id")
         elif [[ $DOQSUB -eq 5 ]];
             then
-            echo '#!/bin/sh' > "$qscript"
-            echo -e "$SCRIPTPREPEND" >> "$qscript"
+            printf '%s\n' '#!/bin/sh' > "$qscript"
+            write_script_prepend >> "$qscript"
             printf 'export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=%s\n' "$NUMBER_OF_THREADS" >> "$qscript"
-            echo -e "$exe" >> "$qscript"
+            printf '%s' "$exe" >> "$qscript"
             id=`sbatch --job-name=antsdef${i} --nodes=1 --ntasks=1 --cpus-per-task=$NUMBER_OF_THREADS --time=${WALLTIME} --mem=${MEMORY} $QSUBOPTS "$qscript" | rev | cut -f1 -d\ | rev`
             jobIDs+=("$id")
             sleep 0.5
         elif [[ $DOQSUB -eq 0 ]];
             then
-            echo -e "$exe" > "$qscript"
+            printf '%s' "$exe" > "$qscript"
             bash "$qscript"
         fi
 

--- a/Scripts/antsMultivariateTemplateConstruction2.sh
+++ b/Scripts/antsMultivariateTemplateConstruction2.sh
@@ -157,9 +157,13 @@ Optional arguments:
 
      -o:  OutputPrefix; A prefix that is prepended to all output files (default = "antsBTP").
 
-     -p:  Commands to prepend to job scripts. Job options for SGE/PBS/SLURM can be included here, but
-          command-line args in this script will take precedence for wall time (see -u), memory (see -v)
-          and number of cores (see -j).
+     -p:  A command or directive to prepend to job scripts. Repeat -p to add multiple lines; entries
+          are written to job scripts in the order given. Job options for SGE/PBS/SLURM can be included here,
+          but command-line args in this script will take precedence for wall time (see -u), memory (see -v),
+          and multithreading (see -T).
+
+          For slurm, a shebang for '/bin/sh' is always the first line in the job script. For SGE and PBS,
+          the shell interpreter is set to '/bin/bash'.
 
      -r:  Do rigid-body registration of inputs to the initial template, before doing the main
           pairwise registration. 0 == off 1 == on (default 0). If you are trying to refine or update
@@ -319,6 +323,23 @@ function reportMappingParameters {
 REPORTMAPPINGPARAMETERS
 }
 
+function write_script_prepend() {
+  if (( ${#SCRIPTPREPEND[@]} > 0 )); then
+    printf '%s\n' "${SCRIPTPREPEND[@]}"
+  fi
+}
+
+function get_image_stem() {
+  local filename=${1##*/}
+
+  # Treat .gz as a compression suffix, then remove the image-format suffix.
+  # This preserves internal periods for both compressed and uncompressed formats.
+  if [[ $filename == *.gz ]]; then
+    filename=${filename%.gz}
+  fi
+  printf '%s\n' "${filename%.*}"
+}
+
 function summarizeimageset() {
 
   local dim=$1
@@ -350,7 +371,7 @@ function summarizeimageset() {
       local image
       for image in "${images[@]}";
         do
-          echo "$image" >> "${output}_list.txt"
+          printf '%s\n' "$image" >> "${output}_list.txt"
         done
       ImageSetStatistics "$dim" "${output}_list.txt" "$output" 0
       rm "${output}_list.txt"
@@ -518,24 +539,24 @@ function jobfnamepadding {
     elif [[ ! -e ${files[0]} ]]; then
       return 0
     fi
-    BASENAME1=`echo "${files[0]}" | cut -d 'b' -f 1`
+    BASENAME1=`printf '%s\n' "${files[0]}" | cut -d 'b' -f 1`
 
     for file in "${files[@]}"
       do
 
       if [[ "${#file}" -eq "9" ]];
        then
-         BASENAME2=`echo "$file" | cut -d 'b' -f 2 `
+         BASENAME2=`printf '%s\n' "$file" | cut -d 'b' -f 2 `
          mv "$file" "${BASENAME1}b_000${BASENAME2}"
 
       elif [[ "${#file}" -eq "10" ]];
         then
-          BASENAME2=`echo "$file" | cut -d 'b' -f 2 `
+          BASENAME2=`printf '%s\n' "$file" | cut -d 'b' -f 2 `
           mv "$file" "${BASENAME1}b_00${BASENAME2}"
 
       elif [[ "${#file}" -eq "11" ]];
         then
-          BASENAME2=`echo "$file" | cut -d 'b' -f 2 `
+          BASENAME2=`printf '%s\n' "$file" | cut -d 'b' -f 2 `
           mv "$file" "${BASENAME1}b_0${BASENAME2}"
       fi
     done
@@ -555,28 +576,13 @@ for (( g = $WHICHMODALITY; g < ${#IMAGESETARRAY[@]}; g+=$NUMBEROFMODALITIES ))
   done
 }
 
-cleanup()
-{
-  echo "\n*** Performing cleanup, please wait ***\n"
-
-    runningANTSpids=$( ps --ppid $$ -o pid= )
-
-  for thePID in $runningANTSpids
-  do
-      echo "killing:  ${thePID}"
-      kill "${thePID}"
-  done
-
-  return $?
-}
-
 control_c()
 # run if user hits control-c
 {
-  echo -en "\n*** User pressed CTRL + C ***\n"
-  cleanup
-  exit $?
-  echo -en "\n*** Script cancelled by user ***\n"
+  trap - SIGINT
+  printf '\n*** User pressed CTRL + C ***\n'
+  printf '\n*** Script cancelled by user ***\n'
+  exit 130
 }
 
 #initializing variables with global scope
@@ -612,7 +618,7 @@ REGTEMPLATES=()
 TEMPLATES=()
 CURRENTIMAGESET=()
 XGRIDOPTS=""
-SCRIPTPREPEND=""
+SCRIPTPREPEND=()
 WALLTIME="20:00:00"
 MEMORY="8G"
 # System specific queue options for SGE/PBS/SLURM, eg "-q name" to submit to a specific queue.
@@ -740,7 +746,7 @@ while getopts "A:T:a:b:c:d:e:f:g:h:i:j:k:l:m:n:o:p:q:s:r:t:u:v:w:x:y:z:" OPT
    TEMPLATENAME=${OUTPUTNAME}template
    ;;
       p) #Script prepend
-   SCRIPTPREPEND=$OPTARG
+   SCRIPTPREPEND+=( "$OPTARG" )
    ;;
       m) #similarity model
    METRICTYPE[${#METRICTYPE[@]}]=$OPTARG
@@ -1198,7 +1204,7 @@ for (( i = 0; i < $NUMBEROFMODALITIES; i++ ))
         for (( j = 0; j < ${#CURRENTIMAGESET[@]}; j+=1 ))
           do
             IMGbase=`basename "${CURRENTIMAGESET[$j]}"`
-            BASENAME=` echo "${IMGbase}" | cut -d '.' -f 1 `
+            BASENAME=$(get_image_stem "$IMGbase")
             COM="${OUTPUT_DIR}/initialCOM${i}_${j}_${IMGbase}"
             COMTRANSFORM="${OUTPUT_DIR}/initialCOM${i}_${j}_${BASENAME}.mat"
             antsAI -d "${DIM}" --convergence 0 --verbose 1 -m "Mattes[${TEMPLATES[$i]},${CURRENTIMAGESET[$j]},32,None]" -o "${COMTRANSFORM}" -t AlignCentersOfMass
@@ -1271,17 +1277,17 @@ if [[ "$RIGID" -eq 1 ]];
         if [[ $DOQSUB -eq 5 ]];
             then
             # SLURM job scripts must start with a shebang
-            echo '#!/bin/sh' > "$qscript"
+            printf '%s\n' '#!/bin/sh' > "$qscript"
             fi
 
-        echo "$SCRIPTPREPEND" >> "$qscript"
+        write_script_prepend >> "$qscript"
         printf 'export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=%s\n' "$NUMBER_OF_THREADS" >> "$qscript"
 
         IMGbase=`basename "${IMAGESETARRAY[$i]}"`
-        BASENAME=` echo "${IMGbase}" | cut -d '.' -f 1 `
+        BASENAME=$(get_image_stem "$IMGbase")
         RIGID="${outdir}/rigid${i}_0_${IMGbase}"
 
-        echo "$exe" >> "$qscript"
+        printf '%s\n' "$exe" >> "$qscript"
 
         exe2='';
         pexe2='';
@@ -1292,19 +1298,19 @@ if [[ "$RIGID" -eq 1 ]];
             k=0
             k=$((i+j))
             IMGbase=`basename "${IMAGESETARRAY[$k]}"`
-            BASENAME=` echo "${IMGbase}" | cut -d '.' -f 1 `
+            BASENAME=$(get_image_stem "$IMGbase")
             RIGID="${outdir}/rigid${i}_${j}_${IMGbase}"
             IMGbaseBASE=`basename "${IMAGESETARRAY[$i]}"`
-            BASENAMEBASE=` echo "${IMGbaseBASE}" | cut -d '.' -f 1 `
+            BASENAMEBASE=$(get_image_stem "$IMGbaseBASE")
             printf -v input_k_q '%q' "${IMAGESETARRAY[$k]}"
             printf -v rigid_q '%q' "$RIGID"
             printf -v rigid_affine_q '%q' "${outdir}/rigid${i}_0GenericAffine.mat"
             printf -v template_j_q '%q' "${TEMPLATES[$j]}"
-            exe2="$exe2 ${WARP} -d $DIM --float $USEFLOAT --verbose 1 -i ${input_k_q} -o ${rigid_q} -t ${rigid_affine_q} -r ${template_j_q}\n"
-            pexe2="$exe2 ${WARP} -d $DIM --float $USEFLOAT --verbose 1 -i ${input_k_q} -o ${rigid_q} -t ${rigid_affine_q} -r ${template_j_q} >> ${metriclog_q}\n"
+            exe2+=" ${WARP} -d $DIM --float $USEFLOAT --verbose 1 -i ${input_k_q} -o ${rigid_q} -t ${rigid_affine_q} -r ${template_j_q}"$'\n'
+            pexe2="$exe2 ${WARP} -d $DIM --float $USEFLOAT --verbose 1 -i ${input_k_q} -o ${rigid_q} -t ${rigid_affine_q} -r ${template_j_q} >> ${metriclog_q}"$'\n'
           done
 
-        echo -e "$exe2" >> "$qscript";
+        printf '%s' "$exe2" >> "$qscript";
 
         if [[ $DOQSUB -eq 1 ]];
           then
@@ -1319,8 +1325,8 @@ if [[ "$RIGID" -eq 1 ]];
         elif [[ $DOQSUB -eq 2 ]];
           then
             # Send pexe and exe2 to same job file so that they execute in series
-            echo "$pexe" >> "${outdir}/job${count}_r.sh"
-            echo -e "$pexe2" >> "${outdir}/job${count}_r.sh"
+            printf '%s\n' "$pexe" >> "${outdir}/job${count}_r.sh"
+            printf '%s' "$pexe2" >> "${outdir}/job${count}_r.sh"
         elif [[ $DOQSUB -eq 3 ]];
           then
             id=`xgrid $XGRIDOPTS -job submit /bin/bash "$qscript" | awk '{sub(/;/,"");print $3}' | tr '\n' ' ' | sed 's:  *: :g'`
@@ -1420,7 +1426,7 @@ if [[ "$RIGID" -eq 1 ]];
             k=0
             k=$((i-j))
             IMGbase=`basename "${IMAGESETARRAY[$i]}"`
-            BASENAME=` echo "${IMGbase}" | cut -d '.' -f 1 `
+            BASENAME=$(get_image_stem "$IMGbase")
             RIGID="${outdir}/rigid${k}_${j}_${IMGbase}"
 
             IMAGERIGIDSET[${#IMAGERIGIDSET[@]}]=$RIGID
@@ -1598,12 +1604,14 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
                 indir=`pwd`
               fi
             IMGbase=`basename "${IMAGESETARRAY[$l]}"`
-            OUTFN=${OUTPUTNAME}input$(printf "%04d" $l)-modality${k}-${IMGbase/%?(.nii.gz|.nii)}
+            IMGstem=$(get_image_stem "$IMGbase")
+            OUTFN=${OUTPUTNAME}input$(printf "%04d" $l)-modality${k}-${IMGstem}
             OUTFN=`basename "${OUTFN}"`
             DEFORMED="${outdir}/${OUTFN}-WarpedToTemplate.nii.gz"
 
             IMGbase=`basename "${IMAGESETARRAY[$j]}"`
-            OUTWARPFN=${OUTPUTNAME}input$(printf "%04d" $j)-${IMGbase/%?(.nii.gz|.nii)}-
+            IMGstem=$(get_image_stem "$IMGbase")
+            OUTWARPFN=${OUTPUTNAME}input$(printf "%04d" $j)-${IMGstem}-
             OUTWARPFN=`basename "${OUTWARPFN}"`
 
             printf -v template_k_q '%q' "${TEMPLATES[$k]}"
@@ -1626,29 +1634,23 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
                 REPAIRED="${outdir}/${OUTFN}Repaired.nii.gz"
                 printf -v repaired_q '%q' "$REPAIRED"
                 if [[ ! -s ${REPAIRED} ]]; then
-                  exe=" $exe $N4 -d ${DIM} -b [ 200 ] -c [ 50x50x40x30,0.00000001 ] -i ${input_l_q} -o ${repaired_q} -r 0 -s 2 --verbose 1\n"
-                  pexe=" $pexe $N4 -d ${DIM} -b [ 200 ] -c [ 50x50x40x30,0.00000001 ] -i ${input_l_q} -o ${repaired_q} -r 0 -s 2 --verbose 1  >> ${metriclog_q} >> ${metriclog_q}\n"
+                  exe=" $exe $N4 -d ${DIM} -b [ 200 ] -c [ 50x50x40x30,0.00000001 ] -i ${input_l_q} -o ${repaired_q} -r 0 -s 2 --verbose 1"$'\n'
+                  pexe=" $pexe $N4 -d ${DIM} -b [ 200 ] -c [ 50x50x40x30,0.00000001 ] -i ${input_l_q} -o ${repaired_q} -r 0 -s 2 --verbose 1  >> ${metriclog_q} >> ${metriclog_q}"$'\n'
                 fi
                 IMAGEMETRICSET="$IMAGEMETRICSET -m ${METRIC}${template_k_q},${repaired_q},${METRICPARAMS}"
                 IMAGEMETRICLINEARSET="$IMAGEMETRICLINEARSET -m MI[ ${template_k_q},${repaired_q},${MODALITYWEIGHTS[$k]},32,Regular,0.25 ]"
 
-                warpexe=" $warpexe ${WARP} -d ${DIM} --float $USEFLOAT --verbose 1 -i ${repaired_q} -o ${deformed_q} -r ${template_k_q} ${OUTPUTTRANSFORMS}\n"
-                warppexe=" $warppexe ${WARP} -d ${DIM} --float $USEFLOAT --verbose 1 -i ${repaired_q} -o ${deformed_q} -r ${template_k_q} ${OUTPUTTRANSFORMS} >> ${metriclog_q}\n"
+                warpexe=" $warpexe ${WARP} -d ${DIM} --float $USEFLOAT --verbose 1 -i ${repaired_q} -o ${deformed_q} -r ${template_k_q} ${OUTPUTTRANSFORMS}"$'\n'
+                warppexe=" $warppexe ${WARP} -d ${DIM} --float $USEFLOAT --verbose 1 -i ${repaired_q} -o ${deformed_q} -r ${template_k_q} ${OUTPUTTRANSFORMS} >> ${metriclog_q}"$'\n'
               else
                 IMAGEMETRICSET="$IMAGEMETRICSET -m ${METRIC}${template_k_q},${input_l_q},${METRICPARAMS}"
                 IMAGEMETRICLINEARSET="$IMAGEMETRICLINEARSET -m MI[ ${template_k_q},${input_l_q},${MODALITYWEIGHTS[$k]},32,Regular,0.25 ]"
 
-                warpexe=" $warpexe ${WARP} -d ${DIM} --float $USEFLOAT --verbose 1 -i ${input_l_q} -o ${deformed_q} -r ${template_k_q} ${OUTPUTTRANSFORMS}\n"
-                warppexe=" $warppexe ${WARP} -d ${DIM} --float $USEFLOAT --verbose 1 -i ${input_l_q} -o ${deformed_q} -r ${template_k_q} ${OUTPUTTRANSFORMS} >> ${metriclog_q}\n"
+                warpexe=" $warpexe ${WARP} -d ${DIM} --float $USEFLOAT --verbose 1 -i ${input_l_q} -o ${deformed_q} -r ${template_k_q} ${OUTPUTTRANSFORMS}"$'\n'
+                warppexe=" $warppexe ${WARP} -d ${DIM} --float $USEFLOAT --verbose 1 -i ${input_l_q} -o ${deformed_q} -r ${template_k_q} ${OUTPUTTRANSFORMS} >> ${metriclog_q}"$'\n'
               fi
 
         done
-
-
-      #  Already defined above
-      #  IMGbase=`basename ${IMAGESETARRAY[$j]}`
-      #  OUTWARPFN=${OUTPUTNAME}${IMGbase/%?(.nii.gz|.nii)}
-      #  OUTWARPFN=`basename ${OUTWARPFN}${j}`
 
         printf -v template0_q '%q' "${TEMPLATES[0]}"
         printf -v input_j_q '%q' "${IMAGESETARRAY[$j]}"
@@ -1666,23 +1668,23 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
 
         if [[ $DOLINEAR -eq 0 ]];
           then
-            exe="$exe ${basecall} ${stageId} ${stage3}\n"
-            pexe="$pexe ${basecall} ${stageId} ${stage3} >> ${metriclog_q}\n"
+            exe="$exe ${basecall} ${stageId} ${stage3}"$'\n'
+            pexe="$pexe ${basecall} ${stageId} ${stage3} >> ${metriclog_q}"$'\n'
           elif [[ $NOWARP -eq 1 ]];
             then
     	      if [[ ${TRANSFORMATION} == "Affine"* ]];
 	        then
           	  # If affine, do standard rigid, then affine with levels, etc from command line
-		  exe="$exebase ${basecall} ${stage0} ${stage1} ${stage3}\n";
-		  pexe="$pexebase ${basecall} ${stage0} ${stage1} ${stage3} >> ${metriclog_q}\n"
+		  exe="$exebase ${basecall} ${stage0} ${stage1} ${stage3}"$'\n';
+		  pexe="$pexebase ${basecall} ${stage0} ${stage1} ${stage3} >> ${metriclog_q}"$'\n'
 	        else
 		  # Rigid only - just use command line params
-		  exe="$exebase ${basecall} ${stage0} ${stage3}\n";
-		  pexe="$pexebase ${basecall} ${stage0} ${stage3} >> ${metriclog_q}\n"
+		  exe="$exebase ${basecall} ${stage0} ${stage3}"$'\n';
+		  pexe="$pexebase ${basecall} ${stage0} ${stage3} >> ${metriclog_q}"$'\n'
                 fi
           else
-            exe="$exe ${basecall} ${stage0} ${stage1} ${stage2} ${stage3}\n"
-            pexe="$pexe ${basecall} ${stage0} ${stage1} ${stage2} ${stage3} >> ${metriclog_q}\n"
+            exe="$exe ${basecall} ${stage0} ${stage1} ${stage2} ${stage3}"$'\n'
+            pexe="$pexe ${basecall} ${stage0} ${stage1} ${stage2} ${stage3} >> ${metriclog_q}"$'\n'
           fi
 
         exe="$exe $warpexe"
@@ -1690,46 +1692,46 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
 
         qscript="${outdir}/job_${count}_${i}.sh"
 
-        echo -e "$exe" >> "${outdir}/job_${count}_${i}_metriclog.txt"
+        printf '%s' "$exe" >> "${outdir}/job_${count}_${i}_metriclog.txt"
         # 6 submit to SGE (DOQSUB=1), PBS (DOQSUB=4), PEXEC (DOQSUB=2), XGrid (DOQSUB=3), SLURM (DOQSUB=5) or else run locally (DOQSUB=0)
         if [[ $DOQSUB -eq 1 ]];
           then
-            echo "$SCRIPTPREPEND" > "$qscript"
+            write_script_prepend > "$qscript"
             printf 'export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=%s\n' "$NUMBER_OF_THREADS" >> "$qscript"
-            echo -e "$exe" >> "$qscript"
+            printf '%s' "$exe" >> "$qscript"
             id=`qsub -cwd -N antsBuildTemplate_deformable_${i} -S /bin/bash ${QSUBOPTS} "$qscript" | awk '{print $3}'`
             jobIDs+=("$id")
             sleep 0.5
         elif [[ $DOQSUB -eq 4 ]];
           then
-            echo -e "$SCRIPTPREPEND" > "$qscript"
+            write_script_prepend > "$qscript"
             printf 'export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=%s\n' "$NUMBER_OF_THREADS" >> "$qscript"
-            echo -e "$exe" >> "$qscript"
+            printf '%s' "$exe" >> "$qscript"
             id=`qsub -N antsdef${i} -l mem=${MEMORY} -l walltime=${WALLTIME} ${QSUBOPTS} "$qscript" | awk '{print $1}'`
             jobIDs+=("$id")
             sleep 0.5
         elif [[ $DOQSUB -eq 2 ]];
           then
-            echo -e "$pexe" >> "${outdir}/job${count}_r.sh"
+            printf '%s' "$pexe" >> "${outdir}/job${count}_r.sh"
         elif [[ $DOQSUB -eq 3 ]];
           then
-            echo -e "$SCRIPTPREPEND" > "$qscript"
+            write_script_prepend > "$qscript"
             printf 'export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=%s\n' "$NUMBER_OF_THREADS" >> "$qscript"
-            echo -e "$exe" >> "$qscript"
+            printf '%s' "$exe" >> "$qscript"
             id=`xgrid $XGRIDOPTS -job submit /bin/bash "$qscript" | awk '{sub(/;/,"");print $3}' | tr '\n' ' ' | sed 's:  *: :g'`
             jobIDs+=("$id")
         elif [[ $DOQSUB -eq 5 ]];
           then
-            echo '#!/bin/sh' > "$qscript"
-            echo -e "$SCRIPTPREPEND" >> "$qscript"
+            printf '%s\n' '#!/bin/sh' > "$qscript"
+            write_script_prepend >> "$qscript"
             printf 'export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=%s\n' "$NUMBER_OF_THREADS" >> "$qscript"
-            echo -e "$exe" >> "$qscript"
+            printf '%s' "$exe" >> "$qscript"
             id=`sbatch --job-name=antsdef${i} --nodes=1 --ntasks=1 --cpus-per-task=${NUMBER_OF_THREADS} --time=${WALLTIME} --mem=${MEMORY} ${QSUBOPTS} "$qscript" | rev | cut -f1 -d\ | rev`
             jobIDs+=("$id")
             sleep 0.5
         elif [[ $DOQSUB -eq 0 ]];
           then
-            echo -e "$exe" > "$qscript"
+            printf '%s' "$exe" > "$qscript"
             bash "$qscript"
         fi
 

--- a/Scripts/shapeupdatetotemplate.sh
+++ b/Scripts/shapeupdatetotemplate.sh
@@ -87,7 +87,7 @@ function summarizeimageset() {
     2) #median
       for i in "${images[@]}";
         do
-          echo $i >> ${output}_list.txt
+          printf '%s\n' "$i" >> "${output}_list.txt"
         done
       ImageSetStatistics $dim ${output}_list.txt ${output} 0
       rm ${output}_list.txt
@@ -95,7 +95,7 @@ function summarizeimageset() {
     3) #median+sharpen
       for i in "${images[@]}";
         do
-          echo $i >> ${output}_list.txt
+          printf '%s\n' "$i" >> "${output}_list.txt"
         done
       ImageSetStatistics $dim ${output}_list.txt ${output} 0
       ImageMath $dim ${output} Sharpen ${output}


### PR DESCRIPTION
Changed some parsing / printing behavior, fixing #1932 and also making the scripts behave better with spaces in file names.

**PR summary**

This PR improves portability and reliability of the maintained multivariate template construction scripts.

Changes
- Replace echo with printf when writing commands, filenames, and generated job scripts.
  - Avoids implementation-dependent escape and option handling.
  - Uses real newline characters in assembled command strings.
- Make -p repeatable.
  - Each occurrence adds one line to generated job scripts.
  - Lines are written in the order supplied.
  - Documents the shell interpreters used for Slurm, SGE, and PBS scripts.
- Improve image filename handling.
  - Preserves internal periods in names such as somefile.something.nii.gz.
  - Supports compressed and uncompressed formats including .nii, .nii.gz, .mha, .nrrd, .mnc, and .mnc.gz.
- Improve ANTSpexec.sh interruption handling.
  - Handles both SIGINT and SIGTERM.
  - Terminates the complete descendant process tree.
  - Sends TERM, allows a three-second grace period, and sends KILL to remaining processes.
  - Returns conventional exit statuses 130 and 143.
  - Initializes killme.sh cleanly and quotes its path.
  - Updates help text to describe automatic cleanup.
- Simplify template-script Ctrl-C handlers.
  - Pexec now owns cleanup of processes it starts.
  - Template scripts report cancellation and exit with status 130.
  - Removes the non-portable GNU-only ps --ppid cleanup code.
- Quote filename-list output in shapeupdatetotemplate.sh.
- Simplify process checking in ANTspexec.sh
  - use portable `kill -0`, avoiding running multiple commands on Mac
  - Document that -j controls parallel processes, not strictly "cores"
  - poll less aggressively (2s vs 0.5s) to further minimize system overhead
  
  
The main change is that `-p` is now repeatable, which should make it easier for cluster users to add prepends to job scripts. Before, it wasn't clear how multi-line commands would work and the script was inconsistent about use of `echo` or `echo -e`. I hope it will be easier to send multiple commands now. 

I also documented the hard-coded interpreting shells, `/bin/sh` for slurm and `/bin/bash` for SGE / PBS, because this also  affects what you can send in a `-p` argument.