### PR TITLE
CI: Add linux arm64 build

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -25,8 +25,24 @@ jobs:
             generators: "Ninja"
           }
         - {
+            name: "Ubuntu-24.04-ARM64-GCC",
+            os: ubuntu-24.04-arm,
+            cc: "gcc",
+            cxx: "g++",
+            build_type: "Release",
+            generators: "Ninja"
+          }
+        - {
             name: "Ubuntu-22.04-GCC",
             os: ubuntu-22.04,
+            cc: "gcc",
+            cxx: "g++",
+            build_type: "Release",
+            generators: "Ninja"
+          }
+        - {
+            name: "Ubuntu-22.04-ARM64-GCC",
+            os: ubuntu-22.04-arm,
             cc: "gcc",
             cxx: "g++",
             build_type: "Release",


### PR DESCRIPTION
Now Github has an official runner for arm64, may as well add to releases

